### PR TITLE
Fix config data collector.

### DIFF
--- a/src/Barryvdh/Debugbar/DataCollector/ConfigCollector.php
+++ b/src/Barryvdh/Debugbar/DataCollector/ConfigCollector.php
@@ -19,7 +19,7 @@ class ConfigCollector extends DataCollector  implements Renderable
         $messages = array();
         foreach($views as $key=>$data){
             $messages[] = array(
-                'message' => $key.' => '.$data,
+                'message' => $key.' => '.var_export($data, true),
                 'is_string' => true,
             );
         }


### PR DESCRIPTION
Trying to use $data directly was resulting in an exception saying "Object of class Closure could not be converted to string".
