### PR TITLE
Update Route methods to support Laravel 4.1

### DIFF
--- a/src/Barryvdh/Debugbar/DataCollector/SymfonyRouteCollector.php
+++ b/src/Barryvdh/Debugbar/DataCollector/SymfonyRouteCollector.php
@@ -19,8 +19,9 @@ class SymfonyRouteCollector extends DataCollector  implements Renderable
      */
     public function collect()
     {
-        $name = \Route::currentRouteName();
-        $route = \Route::getCurrentRoute();
+        $route = \Route::current();
+        $name = $route->getName();
+        
         return $this->getRouteInformation($name, $route);
     }
 


### PR DESCRIPTION
In the new version of Laravel (4.1 that as just been released), the methods 'getCurrentRoute' of the Route facade has been dropped. Instead, you can use the 'current' method to get the current route and then 'getName' on this object to get its name.

Since it is dead simple to update from 4.0 to 4.1, I assume you can make this change to stay on the edge !
