### PR TITLE
fix for registering asset publisher

### DIFF
--- a/src/Barryvdh/Debugbar/ServiceProvider.php
+++ b/src/Barryvdh/Debugbar/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php namespace Barryvdh\Debugbar;
 
 
-class ServiceProvider extends \Illuminate\Support\ServiceProvider {
+class ServiceProvider extends \Illuminate\Foundation\Providers\PublisherServiceProvider {
 
     /**
      * Indicates if loading of the provider is deferred.
@@ -35,6 +35,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider {
      */
     public function register()
     {
+        parent::register();
+
         $self = $this;
         $app = $this->app;
         $this->app['debugbar'] = $this->app->share(function ($app) use($self) {


### PR DESCRIPTION
This fixes the asset.publisher exception when using Artisan from `Artisan::call()`.
