### PR TITLE
Removed the dependancy on Laravel aliases

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Config;
+
 return array(
 
     /*
@@ -11,7 +13,7 @@ return array(
      |
      */
 
-    'enabled' => \Config::get('app.debug'),
+    'enabled' => Config::get('app.debug'),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Came across this issue when working on a Laravel project in which the alias Config had been changed. Hence \Config could not be found.

Sorry about the commit history mess. Couldn't figure out how to clean it up. 
