### PR TITLE
Change default config to disable Debugbar in CLI

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -9,11 +9,12 @@ return array(
      | Debugbar Settings
      |--------------------------------------------------------------------------
      |
-     | Debugbar is enabled by default, when debug is set to true in app.php.
+     | Debugbar is enabled by default, when debug is set to true in app.php
+     | in CLI mode Debugbar is always disabled
      |
      */
 
-    'enabled' => Config::get('app.debug'),
+    'enabled' => Config::get('app.debug') && !App::runningInConsole(),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
After few hours of struggle :smile:, I've found Debugbar to eat a bit of resources for CLI operations involving large amounts of DB inserts. This is normal, since every log-data uses some memory but unfortunately - quite hard to track down.

This PR adds simple logic for `config.enabled` to prevent Debugbar from CLI mode by default (artisan ...). Just to save someone's time in the future :)

BTW: the `Debugbar::disable();` before seeding loop didn't seem to solve the memory use growth issue, hence this PR.
