### PR TITLE
Fix WSOD if not using Laravel's 'auth' facade

### DIFF
--- a/src/Barryvdh/Debugbar/LaravelDebugBar.php
+++ b/src/Barryvdh/Debugbar/LaravelDebugBar.php
@@ -281,7 +281,12 @@ class LaravelDebugbar extends DebugBar
         $this->setHttpDriver($httpDriver);
 
         if($this->shouldCollect('symfony_request', true) and !$this->hasCollector('request')){
-            $this->addCollector(new SymfonyRequestCollector($request, $response, $sessionManager, $app['auth']));
+            // Only pass $app['auth'] if we specify in config
+            if($this->shouldCollect('auth')){
+                $this->addCollector(new SymfonyRequestCollector($request, $response, $sessionManager, $app['auth']));
+            }else{
+                $this->addCollector(new SymfonyRequestCollector($request, $response, $sessionManager));
+            }
         }
 
         if($response->isRedirection()){


### PR DESCRIPTION
I do not use Laravel's Auth facade so just calling `$app['auth']` creates a WSOD because `'Class auth does not exist'` because its never registered by the `Illuminate\Auth\AuthServiceProvider` in Laravel.

This just adds a config check so you can avoid this by not wanting to collect auth.
