### PR TITLE
added both commands in the same 'commands' call

### DIFF
--- a/src/Barryvdh/Debugbar/ServiceProvider.php
+++ b/src/Barryvdh/Debugbar/ServiceProvider.php
@@ -97,8 +97,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider {
                 return new Console\ClearCommand($app['debugbar']);
             });
 
-        $this->commands('command.debugbar.publish');
-        $this->commands('command.debugbar.clear');
+        $this->commands(array('command.debugbar.publish', 'command.debugbar.clear'));
 
         if($this->shouldUseMiddleware()){
             $this->app->middleware('Barryvdh\Debugbar\Middleware', array($this->app));


### PR DESCRIPTION
I tried to use the debugbar and it wasn't working, it kept string to say the command was not found:

```
$ php artisan debugbar:publish

Sorry, command-not-found has crashed! Please file a bug report at:
https://bugs.launchpad.net/command-not-found/+filebug
Please include the following information with the report:

command-not-found version: 0.3
Python version: 3.4.0 candidate 1
Distributor ID: Ubuntu
Description:    Ubuntu 14.04 LTS
Release:    14.04
Codename:   trusty
Exception information:

unsupported locale setting
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/CommandNotFound/util.py", line 24, in crash_guard
    callback()
  File "/usr/lib/command-not-found", line 69, in main
    enable_i18n()
  File "/usr/lib/command-not-found", line 40, in enable_i18n
    locale.setlocale(locale.LC_ALL, '')
  File "/usr/lib/python3.4/locale.py", line 592, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```

I did a little debugging and found that passing the commands to the `commands` method as an array fixed my error.
