### PR TITLE
Update ajax request check to use wantsJson vs isXmlHttpRequest

### DIFF
--- a/src/Barryvdh/Debugbar/LaravelDebugBar.php
+++ b/src/Barryvdh/Debugbar/LaravelDebugBar.php
@@ -353,7 +353,7 @@ class LaravelDebugbar extends DebugBar
             }catch(\Exception $e){
                 $app['log']->error('Debugbar exception: '.$e->getMessage());
             }
-        }elseif( $request->isXmlHttpRequest() and $app['config']->get('laravel-debugbar::config.capture_ajax', true)){
+        }elseif( ($request->isXmlHttpRequest() || $request->wantsJson()) and $app['config']->get('laravel-debugbar::config.capture_ajax', true)){
             try {
                 $this->sendDataInHeaders(true);
             }catch(\Exception $e){


### PR DESCRIPTION
Helps with #142 as Angular doesn't set the xmlhttp header on it's requests, but _does_ set it's Accept header to application/json (which jquery uses as well)

You still need to set up the $http intercept handler in angular though :)
