### PR TITLE
Git files cleanup and additions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,22 +1,8 @@
-# Auto detect text files and perform LF normalization
 * text=auto
 
-# Custom for Visual Studio
-*.cs     diff=csharp
-*.sln    merge=union
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union
-
-# Standard to msysgit
-*.doc     diff=astextplain
-*.DOC     diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF     diff=astextplain
-*.rtf     diff=astextplain
-*.RTF     diff=astextplain
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /vendor
-composer.phar
 composer.lock
-.DS_Store


### PR DESCRIPTION
My export-ignore stuff is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.
