### PR TITLE
Updated the branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "1.6-dev"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
The current alias would mean somebody could ask composer for `1.4.*@dev`, and they would infact get the latest commit to the master - not the desired behaviour. We need to specify the minor version too in the branch alias.
