### PR TITLE
Update namespace to reflect laravel/framework#e8df05c

### DIFF
--- a/src/Barryvdh/Debugbar/Console/PublishCommand.php
+++ b/src/Barryvdh/Debugbar/Console/PublishCommand.php
@@ -1,6 +1,6 @@
 <?php
 namespace Barryvdh\Debugbar\Console;
-use Illuminate\Foundation\AssetPublisher;
+use Illuminate\Foundation\Publishing\AssetPublisher;
 use Illuminate\Console\Command;
 
 /**


### PR DESCRIPTION
As said on title, the on the laravel master branch the namespace was updated for publishing classes
see [laravel/framework#e8df05c](https://github.com/laravel/framework/commit/e8df05c6472c85824e27ea9d56959778ab85f07c)

Edit: adding the error

``` json
{
   "error":{
      "type":"ErrorException",
      "message":"Argument 1 passed to Barryvdh\\Debugbar\\Console\\PublishCommand::__construct() must be an instance of Illuminate\\Foundation\\AssetPublisher, instance of Illuminate\\Foundation\\Publishing\\AssetPublisher given, called in \/home\/vagrant\/laravel\/blog\/vendor\/barryvdh\/laravel-debugbar\/src\/Barryvdh\/Debugbar\/ServiceProvider.php on line 92 and defined",
      "file":"\/home\/vagrant\/laravel\/blog\/vendor\/barryvdh\/laravel-debugbar\/src\/Barryvdh\/Debugbar\/Console\/PublishCommand.php",
      "line":40
   }
```
