### PR TITLE
Fix for UserInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "laravel/framework": "~4.0|~5.0",
+        "laravel/framework": "~5.0",
         "symfony/finder": "~2.3",
         "maximebf/debugbar": "~1.9.15"
     },

--- a/src/DataCollector/AuthCollector.php
+++ b/src/DataCollector/AuthCollector.php
@@ -5,7 +5,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\Renderable;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Auth\UserInterface;
+use Illuminate\Contracts\Auth\User as UserContract;
 use Illuminate\Support\Contracts\ArrayableInterface;
 
 /**
@@ -54,7 +54,7 @@ class AuthCollector extends DataCollector implements Renderable
      * @param \Illuminate\Auth\UserInterface $user
      * @return array
      */
-    protected function getUserInformation(UserInterface $user = null)
+    protected function getUserInformation(UserContract $user = null)
     {
         // Defaults
         if (is_null($user)) {


### PR DESCRIPTION
In Laravel 5.0 Contracts are used. So there is no Illuminate\Auth\UserInterface any more. There is Illuminate\Contracts\Auth\User.
Also changed dependency in composer.json because of the backward incompatibility
