### PR TITLE
[WIP] Explain Queries

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -47,6 +47,20 @@ class QueryCollector extends PDOCollector
     }
 
     /**
+     * Enable/disable the EXPLAIN queries
+     *
+     * @param  bool $enabled
+     * @param  array|null $types Array of types to explain queries (select/insert/update/delete)
+     */
+    public function setExplainSource($enabled, $types)
+    {
+        $this->explainQuery = $enabled;
+        if($types){
+            $this->explainTypes = $types;
+        }
+    }
+    
+    /**
      *
      * @param string $query
      * @param array $bindings

--- a/src/LaravelDebugBar.php
+++ b/src/LaravelDebugBar.php
@@ -297,6 +297,11 @@ class LaravelDebugbar extends DebugBar
             if ($this->app['config']->get('laravel-debugbar::config.options.db.backtrace')) {
                 $queryCollector->setFindSource(true);
             }
+            
+            if ($this->app['config']->get('laravel-debugbar::config.options.db.explain.enabled')) {
+                $types = $this->app['config']->get('laravel-debugbar::config.options.db.explain.types');
+                $queryCollector->setExplainSource(true, $types);
+            }
 
             $this->addCollector($queryCollector);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -117,6 +117,10 @@ return array(
             'with_params'       => true,   // Render SQL with the parameters substituted
             'timeline'          => false,  // Add the queries to the timeline
             'backtrace'         => false,  // EXPERIMENTAL: Use a backtrace to find the origin of the query in your files.
+            'explain' => array(            // EXPERIMENTAL: Show EXPLAIN output on queries
+                'enabled' => false,
+                'types' => array('SELECT'), // array('SELECT', 'INSERT', 'UPDATE', 'DELETE'); for MySQL 5.6.3+
+            ),
         ),
         'mail' => array(
             'full_log' => false


### PR DESCRIPTION
Following up on #209

Adds an option to run EXPLAIN queries for all run queries (for the chosen type of queries, default = select). This will add the output of the EXPLAIN to a new query row, in the params.

![explain](https://cloud.githubusercontent.com/assets/973269/4590240/4562cd7e-505d-11e4-97ff-9a92324342fd.png)
