### PR TITLE
Code blocks with syntax highlighting + small typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,15 +41,21 @@ It also provides a Facade interface for easy logging Messages, Exceptions and Ti
 
 Require this package with composer:
 
-    composer require barryvdh/laravel-debugbar
+```
+composer require barryvdh/laravel-debugbar
+```
 
 After updating composer, add the ServiceProvider to the providers array in app/config/app.php
 
-    'Barryvdh\Debugbar\ServiceProvider',
-    
+```
+'Barryvdh\Debugbar\ServiceProvider',
+```
+
 If you want to use the facade to log messages, add this to your facades in app.php:
 
-    'Debugbar' => 'Barryvdh\Debugbar\Facade',
+```
+'Debugbar' => 'Barryvdh\Debugbar\Facade',
+```
 
 ~~You need to publish the assets from this package.~~ Since 1.7, you don't need to publish the assets anymore.
 
@@ -57,57 +63,71 @@ The profiler is enabled by default, if you have app.debug=true. You can override
 You can also set in your config if you want to include/exclude the vendor files also (FontAwesome, Highlight.js and jQuery). If you already use them in your site, set it to false.
 You can also only display the js of css vendors, by setting it to 'js' or 'css'. (Highlight.js requires both css + js, so set to `true` for syntax highlighting)
 
-    php artisan config:publish barryvdh/laravel-debugbar
+```
+php artisan config:publish barryvdh/laravel-debugbar
+```
 
 You can also disable/enable the loggers you want. You can also use the IoC container to add extra loggers. (`$app['debugbar']->addCollector(new MyDataCollector)`)
 
 You can now add messages using the Facade (when added), using the PSR-3 levels (debug, info, notice, warning, error, critical, alert, emergency):
 
-    Debugbar::info($object);
-    Debugbar::error("Error!");
-    Debugbar::warning('Watch out..');
-    Debugbar::addMessage('Another message', 'mylabel');
+```php
+Debugbar::info($object);
+Debugbar::error('Error!');
+Debugbar::warning('Watch out…');
+Debugbar::addMessage('Another message', 'mylabel');
+```
 
 And start/stop timing:
 
-    Debugbar::startMeasure('render','Time for rendering');
-    Debugbar::stopMeasure('render');
-    Debugbar::addMeasure('now', LARAVEL_START, microtime(true));
-    Debugbar::measure('My long operation', function() {
-        //Do something..
-    });
+```php
+Debugbar::startMeasure('render','Time for rendering');
+Debugbar::stopMeasure('render');
+Debugbar::addMeasure('now', LARAVEL_START, microtime(true));
+Debugbar::measure('My long operation', function() {
+    // Do something…
+});
+```
 
 Or log exceptions:
 
-    try {
-        throw new Exception('foobar');
-    } catch (Exception $e) {
-        Debugbar::addException($e);
-    }
-    
+```php
+try {
+    throw new Exception('foobar');
+} catch (Exception $e) {
+    Debugbar::addException($e);
+}
+```
+
 There are also helper functions available for the most common calls:
 
-    // All arguments will be dumped as a debug message
-    debug($var1, $someString, $intValue, $object);
-    
-    start_measure('render','Time for rendering');
-    stop_measure('render');
-    add_measure('now', LARAVEL_START, microtime(true));
-    measure('My long operation', function() {
-        //Do something..
-    });
+```php
+// All arguments will be dumped as a debug message
+debug($var1, $someString, $intValue, $object);
+
+start_measure('render','Time for rendering');
+stop_measure('render');
+add_measure('now', LARAVEL_START, microtime(true));
+measure('My long operation', function() {
+    // Do something…
+});
+```
 
 If you want you can add your own DataCollectors, through the Container or the Facade:
 
-    Debugbar::addCollector(new DebugBar\DataCollector\MessagesCollector('my_messages'));
-    //Or via the App container:
-    $debugbar = App::make('debugbar');
-    $debugbar->addCollector(new DebugBar\DataCollector\MessagesCollector('my_messages'));
+```php
+Debugbar::addCollector(new DebugBar\DataCollector\MessagesCollector('my_messages'));
+//Or via the App container:
+$debugbar = App::make('debugbar');
+$debugbar->addCollector(new DebugBar\DataCollector\MessagesCollector('my_messages'));
+```
 
 By default, the Debugbar is injected just before `</body>`. If you want to inject the Debugbar yourself,
 set the config option 'inject' to false and use the renderer yourself and follow http://phpdebugbar.com/docs/rendering.html
 
-    $renderer = Debugbar::getJavascriptRenderer();
+```php
+$renderer = Debugbar::getJavascriptRenderer();
+```
 
 Note: Not using the auto-inject, will disable the Request information, because that is added After the response.
 You can add the default_request datacollector in the config as alternative.
@@ -115,8 +135,10 @@ You can add the default_request datacollector in the config as alternative.
 ## Enabling/Disabling on run time
 You can enable or disable the debugbar during run time.
 
-    \Debugbar::enable();
-    \Debugbar::disable();
+```php
+\Debugbar::enable();
+\Debugbar::disable();
+```
 
 NB. Once enabled, the collectors are added (and could produce extra overhead), so if you want to use the debugbar in production, disable in the config and only enable when needed.
 
@@ -127,18 +149,24 @@ Laravel Debugbar comes with two Twig Extensions. These are tested with [rcrowe/T
 
 Add the following extensions to your TwigBridge config/extensions.php (or register the extensions manually)
 
-    'Barryvdh\Debugbar\Twig\Extension\Debug',
-    'Barryvdh\Debugbar\Twig\Extension\Dump',
-    'Barryvdh\Debugbar\Twig\Extension\Stopwatch',
+```php
+'Barryvdh\Debugbar\Twig\Extension\Debug',
+'Barryvdh\Debugbar\Twig\Extension\Dump',
+'Barryvdh\Debugbar\Twig\Extension\Stopwatch',
+```
 
 The Dump extension will replace the [dump function](http://twig.sensiolabs.org/doc/functions/dump.html) to output variables using the DataFormatter. The Debug extension adds a `debug()` function which passes variables to the Message Collector,
 instead of showing it directly in the template. It dumps the arguments, or when empty; all context variables.
 
-    {{ debug() }}
-    {{ debug(user, categories) }}
+```
+{{ debug() }}
+{{ debug(user, categories) }}
+```
 
 The Stopwatch extension adds a [stopwatch tag](http://symfony.com/blog/new-in-symfony-2-4-a-stopwatch-tag-for-twig)  similar to the one in Symfony/Silex Twigbridge.
 
-    {% stopwatch "foo" %}
-        ... some things that gets timed
-    {% endstopwatch %}
+```
+{% stopwatch "foo" %}
+    …some things that gets timed
+{% endstopwatch %}
+```


### PR DESCRIPTION
I also changed '..' and '...' to more appropriate '…' char and changed double quotes to single quote to Debugbar::error('Error!');
