### PR TITLE
removed shutdown() function

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,13 +21,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         if ($app->runningInConsole()) {
             if ($this->app['config']->get('laravel-debugbar::config.capture_console')) {
-                $app->shutdown(
-                    function ($app) {
-                        /** @var LaravelDebugbar $debugbar */
-                        $debugbar = $app['debugbar'];
-                        $debugbar->collectConsole();
-                    }
-                );
+                /** @var LaravelDebugbar $debugbar */
+                $debugbar = $app['debugbar'];
+                $debugbar->collectConsole();
             } else {
                 $this->app['config']->set('laravel-debugbar::config.enabled', false);
             }


### PR DESCRIPTION
For issue related to :
https://github.com/barryvdh/laravel-debugbar/issues/237

exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Call to undefined method Illuminate\Foundation\Application::shutdown()' in /barryvdh/laravel-debugbar/src/ServiceProvider.php:24

As the function shutdown() is removed from laravel 5
