### PR TITLE
Path prefix support for asset routes (for #233)

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,7 +43,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         }
 
         $this->app['router']->get(
-            '_debugbar/open',
+            $this->app['config']->get('laravel-debugbar::config.path_prefix', '') . '_debugbar/open',
             array(
                 'uses' => 'Barryvdh\Debugbar\Controllers\OpenHandlerController@handle',
                 'as' => 'debugbar.openhandler',
@@ -51,7 +51,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         );
 
         $this->app['router']->get(
-            '_debugbar/assets/stylesheets',
+            $this->app['config']->get('laravel-debugbar::config.path_prefix', '') . '_debugbar/assets/stylesheets',
             array(
                 'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@css',
                 'as' => 'debugbar.assets.css',
@@ -59,7 +59,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         );
 
         $this->app['router']->get(
-            '_debugbar/assets/javascript',
+            $this->app['config']->get('laravel-debugbar::config.path_prefix', '') . '_debugbar/assets/javascript',
             array(
                 'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@js',
                 'as' => 'debugbar.assets.js',

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -52,6 +52,20 @@ return array(
 
     /*
      |--------------------------------------------------------------------------
+     | Path prefix for asset routes
+     |--------------------------------------------------------------------------
+     |
+     | In some rare cases (if, for example, your Laravel installation is located in a virtual folder)
+     | you may want to make DebugBar use specific path prefix in routing.
+     | For example, if you put your Laravel project into /laravel virtual (not physical) folder, Laravel
+     | may still omit "/laravel" prefix when building links for you. In this case you can set the prefix manually
+     |
+     */
+
+    'path_prefix' => '',
+
+    /*
+     |--------------------------------------------------------------------------
      | Capture Ajax Requests
      |--------------------------------------------------------------------------
      |


### PR DESCRIPTION
This small PR adds an ability to define URL prefix for asset routing. This solves cases like #233 (they arise, for example, if you have a website under a virtual, non-physical folder in nginx and Laravel doesn't detect any base path).

I've tested it on my vagrant configuration, which has such virtual folder configured. All seem to run fine.