### PR TITLE
converts boolean variable type to string

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -11,7 +11,7 @@ return array(
      |
      */
 
-    'enabled' => config('app.debug'),
+    'enabled' => config('app.debug') ? 'true' : 'false',
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
i am using .env file and without this code my debugbar can not load. when i use the code echo config('app.debug') in a controller code raises boolean string convertion error. after i make this change its ok :)