### PR TITLE
Route prefix support added for Laravel Debug Bar internal routes (Laravel 4.x)

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -42,29 +42,33 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             );
         }
 
-        $this->app['router']->get(
-            '_debugbar/open',
-            array(
-                'uses' => 'Barryvdh\Debugbar\Controllers\OpenHandlerController@handle',
-                'as' => 'debugbar.openhandler',
-            )
-        );
+        $this->app['router']->group(
+            ['prefix' => $this->app['config']->get('laravel-debugbar::config.route_prefix')], function () {
 
-        $this->app['router']->get(
-            '_debugbar/assets/stylesheets',
-            array(
-                'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@css',
-                'as' => 'debugbar.assets.css',
-            )
-        );
+            $this->app['router']->get(
+                '_debugbar/open',
+                array(
+                    'uses' => 'Barryvdh\Debugbar\Controllers\OpenHandlerController@handle',
+                    'as' => 'debugbar.openhandler',
+                )
+            );
 
-        $this->app['router']->get(
-            '_debugbar/assets/javascript',
-            array(
-                'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@js',
-                'as' => 'debugbar.assets.js',
-            )
-        );
+            $this->app['router']->get(
+                '_debugbar/assets/stylesheets',
+                array(
+                    'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@css',
+                    'as' => 'debugbar.assets.css',
+                )
+            );
+
+            $this->app['router']->get(
+                '_debugbar/assets/javascript',
+                array(
+                    'uses' => 'Barryvdh\Debugbar\Controllers\AssetController@js',
+                    'as' => 'debugbar.assets.js',
+                )
+            );
+        });
 
         if ($this->app['config']->get('laravel-debugbar::config.enabled')) {
             /** @var LaravelDebugbar $debugbar */

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -154,4 +154,15 @@ return array(
 
     'inject' => true,
 
+    /*
+     |--------------------------------------------------------------------------
+     | DebugBar route prefix
+     |--------------------------------------------------------------------------
+     |
+     | Sometimes you want to set route prefix to be used by DebugBar to load
+     | its resources from. Usually the need comes from misconfigured web server or
+     | from trying to overcome bugs like this: http://trac.nginx.org/nginx/ticket/97
+     |
+     */
+    'route_prefix' => '',
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -164,5 +164,5 @@ return array(
      | from trying to overcome bugs like this: http://trac.nginx.org/nginx/ticket/97
      |
      */
-    'route_prefix' => '',
+    'route_prefix' => '_debugbar',
 );


### PR DESCRIPTION
This adds support for configuring Laravel debug bar route prefixes so that Debug bar could be used in cases, affected by bugs like this: http://trac.nginx.org/nginx/ticket/97 where root path, detected by nginx is different from the real one.
