### PR TITLE
Route prefix made configurable (Laravel 5)

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -142,4 +142,16 @@ return array(
 
     'inject' => true,
 
+    /*
+     |--------------------------------------------------------------------------
+     | DebugBar route prefix
+     |--------------------------------------------------------------------------
+     |
+     | Sometimes you want to set route prefix to be used by DebugBar to load
+     | its resources from. Usually the need comes from misconfigured web server or
+     | from trying to overcome bugs like this: http://trac.nginx.org/nginx/ticket/97
+     |
+     */
+    'route_prefix' => '_debugbar',
+
 );

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -65,8 +65,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $routeConfig = [
             'namespace' => 'Barryvdh\Debugbar\Controllers',
-            'prefix' => '_debugbar',
+            'prefix' => $this->app['config']->get('debugbar.route_prefix'),
         ];
+
         $this->app['router']->group($routeConfig, function($router) {
             $router->get('open', [
                 'uses' => 'OpenHandlerController@handle',


### PR DESCRIPTION
This adds possibility to configure route prefix to make Laravel Debug bar usable in cases affected by bug like this one (http://trac.nginx.org/nginx/ticket/97).