### PR TITLE
Refacto the way user info are displayed

### DIFF
--- a/src/DataCollector/AuthCollector.php
+++ b/src/DataCollector/AuthCollector.php
@@ -61,18 +61,16 @@ class AuthCollector extends DataCollector implements Renderable
             );
         }
 
-        // The default auth identifer is the ID number, which isn't all that
-        // useful. Try username and email.
-        $identifier = $user->getAuthIdentifier();
-        if (is_numeric($identifier)) {
-            try {
-                if ($user->username) {
-                    $identifier = $user->username;
-                } elseif ($user->email) {
-                    $identifier = $user->email;
-                }
-            } catch (\Exception $e) {
+        // We try to display first the username or the email attribute of the User object
+        // Otherwise, the identifier, which is most likely the ID number, will be displayed as a fallback.
+        try {
+            if ($user->username) {
+                $identifier = $user->username;
+            } elseif ($user->email) {
+                $identifier = $user->email;
             }
+        } catch (\Exception $e) {
+            $identifier = $user->getAuthIdentifier();
         }
 
         return array(


### PR DESCRIPTION
I quickly reviewed how the user information are displayed.
Initially you were checking if the AuthIdentifier is an numeric value, then you would try to display username or email attributes.
On a specific project I don't use numeric values for my AuthIdentifier, I use serials like '003g000000Sanpv' which are non-numeric values.
What I offer here is we try to display username, email first before falling back to display the identifier so we don't check if it's numeric.
