### PR TITLE
[L5] Fix for addon crash when DB::disableQueryLog() was called in a user application

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -251,7 +251,7 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
-        if ($this->shouldCollect('db', true) && isset($this->app['db'])) {
+        if ($this->shouldCollect('db', true) && isset($this->app['db']) && $this->app['db']->logging()) {
             $db = $this->app['db'];
             if ($debugbar->hasCollector('time') && $this->app['config']->get(
                     'debugbar.options.db.timeline',


### PR DESCRIPTION
This fixes an addon crash when DB::disableQueryLog() was used inside an application to manually turn off query logging. In this case DebugBar is unable to start with the following cryptic messages in Laravel log:

```
[2015-05-25 16:10:18] development.ERROR: Debugbar exception: Undefined property: stdClass::$id  
```

Those messages are emited by `\Barryvdh\Debugbar\DataCollector\QueryCollector::collect()` which doesn't know what to collect when is nothing to ;)