### PR TITLE
[L4] Fix for addon crash when DB::disableQueryLog() was called in a user application

### DIFF
--- a/src/LaravelDebugBar.php
+++ b/src/LaravelDebugBar.php
@@ -262,7 +262,7 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
-        if ($this->shouldCollect('db', true) and isset($this->app['db'])) {
+        if ($this->shouldCollect('db', true) and isset($this->app['db']) and $this->app['db']->logging()) {
             $db = $this->app['db'];
             if ($debugbar->hasCollector('time') && $this->app['config']->get(
                     'laravel-debugbar::config.options.db.timeline',


### PR DESCRIPTION
This fixes an addon crash when DB::disableQueryLog() was used inside an application to manually turn off query logging. In this case DebugBar is unable to start with the following cryptic messages in Laravel log:

```
[2015-05-25 16:10:18] development.ERROR: Debugbar exception: Undefined property: stdClass::$id  
```
