### PR TITLE
[L5] Fix for crash when attempting to explain non-mysql queries

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -272,7 +272,7 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setFindSource(true);
             }
 
-            if ($this->app['config']->get('debugbar.options.db.explain.enabled')) {
+            if ($this->app['config']->get('debugbar.options.db.explain.enabled') && ($this->app['db']->getDriverName( ) == 'mysql')) {
                 $types = $this->app['config']->get('debugbar.options.db.explain.types');
                 $queryCollector->setExplainSource(true, $types);
             }


### PR DESCRIPTION
Currently only MySQL queries are supported for EXPLAIN so... (I work with Postgres).