### PR TITLE
[L4] Fix for crash when attempting to explain non-mysql queries

### DIFF
--- a/src/LaravelDebugBar.php
+++ b/src/LaravelDebugBar.php
@@ -283,7 +283,8 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setFindSource(true);
             }
 
-            if ($this->app['config']->get('laravel-debugbar::config.options.db.explain.enabled')) {
+            if ($this->app['config']->get('laravel-debugbar::config.options.db.explain.enabled') && ($this->app['db']->getDriverName( ) == 'mysql')
+            ) {
                 $types = $this->app['config']->get('laravel-debugbar::config.options.db.explain.types');
                 $queryCollector->setExplainSource(true, $types);
             }


### PR DESCRIPTION
Currently only MySQL queries are supported for EXPLAIN so... (I work with Postgres).