### PR TITLE
Default enable session collector.

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -89,7 +89,7 @@ return array(
         'files'           => false, // Show the included files
         'config'          => false, // Display config settings
         'auth'            => false, // Display Laravel authentication status
-        'session'         => false, // Display session data in a separate tab
+        'session'         => true,  // Display session data
     ),
 
     /*


### PR DESCRIPTION
I find this [session collector](http://puu.sh/ieCQN/998526477d.png) very useful.  What do you think about enabling it as default collector?

If not, maybe it should be mentioned somewhere in your README as an option?