### PR TITLE
debugbar specific locations should have debugbar enabled by default

### DIFF
--- a/src/Controllers/AssetController.php
+++ b/src/Controllers/AssetController.php
@@ -11,6 +11,7 @@ class AssetController extends BaseController
      */
     public function js()
     {
+        $this->debugbar->enable();
         $renderer = $this->debugbar->getJavascriptRenderer();
 
         $content = $renderer->dumpAssetsToString('js');
@@ -31,6 +32,7 @@ class AssetController extends BaseController
      */
     public function css()
     {
+        $this->debugbar->enable();
         $renderer = $this->debugbar->getJavascriptRenderer();
 
         $content = $renderer->dumpAssetsToString('css');


### PR DESCRIPTION
When debugbar is not enabled, the ServiceProvider.php does not call boot method of $debugbar

```
if ( ! $enabled) {
    return;
}

/** @var LaravelDebugbar $debugbar */
$debugbar = $this->app['debugbar'];
$debugbar->boot();
```

This results into collectors not being added, so when JavascriptRenderer tries to complete the list of assets (inside the getAssets method), the _views_ and _queries_ is missing

```
foreach ($this->debugBar->getCollectors() as $collector) {
    if (($collector instanceof AssetProvider) && !in_array($collector->getName(), $this->ignoredCollectors)) {
        $additionalAssets[] = $collector->getAssets();
    }
}
```
