### PR TITLE
Delegate cache busting query string to the UrlGenerator

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -12,7 +12,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
     // Use XHR handler by default, instead of jQuery
     protected $ajaxHandlerBindToJquery = false;
     protected $ajaxHandlerBindToXHR = true;
-    
+
     /** @var \Illuminate\Routing\UrlGenerator */
     protected $url;
 
@@ -43,20 +43,17 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             return parent::renderHead();
         }
 
-        $jsModified = $this->getModifiedTime('js');
-        $cssModified = $this->getModifiedTime('css');
+        $cssRoute = $this->url->route('debugbar.assets.css', [
+            'v' => $this->getModifiedTime('css')
+        ]);
 
-        $html = '';
-        $html .= sprintf(
-            '<link rel="stylesheet" type="text/css" href="%s?%s">' . "\n",
-            $this->url->route('debugbar.assets.css'),
-            $cssModified
-        );
-        $html .= sprintf(
-            '<script type="text/javascript" src="%s?%s"></script>' . "\n",
-            $this->url->route('debugbar.assets.js'),
-            $jsModified
-        );
+        $jsRoute  = $this->url->route('debugbar.assets.js', [
+            'v' => $this->getModifiedTime('js')
+       ]);
+
+        $html  = '';
+        $html .= "<link rel='stylesheet' type='text/css' href='{$cssRoute}'>";
+        $html .= "<script type='text/javascript' src='{$jsRoute}'></script>";
 
         if ($this->isJqueryNoConflictEnabled()) {
             $html .= '<script type="text/javascript">jQuery.noConflict(true);</script>' . "\n";


### PR DESCRIPTION
In our case we override the UrlGenerator to provide cache busting and a few shortcuts to mounting locations. The problem is Debugbar adds a query string to bust cache even though one exists. An easy solution would be to offload the work onto the UrlGenerator since it knows best how to hand the URL.

So something like this:
`http://focus.dev/Modules.php?modname=laravel/route?123`

Becomes:
`http://focus.dev/Modules.php?modname=laravel/route&v=123`