### PR TITLE
Filters deprecated in favour of middleware

### DIFF
--- a/src/DataCollector/IlluminateRouteCollector.php
+++ b/src/DataCollector/IlluminateRouteCollector.php
@@ -54,7 +54,7 @@ class IlluminateRouteCollector extends DataCollector implements Renderable
         $result = array(
     	   'uri' => $uri ?: '-',
         );
-        
+
         $result = array_merge($result, $action);
 
 
@@ -73,82 +73,27 @@ class IlluminateRouteCollector extends DataCollector implements Renderable
             $filename = ltrim(str_replace(base_path(), '', $reflector->getFileName()), '/');
             $result['file'] = $filename . ':' . $reflector->getStartLine() . '-' . $reflector->getEndLine();
         }
-		
-		if ($before = $this->getBeforeFilters($route)) {
-		    $result['before'] = $before;
+
+		if ($middleware = $this->getMiddleware($route)) {
+		    $result['middleware'] = $middleware;
 		}
-		
-		if ($after = $this->getAfterFilters($route)) {
-		    $result['after'] = $after;
-		}
-		
+
+
+
         return $result;
     }
 
     /**
-     * Get before filters
+     * Get middleware
      *
      * @param  \Illuminate\Routing\Route $route
      * @return string
      */
-    protected function getBeforeFilters($route)
+    protected function getMiddleware($route)
     {
-        $before = array_keys($route->beforeFilters());
+        $middleware = array_keys($route->middleware());
 
-        $before = array_unique(array_merge($before, $this->getPatternFilters($route)));
-
-        return implode(', ', $before);
-    }
-
-    /*
-     * The following is copied/modified from the RoutesCommand from Laravel, by Taylor Otwell
-     * https://github.com/laravel/framework/blob/4.1/src/Illuminate/Foundation/Console/RoutesCommand.php
-     *
-     */
-
-    /**
-     * Get all of the pattern filters matching the route.
-     *
-     * @param  \Illuminate\Routing\Route $route
-     * @return array
-     */
-    protected function getPatternFilters($route)
-    {
-        $patterns = array();
-
-        foreach ($route->methods() as $method) {
-            // For each method supported by the route we will need to gather up the patterned
-            // filters for that method. We will then merge these in with the other filters
-            // we have already gathered up then return them back out to these consumers.
-            $inner = $this->getMethodPatterns($route->uri(), $method);
-
-            $patterns = array_merge($patterns, array_keys($inner));
-        }
-
-        return $patterns;
-    }
-
-    /**
-     * Get the pattern filters for a given URI and method.
-     *
-     * @param  string $uri
-     * @param  string $method
-     * @return array
-     */
-    protected function getMethodPatterns($uri, $method)
-    {
-        return $this->router->findPatternFilters(Request::create($uri, $method));
-    }
-
-    /**
-     * Get after filters
-     *
-     * @param  Route $route
-     * @return string
-     */
-    protected function getAfterFilters($route)
-    {
-        return implode(', ', array_keys($route->afterFilters()));
+        return implode(', ', $middleware);
     }
 
     /**

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -141,24 +141,6 @@ class LaravelDebugbar extends DebugBar
                       }
                   }
                 );
-
-                //Check if App::before is already called..
-                if ($this->app->isBooted()) {
-                    $debugbar->startMeasure('application', 'Application');
-                } else {
-                    $this->app['router']->before(
-                      function () use ($debugbar) {
-                          $debugbar->startMeasure('application', 'Application');
-                      }
-                    );
-                }
-
-                $this->app['router']->after(
-                  function () use ($debugbar) {
-                      $debugbar->stopMeasure('application');
-                      $debugbar->startMeasure('after', 'After application');
-                  }
-                );
             }
 
         }

--- a/src/Middleware/Debugbar.php
+++ b/src/Middleware/Debugbar.php
@@ -44,6 +44,8 @@ class Debugbar {
         /** @var \Barryvdh\Debugbar\LaravelDebugbar $debugbar */
         $debugbar = $this->app['debugbar'];
 
+        $debugbar->startMeasure('application', 'Application');
+
         try {
             /** @var \Illuminate\Http\Response $response */
             $response = $next($request);
@@ -53,6 +55,9 @@ class Debugbar {
             $this->exceptionHandler->report($e);
             $response = $this->exceptionHandler->render($request, $e);
         }
+
+        $debugbar->stopMeasure('application');
+        $debugbar->startMeasure('after', 'After application');
 
         return $debugbar->modifyResponse($request, $response);
 


### PR DESCRIPTION
As title says, filters are deprecated in Laravel 5, and have now been removed altogether in master (and therefore 5.2).