### PR TITLE
Type-hint appropriate arguments

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -456,7 +456,7 @@ class LaravelDebugbar extends DebugBar
      * @param  \Symfony\Component\HttpFoundation\Response $response
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function modifyResponse($request, $response)
+    public function modifyResponse(Request $request, Response $response)
     {
         $app = $this->app;
         if ($app->runningInConsole() || !$this->isEnabled() || $this->isDebugbarRequest()) {
@@ -593,7 +593,7 @@ class LaravelDebugbar extends DebugBar
      * @param  \Symfony\Component\HttpFoundation\Request $request
      * @return bool
      */
-    protected function isJsonRequest($request)
+    protected function isJsonRequest(Request $request)
     {
         // If XmlHttpRequest, return true
         if ($request->isXmlHttpRequest()) {
@@ -841,7 +841,7 @@ class LaravelDebugbar extends DebugBar
         }
     }
 
-    protected function addClockworkHeaders($response)
+    protected function addClockworkHeaders(Response $response)
     {
         $prefix = $this->app['config']->get('debugbar.route_prefix');
         $response->headers->set('X-Clockwork-Id', $this->getCurrentRequestId(), true);


### PR DESCRIPTION
Some methods accepting `$request` and `$response` as arguments did not have the appropriate type hints, although the dockblock tags were suggesting these classes.

This makes user mistakes hard to debug. For example:

I did a mistake in my `Exceptions\Handler.php` of returning a `View` instead of a `Response` instance.

```php
public function render(Request $request, Exception $e) {
    if ($e instanceof NotFoundHttpException) {
        return view('my.custom.404');
    }
}
```

The output was `exception 'BadMethodCallException' with message 'Method [isRedirection] does not exist on view.'`.
`LaravelDebugbar` is calling `isRedirection()` on a `$response` argument, but there has no check if that argument was indeed a `Response` instance.

By typehinting those arguments we can prevent this kind of errors and make the package less error-prone.