### PR TITLE
Disallow php < 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "illuminate/support": "~5.0.17|5.1.*",
         "symfony/finder": "~2.6",
         "maximebf/debugbar": "~1.10.2"


### PR DESCRIPTION
There are several places where this packages uses the ::class attribute.
This attribute was not available before php 5.5