### PR TITLE
Update ViewCollector.php for StringBladeCompiler

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -54,14 +54,20 @@ class ViewCollector extends TwigCollector
     {
         $name = $view->getName();
         $path = $view->getPath();
-        if ($path) {
-            $path = ltrim(str_replace(base_path(), '', realpath($path)), '/');
-        }
+        
+        if (!is_object($path)) {
+            if ($path) {
+                $path = ltrim(str_replace(base_path(), '', realpath($path)), '/');
+            }
 
-        if (substr($path, -10) == '.blade.php') {
-            $type = 'blade';
+            if (substr($path, -10) == '.blade.php') {
+                $type = 'blade';
+            } else {
+                $type = pathinfo($path, PATHINFO_EXTENSION);
+            }
         } else {
-            $type = pathinfo($path, PATHINFO_EXTENSION);
+            $type = get_class($view);
+            $path = '';
         }
 
         if (!$this->collect_data) {


### PR DESCRIPTION
This change is to support my StringBladeCompiler plugin.

Without the change the debugbar generates an error, "realpath () expects parameter 1 to be a valid path, object given"

This is because the path is an object when using the StringBladeCompler plugin instead of a template file path.

Thanks.