### PR TITLE
Option for Custom storage

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -31,7 +31,7 @@ return array(
         'driver' => 'file', // redis, file, pdo, custom
         'path' => storage_path() . '/debugbar', // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)
-        'provider'=>"" // Instance of StorageInterface for custom driver
+        'provider' => '' // Instance of StorageInterface for custom driver
     ),
 
     /*

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -28,9 +28,10 @@ return array(
      */
     'storage' => array(
         'enabled' => true,
-        'driver' => 'file', // redis, file, pdo
+        'driver' => 'file', // redis, file, pdo, custom
         'path' => storage_path() . '/debugbar', // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)
+        'provider'=>"" // Instance of StorageInterface for custom driver
     ),
 
     /*

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -787,7 +787,7 @@ class LaravelDebugbar extends DebugBar
                     break;
                 case 'custom':
                     $class = $config->get('debugbar.storage.provider');
-                    $storage = app($class);
+                    $storage = $this->app->make($class);
                     break;
                 case 'file':
                 default:

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -785,6 +785,10 @@ class LaravelDebugbar extends DebugBar
                     $connection = $config->get('debugbar.storage.connection');
                     $storage = new RedisStorage($this->app['redis']->connection($connection));
                     break;
+                case 'custom':
+                    $class = $config->get('debugbar.storage.provider');
+                    $storage = app($class);
+                    break;
                 case 'file':
                 default:
                     $path = $config->get('debugbar.storage.path');


### PR DESCRIPTION
Other than file, PDO and redis, This PR add the functionality to developers to have their own Storage interface.

Working:
in config 

     'storage' => array(
        'enabled' => true,
        'driver' => 'custom', // redis, file, pdo, custom
        'path' => storage_path() . '/debugbar', // For file driver
        'connection' => null,   // Leave null for default connection (Redis/PDO)
        'provider'=>"App/Framework/ElasticStorage" // Instance of StorageInterface for custom driver
    ),

    <?php

  class ElasticStorage implements StorageInterface{
 
  }




