### PR TITLE
Move appended storage path inside `storage_path` function call and indent array values

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -27,11 +27,11 @@ return array(
      |
      */
     'storage' => array(
-        'enabled' => true,
-        'driver' => 'file', // redis, file, pdo, custom
-        'path' => storage_path() . '/debugbar', // For file driver
+        'enabled'    => true,
+        'driver'     => 'file', // redis, file, pdo, custom
+        'path'       => storage_path('debugbar'), // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)
-        'provider' => '' // Instance of StorageInterface for custom driver
+        'provider'   => '' // Instance of StorageInterface for custom driver
     ),
 
     /*


### PR DESCRIPTION
`storage_path` accepts a `$path`parameter and will properly append it to the storage path taking care of the directory separator itself.