### PR TITLE
[5.2] Add support for multi auth

### DIFF
--- a/src/DataCollector/MultiAuthCollector.php
+++ b/src/DataCollector/MultiAuthCollector.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+/**
+ * Collector for Laravel's Auth provider
+ */
+class MultiAuthCollector extends AuthCollector
+{
+    /** @var array $guards */
+    protected $guards;
+
+    /**
+     * @param \Illuminate\Auth\AuthManager $auth
+     * @param array $guards
+     */
+    public function __construct($auth, $guards)
+    {
+        parent::__construct($auth);
+        $this->guards = $guards;
+    }
+
+
+    /**
+     * @{inheritDoc}
+     */
+    public function collect()
+    {
+        $data = [];
+        $names = '';
+
+        foreach($this->guards as $guardName) {
+            $user = $this->auth->guard($guardName)->user();
+            $data['guards'][$guardName] = $this->getUserInformation($user);
+            if(!is_null($user)) {
+                $names .= $guardName . ": " . $data['guards'][$guardName]['name'] . ', ';
+            }
+        }
+
+        foreach ($data['guards'] as $key => $var) {
+            if (!is_string($data['guards'][$key])) {
+                $data['guards'][$key] = $this->formatVar($var);
+            }
+        }
+
+        $data['names'] = rtrim($names, ', ');
+
+        return $data;
+    }
+    
+    /**
+     * @{inheritDoc}
+     */
+    public function getWidgets()
+    {
+        $widgets = array(
+            "auth" => array(
+                "icon" => "lock",
+                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
+                "map" => "auth.guards",
+                "default" => "{}"
+            )
+        );
+
+        if ($this->showName) {
+            $widgets['auth.name'] = array(
+                'icon' => 'user',
+                'tooltip' => 'Auth status',
+                'map' => 'auth.names',
+                'default' => '',
+            );
+        }
+
+        return $widgets;
+    }
+}

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -5,6 +5,7 @@ use Barryvdh\Debugbar\DataCollector\EventCollector;
 use Barryvdh\Debugbar\DataCollector\FilesCollector;
 use Barryvdh\Debugbar\DataCollector\LaravelCollector;
 use Barryvdh\Debugbar\DataCollector\LogsCollector;
+use Barryvdh\Debugbar\DataCollector\MultiAuthCollector;
 use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\DataCollector\SessionCollector;
 use Barryvdh\Debugbar\DataCollector\SymfonyRequestCollector;
@@ -354,7 +355,14 @@ class LaravelDebugbar extends DebugBar
 
         if ($this->shouldCollect('auth', false)) {
             try {
-                $authCollector = new AuthCollector($app['auth']);
+                if($this->checkVersion('5.2')) {
+                    // fix for compatibility with Laravel 5.2.*
+                    $guards = array_keys($this->app['config']->get('auth.guards'));
+                    $authCollector = new MultiAuthCollector($app['auth'], $guards);
+                } else {
+                    $authCollector = new AuthCollector($app['auth']);
+                }
+
                 $authCollector->setShowName(
                     $this->app['config']->get('debugbar.options.auth.show_name')
                 );


### PR DESCRIPTION
Laravel 5.2 supports custom user providers, but unfortunately this isn't currenty supported by Laravel Debugbar. This is my fast and dirty way to solve this problem. See also https://github.com/barryvdh/laravel-debugbar/issues/436
There are no backwards compatibility issues since original AuthCollector isn't touched. This is how it looks:

![screenshot-wesele123_v2 wp 2016-01-30 03-40-58](https://cloud.githubusercontent.com/assets/8512597/12693280/4d197be6-c706-11e5-839c-734239b274a4.png)

