### PR TITLE
While caching config, the enabled setting was overwritten

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,7 +64,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
         if ($app->runningInConsole()) {
-            $this->app['config']->set('debugbar.enabled', false);
+            if(false === array_key_exists(1, \Request::server('argv'))
+                || true === empty($artisanCommand = \Request::server('argv')[1]) 
+                || 'config:cache' !== $artisanCommand
+            ) {
+                $this->app['config']->set('debugbar.enabled', false);
+            }
         }
 
         $routeConfig = [


### PR DESCRIPTION
The service provider set debugbar.enabled to false when running any console command, including config:cache. Said command uses the config array to create the cache file, and thus the configuration unexpectedly changes.

(A situation where the config is cached with the debugbar is enabled probably almost never occurs, nevertheless the debugbar is a nice performance testing tool, which includes testing the performance gain by caching the configuration)