### PR TITLE
[L5] Fatal Error in Lumen 5.2.* Query Collector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -82,7 +82,7 @@ class QueryCollector extends PDOCollector
     {
         // If the query argument is an instance of QueryExecuted the rest of the
         // arguments are probably wrong types and are going to crash
-        // the colletor.
+        // the collector.
         if ( $query instanceof \Illuminate\Database\Events\QueryExecuted )
         {
             $bindings = $query->bindings;

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -80,6 +80,17 @@ class QueryCollector extends PDOCollector
      */
     public function addQuery($query, $bindings, $time, $connection)
     {
+        // If the query argument is an instance of QueryExecuted the rest of the
+        // arguments are probably wrong types and are going to crash
+        // the colletor.
+        if ( $query instanceof \Illuminate\Database\Events\QueryExecuted )
+        {
+            $bindings = $query->bindings;
+            $time = $query->time;
+            $connection = $query->connection;
+            $query = $query->sql;
+        }
+        
         $explainResults = array();
         $time = $time / 1000;
         $endTime = microtime(true);


### PR DESCRIPTION
This is the Lumen version I have. (Lumen (5.2.4) (Laravel Components 5.2.*))

Since it didn't work with the stable version of laravel-debugbar I had to download the master branch and it worked fine until I started running queries through Eloquent. All of them were crashing because LaravelDebugbar couldn't cast the event object as a string due to lack of __toString() method in the QueryExecuted object. My solution is a bit hacky and you should change it however you please. I haven't done much pull requesting before and I am not sure how you deal with this sort of things but this is the easiest solution I could come with. 

I also didn't see issues in the issue tracker about it, but the fatal error is pretty evident if you run queries with the latest Laravel Lumen framework. 

Thank you for your time reviewing this pull request! 