### PR TITLE
[L5] Replacing version_compare with parameter type check

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -295,8 +295,9 @@ class LaravelDebugbar extends DebugBar
                         // Laravel 5.2 changed the way some core events worked. We must account for
                         // the first argument being an "event object", where arguments are passed
                         // via object properties, instead of individual arguments.
-                        // In my opinion it is better to type check rather than version check for the
-                        // long term. 
+                        // In my opinion it is better to type check rather than version check in the
+                        // long term. Lumen doesn't support SemVer standard either, thus breaking
+                        // the version_compare function
                         if ( $query instanceof \Illuminate\Database\Events\QueryExecuted ) {
                             $bindings = $query->bindings;
                             $time = $query->time;

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -295,7 +295,9 @@ class LaravelDebugbar extends DebugBar
                         // Laravel 5.2 changed the way some core events worked. We must account for
                         // the first argument being an "event object", where arguments are passed
                         // via object properties, instead of individual arguments.
-                        if (version_compare($this->version, '5.2.0', '>=')) {
+                        // In my opinion it is better to type check rather than version check for the
+                        // long term. 
+                        if ( $query instanceof \Illuminate\Database\Events\QueryExecuted ) {
                             $bindings = $query->bindings;
                             $time = $query->time;
                             $connection = $query->connection;


### PR DESCRIPTION
A fix has been pushed for Laravel 5.2 making the debugbar being able to recognize Laravel's version and act accordingly. 

However for some reason Taylor pushed non-standard version for Lumen. It is still using SemVer but it is somewhat expanded and would require RegEx to parse accordingly (which is overkill, in my opinion). 

Long story short, the checkVersion helper is unable to work properly with Lumen's version output. 

By adding type check of parameters I'm assuming that it won't break compatibility with older versions of Laravel 5 (E.g. 5.0, 5.1)

It is a simple fix. From my tests (Laravel 5.2 and Lumen 5.2) it seems to record queries and display them properly. 

I've checked what happens when Illuminate\Database\Events\QueryExecuted class is missing. The code just doesn't go into the conditional and reverts back to the old logic for Laravel 5.1 and less. 