### PR TITLE
Fixes #403 - Need to reflash the session.

### DIFF
--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -2,6 +2,7 @@
 
 use Barryvdh\Debugbar\LaravelDebugbar;
 use Illuminate\Routing\Controller;
+use Illuminate\Http\Request;
 
 if (class_exists('Illuminate\Routing\Controller')) {
 
@@ -9,9 +10,10 @@ if (class_exists('Illuminate\Routing\Controller')) {
     {
         protected $debugbar;
 
-        public function __construct(LaravelDebugbar $debugbar)
+        public function __construct(Request $request, LaravelDebugbar $debugbar)
         {
             $this->debugbar = $debugbar;
+            $request->session()->reflash();
         }
     }
 
@@ -21,10 +23,10 @@ if (class_exists('Illuminate\Routing\Controller')) {
     {
         protected $debugbar;
 
-        public function __construct(LaravelDebugbar $debugbar)
+        public function __construct(Request $request, LaravelDebugbar $debugbar)
         {
             $this->debugbar = $debugbar;
+            $request->session()->reflash();
         }
     }
 }
-


### PR DESCRIPTION
This is a fix for issue #403.

This was lost when the package was updated to L5. The session needs to be flashed in our controller, otherwise the flash variables get lost once the package requests it's assets