### PR TITLE
Fix HTML5 Validation

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -45,7 +45,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             'v' => $this->getModifiedTime('js')
        ]);
 
-        $html  = "<link rel='stylesheet' type='text/css' href='{$cssRoute}'>";
+        $html  = "<link rel='stylesheet' type='text/css' property='stylesheet' href='{$cssRoute}'>";
         $html .= "<script type='text/javascript' src='{$jsRoute}'></script>";
 
         if ($this->isJqueryNoConflictEnabled()) {


### PR DESCRIPTION
The HTML validation of a document with Debugbar enabled gives this error: `Element link is missing required attribute property.`

The line source of the error is the link tag:

```
<link rel='stylesheet' type='text/css' href='http://localhost:8080/_debugbar/assets/stylesheets?v=1462974883'>
```