### PR TITLE
adjust middleware order

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -151,7 +151,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     protected function registerMiddleware($middleware)
     {
         $kernel = $this->app['Illuminate\Contracts\Http\Kernel'];
-        $kernel->pushMiddleware($middleware);
+        $kernel->prependMiddleware($middleware);
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -70,6 +70,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $enabled = $this->checkAppDebug();
         }
 
+        if ($enabled instanceof \Closure) {
+            $enabled = $enabled();
+        }
+
         if (! $enabled) {
             return;
         }


### PR DESCRIPTION
in laravel 5.1, debugbar makes previous url to asset url like http://example.com/_debugbar/assets/javascript?1456726057

debugbar assets are handled by controller. 
so, \Illuminate\Session\Middleware\StartSession is called and then _previous variable in session is changed by storeCurrentUrl function.

that's why "return back();" redirects to debugbar asset page.

so, i moved debugbar middleware to top level of middlewares.
after that it works well for me.

if it still has problem. please let me know. i will fix it again.

thank you.

laravel 5.2 is fine. but laravel 5.1 is not
i didn't check the all version but i think there is a same bug under 5.1 version.
