### PR TITLE
Allow callback to determine `enabled` config value

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,7 +64,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
         // If enabled is null, set from the app.debug value
-        $enabled = $this->app['config']->get('debugbar.enabled');
+        $enabled = value($this->app['config']->get('debugbar.enabled'));
 
         if (is_null($enabled)) {
             $enabled = $this->checkAppDebug();


### PR DESCRIPTION
When callbacks are allowed, you can for example enable or disable the debugbar for specific ips.

Resolves #523 