### PR TITLE
option to only collect slow queries

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -309,7 +309,11 @@ class LaravelDebugbar extends DebugBar
                             $connection = $db->connection($connectionName);
                         }
 
-                        $queryCollector->addQuery((string) $query, $bindings, $time, $connection);
+                        //allow collecting only queries slower than a specified amount of milliseconds
+                        $threshold = $this->app['config']->get('debugbar.options.db.slow_threshold', false);
+                        if (!$threshold || $time > $threshold) {
+                            $queryCollector->addQuery((string)$query, $bindings, $time, $connection);
+                        }
                     }
                 );
             } catch (\Exception $e) {


### PR DESCRIPTION
check if a new config setting `debugbar.options.db.slow_threshold` is set. if so, only add the current query to the collector if it is slower then this setting

ie)

```
 'options' => array(
        'db' => array(
            'slow_threshold'    => 100, //milliseconds a query must be slower then to be collected
        ),
```
