### PR TITLE
Fix for displaying middleware names

### DIFF
--- a/src/DataCollector/IlluminateRouteCollector.php
+++ b/src/DataCollector/IlluminateRouteCollector.php
@@ -74,26 +74,7 @@ class IlluminateRouteCollector extends DataCollector implements Renderable
             $result['file'] = $filename . ':' . $reflector->getStartLine() . '-' . $reflector->getEndLine();
         }
 
-		if ($middleware = $this->getMiddleware($route)) {
-		    $result['middleware'] = $middleware;
-		}
-
-
-
         return $result;
-    }
-
-    /**
-     * Get middleware
-     *
-     * @param  \Illuminate\Routing\Route $route
-     * @return string
-     */
-    protected function getMiddleware($route)
-    {
-        $middleware = array_keys($route->middleware());
-
-        return implode(', ', $middleware);
     }
 
     /**


### PR DESCRIPTION
If you assign multiple middlewares to a route, the DebugBar shows the indexes of middlewares, not names.

No need for `getMiddleware()` method to check if route has multiple middlewares, since `\Illuminate\Routing\Route@getAction()` method does it for us.

![route](https://cloud.githubusercontent.com/assets/11529470/18130628/6d210b62-6f98-11e6-9b09-e6dfecbd655b.png)
