### PR TITLE
Fixed bug: wrong substitution of placeholders in QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -100,7 +100,12 @@ class QueryCollector extends PDOCollector
         $bindings = $this->checkBindings($bindings);
         if (!empty($bindings) && $this->renderSqlWithParams) {
             foreach ($bindings as $key => $binding) {
-                $regex = is_numeric($key) ? '/\?/' : "/:{$key}/";
+                // This regex matches placeholders only, not the question marks,
+                // nested in quotes, while we iterate through the bindings
+                // and substitute placeholders by suitable values.
+                $regex = is_numeric($key)
+                    ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
+                    : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
                 $query = preg_replace($regex, $pdo->quote($binding), $query, 1);
             }
         }


### PR DESCRIPTION
Hi.

I found a bug of displaying the collected queries on "Queries" tab. The problem is that addQuery method (in Barryvdh\Debugbar\DataCollector\QueryCollector class) while is it iterating through the bindings array uses wrong regex, that replaces _any_ question mark (placeholder) in the query string by the binded value, even this question mark is nested in quotes, of previously replaced placeholders. As the users may pass string containing '?' sign as where parameter of query this will result as a wrong output.

The dummy query to demonstrate the problem:

`DB::table('users')->select('*')->where('name', 'first?')->where('name', 'second?')->where('id', 42)->get();`

Will result a buggy output, with unfilled placeholders on the tail:

`select * from "users" where "name" = 'first'second'42''' and "name" = ? and "id" = ?`

I had rewrite the regex to detect only _real_ placeholders in the query. Changes are in this pull request.

The following is an other dummy query to test the new regex in a lot of different cases. Tested both on PostgreSQL and MySQL.

DB::table('users')->select('*')
    ->where('name', '?') // TEST01
    ->where('name', 'TEST02: string with question mark? ...passed!')
    ->where('name', 'TEST03: string? with? multiple? question? marks??? ...passed!')
    ->where('name', "TEST04: one ' single quote and question mark? ...passed!")
    ->where('name', 'TEST05: one " double quote and question mark? ...passed!')
    ->where('name', 'TEST06: one escaped \' single quote and question mark? ...passed!')
    ->where('name', "TEST07: one escaped \" double quote and question mark? ...passed!")
    ->where('name', "TEST08: two '' single quotes and question mark? ...passed!")
    ->where('name', 'TEST09: two "" double quotes and question mark? ...passed!')
    ->where('name', "TEST10: question mark nested in 'single quotes?' ...passed!")
    ->where('name', 'TEST11: question mark nested in "double quotes?" ...passed!')
    ->where('name', "TEST12: question mark nested in `backticks (mysql) quotes?` ...passed!")
    ->where('name', 'TEST13: question mark nested in \'escaped single quotes?\' ...passed!')
    ->where('name', "TEST14: question mark nested in \"double quotes?\" ...passed!")
    ->where('name', "TEST15: question mark nested in \`escaped backticks (mysql) quotes?\` ...passed!")
    ->where('id', 1)
    ->get();

Hint: success if placeholder for last ('id') param is correctly replaced by it's binded value.

Hope this improvement will be helpful! ;)

P.S.
This is my first public pull request on Github. 