### PR TITLE
Add optional request header to disable debugbar response injection

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -157,6 +157,19 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | No Debugbar Injection Header
+     |--------------------------------------------------------------------------
+     |
+     | Specify an optional header you can add to individual requests to disable
+     | debugbar data collection and response injection.  This is useful when you
+     | have a certain request that must be unaltered.
+     |
+     */
+
+    'no_injection_header' => 'X-NO-DEBUGBAR',
+
+    /*
+     |--------------------------------------------------------------------------
      | DebugBar route prefix
      |--------------------------------------------------------------------------
      |

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -474,7 +474,7 @@ class LaravelDebugbar extends DebugBar
     public function modifyResponse(Request $request, Response $response)
     {
         $app = $this->app;
-        if ($app->runningInConsole() || !$this->isEnabled() || $this->isDebugbarRequest()) {
+        if ($app->runningInConsole() || !$this->isEnabled() || $this->isDebugbarRequest() || $request->header($app['config']->get('debugbar.no_injection_header') )) {
             return $response;
         }
 


### PR DESCRIPTION
This adds an optional header that you can add to your request to disable the debugbar data collection/response injection.  I looked through the code and could not find anything obvious to do this.

I experienced the initial issue with running the [Node Laravel Echo Server](https://github.com/tlaverdure/laravel-echo-server).  When joining a private channel, it sends an HTTP request to the broadcasting auth endpoints, which in turn replies "true" if the user can join the channel.  However, in a development environment with response injection enabled, the debugbar injection happens and the echo server is unable to parse the reply (it's expecting JSON) correctly.  Having a way to disable the injection with this request would remediate this issue.

I hope this is useful and if something is obviously wrong, any pointers would be great.  This is my #1 pull request on an open source project!