### PR TITLE
Fix comment for "inject" location

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -147,7 +147,7 @@ return [
      | Inject Debugbar in Response
      |--------------------------------------------------------------------------
      |
-     | Usually, the debugbar is added just before <body>, by listening to the
+     | Usually, the debugbar is added just before </body>, by listening to the
      | Response after the App is done. If you disable this, you have to add them
      | in your template yourself. See http://phpdebugbar.com/docs/rendering.html
      |


### PR DESCRIPTION
I was reading comments in debugbar config. It has to be `</body>` or I misunderstood something?