### PR TITLE
service provider route from boot to register

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,32 +48,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             }
         );
 
-        $this->commands(['command.debugbar.clear']);
-    }
-
-    /**
-     * Bootstrap the application events.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $app = $this->app;
-
-        $configPath = __DIR__ . '/../config/debugbar.php';
-        $this->publishes([$configPath => $this->getConfigPath()], 'config');
-
-        // If enabled is null, set from the app.debug value
-        $enabled = $this->app['config']->get('debugbar.enabled');
-
-        if (is_null($enabled)) {
-            $enabled = $this->checkAppDebug();
-        }
-
-        if (! $enabled) {
-            return;
-        }
-
         $routeConfig = [
             'namespace' => 'Barryvdh\Debugbar\Controllers',
             'prefix' => $this->app['config']->get('debugbar.route_prefix'),
@@ -100,6 +74,34 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 'as' => 'debugbar.assets.js',
             ]);
         });
+
+        $this->commands(['command.debugbar.clear']);
+    }
+
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $app = $this->app;
+
+        $configPath = __DIR__ . '/../config/debugbar.php';
+        $this->publishes([$configPath => $this->getConfigPath()], 'config');
+
+        // If enabled is null, set from the app.debug value
+        $enabled = $this->app['config']->get('debugbar.enabled');
+
+        if (is_null($enabled)) {
+            $enabled = $this->checkAppDebug();
+        }
+
+        if (! $enabled) {
+            return;
+        }
+
+
 
         if ($app->runningInConsole() || $app->environment('testing')) {
             return;


### PR DESCRIPTION
Hi, 

I have move the route in the service provider from the boot method to the register method. 

In Laravel the boot method occur at the end of everything. 

The process is register everything and boot . So by adding your route in the boot, we can't tweak the precedence of register with the package by registring in order. 

SO , actually we have the problem. Can you validate en merge. 