### PR TITLE
css/js loaded at any protocol case

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -43,7 +43,10 @@ class JavascriptRenderer extends BaseJavascriptRenderer
 
         $jsRoute = route('debugbar.assets.js', [
             'v' => $this->getModifiedTime('js')
-       ]);
+        ]);
+
+        $cssRoute = preg_replace('/\Ahttps?:/', '', $cssRoute);
+        $jsRoute  = preg_replace('/\Ahttps?:/', '', $jsRoute);
 
         $html  = "<link rel='stylesheet' type='text/css' property='stylesheet' href='{$cssRoute}'>";
         $html .= "<script type='text/javascript' src='{$jsRoute}'></script>";


### PR DESCRIPTION
Debugbar doesn't working in under the HTTPS-HTTP reverse-proxy.

For example,

```
HTTPS (AWS ELB) ->HTTP (Laravel)
```

In this case,  browser blocked debugbar's css and js on different protocol between https and http.
So, remove protocol prefix at loading css and js, it will success to load these assets.

