### PR TITLE
Option to use debugbar with content-security-policy headers

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -144,6 +144,17 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Content security policy compatible
+     |--------------------------------------------------------------------------
+     |
+     | If you have set a content security policy in your header you need to set
+     | this variable to true. You need to add "img-src:'self' data:" to your
+     | csp header. Note: Storage needs to be enabled for this to work.
+     |
+     */
+    'csp-compatible' => false,
+    /*
+     |--------------------------------------------------------------------------
      | Inject Debugbar in Response
      |--------------------------------------------------------------------------
      |

--- a/src/Controllers/AssetController.php
+++ b/src/Controllers/AssetController.php
@@ -44,6 +44,17 @@ class AssetController extends BaseController
         return $this->cacheResponse($response);
     }
 
+    public function init()
+    {
+        $renderer = $this->debugbar->getJavascriptRenderer();
+        $content = $renderer->renderInitScript();
+        $response = new Response(
+            $content, 200, [
+                'Content-Type' => 'text/javascript',
+            ]
+        );
+        return $this->cacheResponse($response);
+    }
     /**
      * Cache the response 1 year (31536000 sec)
      */

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -51,11 +51,16 @@ class JavascriptRenderer extends BaseJavascriptRenderer
         $html  = "<link rel='stylesheet' type='text/css' property='stylesheet' href='{$cssRoute}'>";
         $html .= "<script type='text/javascript' src='{$jsRoute}'></script>";
 
+        return $html;
+    }
+    protected function getJsInitializationCode()
+    {
+        $js = '';
         if ($this->isJqueryNoConflictEnabled()) {
-            $html .= '<script type="text/javascript">jQuery.noConflict(true);</script>' . "\n";
+            $js .= 'jQuery.noConflict(true);' . "\n";
         }
 
-        return $html;
+        return $js . parent::getJsInitializationCode();
     }
 
     /**
@@ -96,6 +101,24 @@ class JavascriptRenderer extends BaseJavascriptRenderer
         return $content;
     }
 
+    /**
+     * Return the init script as a string
+     *
+     * @return string
+     */
+    public function renderInitScript()
+    {
+        $openHandlerUrl = route('debugbar.openhandler');
+        $this->setOpenHandlerUrl($openHandlerUrl);
+        $content = $this->getJsInitializationCode();
+        $content .= sprintf(
+            "%s.loadDataSet($(\"span[data-debugbar-id]\").attr(\"data-debugbar-id\"), \"(ajax)\");\n",
+            $this->variableName,
+            $this->openHandlerClass,
+            json_encode(array("url" => $this->openHandlerUrl))
+        );
+        return $content;
+    }
     /**
      * Makes a URI relative to another
      *

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -591,7 +591,7 @@ class LaravelDebugbar extends DebugBar
             } catch (\Exception $e) {
                 $app['log']->error('Debugbar exception: ' . $e->getMessage());
             }
-        } elseif ($app['config']->get('debugbar.inject', true) && $app['config']->get('debugbar.csp-compatible', true)) {
+        } elseif ($app['config']->get('debugbar.inject', true) && $app['config']->get('debugbar.csp-compatible', false)) {
             try {
                 $this->injectDebugbarCSP($response);
             } catch (\Exception $e) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -591,6 +591,12 @@ class LaravelDebugbar extends DebugBar
             } catch (\Exception $e) {
                 $app['log']->error('Debugbar exception: ' . $e->getMessage());
             }
+        } elseif ($app['config']->get('debugbar.inject', true) && $app['config']->get('debugbar.csp-compatible', true)) {
+            try {
+                $this->injectDebugbarCSP($response);
+            } catch (\Exception $e) {
+                $app['log']->error('Debugbar exception: ' . $e->getMessage());
+            }
         } elseif ($app['config']->get('debugbar.inject', true)) {
             try {
                 $this->injectDebugbar($response);
@@ -713,6 +719,43 @@ class LaravelDebugbar extends DebugBar
         $response->headers->remove('Content-Length');
     }
 
+    public function injectDebugbarCSP(Response $response)
+    {
+        if (!$this->app['config']->get('debugbar.storage.enabled')) {
+            throw new \Exception('Store needs to be enabled for content security policy');
+        }
+        //collect and store data
+        $this->collect();
+
+        $content = $response->getContent();
+
+        $renderer = $this->getJavascriptRenderer();
+        if ($this->getStorage()) {
+            $openHandlerUrl = route('debugbar.openhandler');
+            $renderer->setOpenHandlerUrl($openHandlerUrl);
+        }
+
+        $initRoute = route('debugbar.assets.init', [
+            'v' => filemtime(config_path('debugbar.php'))
+        ]);
+	
+	$initRoute = preg_replace('/\Ahttps?:/', '', $initRoute);
+	
+        $scriptContent = $renderer->renderHead() .
+            "<span data-debugbar-id='{$this->getCurrentRequestId()}'></span> 
+            <script type='text/javascript' src='{$initRoute}'></script>";
+
+        $pos = strripos($content, '</body>');
+        if (false !== $pos) {
+            $content = substr($content, 0, $pos) . $scriptContent . substr($content, $pos);
+        } else {
+            $content = $content . $scriptContent;
+        }
+
+        // Update the new content and reset the content length
+        $response->setContent($content);
+        $response->headers->remove('Content-Length');
+    }
     /**
      * Disable the Debugbar
      */

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -99,6 +99,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 'uses' => 'AssetController@js',
                 'as' => 'debugbar.assets.js',
             ]);
+            $router->get('assets/init', [
+                'uses' => 'AssetController@init',
+                'as' => 'debugbar.assets.init',
+            ]);
         });
 
         if ($app->runningInConsole() || $app->environment('testing')) {


### PR DESCRIPTION
The debug bar wasn’t compatible with a content security policy that doesn't allow inline-script.
I made it possible to load the init script through a route and made use of the option to load the data with an ajax request. 

You need to add "img-src:'self' data:" to your content security policy header and storage needs to be enabled.

The lines for ‘jQuery.noConflict(true); ’ are moved to the getJsInitializationCode because those needs to be at the scripts file. All other changes are new lines.
