### PR TITLE
add error handing in "clear" command to ignore exceptions about storage locations that do exist

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -19,9 +19,17 @@ class ClearCommand extends Command
     public function fire()
     {
         $this->debugbar->boot();
-        
+
         if ($storage = $this->debugbar->getStorage()) {
-            $storage->clear();
+            try
+            {
+                $storage->clear();
+            } catch(\InvalidArgumentException $e) {
+                // hide InvalidArgumentException if storage location does not exist
+                if(strpos($e->getMessage(), 'does not exist') === false) {
+                    throw $e;
+                }
+            }
             $this->info('Debugbar Storage cleared!');
         } else {
             $this->error('No Debugbar Storage found..');


### PR DESCRIPTION
add error handing in "clear" command to ignore exceptions about storage locations that do exist

This prevents the Laravel command from erroring when storage does not exist and the debugbar:clear command is run.