### PR TITLE
Update for 5.4

### DIFF
--- a/src/DataCollector/SessionCollector.php
+++ b/src/DataCollector/SessionCollector.php
@@ -8,13 +8,13 @@ use DebugBar\DataCollector\Renderable;
 
 class SessionCollector extends DataCollector implements DataCollectorInterface, Renderable
 {
-    /** @var  \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
+    /** @var  \Symfony\Component\HttpFoundation\Session\SessionInterface|\Illuminate\Contracts\Session\Session $session */
     protected $session;
 
     /**
      * Create a new SessionCollector
      *
-     * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
+     * @param \Symfony\Component\HttpFoundation\Session\SessionInterface|\Illuminate\Contracts\Session\Session $session
      */
     public function __construct($session)
     {

--- a/src/SymfonyHttpDriver.php
+++ b/src/SymfonyHttpDriver.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
  */
 class SymfonyHttpDriver implements HttpDriverInterface
 {
-    /** @var \Symfony\Component\HttpFoundation\Session\Session */
+    /** @var \Symfony\Component\HttpFoundation\Session\Session|\Illuminate\Contracts\Session\Session */
     protected $session;
     /** @var \Symfony\Component\HttpFoundation\Response */
     protected $response;
@@ -48,6 +48,13 @@ class SymfonyHttpDriver implements HttpDriverInterface
      */
     public function setSessionValue($name, $value)
     {
+        // In Laravel 5.4 the session changed to use their own custom implementation
+        // instead of the one from Symfony. One of the changes was the set method
+        // that was changed to put. Here we check if we are using the new one.
+        if ($this->session instanceof \Illuminate\Contracts\Session\Session) {
+            $this->session->put($name, $value);
+            return;
+        }
         $this->session->set($name, $value);
     }
 


### PR DESCRIPTION
There might be more already, and there might come more in the future.
But this seems to at least fix the breaking changes that prevents the application to boot when you install the DebugBar in a new Laravel 5.4 installation.

Commits with breaking changes that affected this package: (that I know of)
Log: https://github.com/laravel/framework/commit/57c82d095c356a0fe0f9381536afec768cdcc072?diff=split
Session: https://github.com/laravel/framework/commit/66976ba3f559ee6ede4cc865ea995996cd42ee1b?diff=split