### PR TITLE
[5.4] The HttpDriver gets a SessionManager instead of Session\Store, so instanceof check didn't work

### DIFF
--- a/src/SymfonyHttpDriver.php
+++ b/src/SymfonyHttpDriver.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
  */
 class SymfonyHttpDriver implements HttpDriverInterface
 {
-    /** @var \Symfony\Component\HttpFoundation\Session\Session|\Illuminate\Contracts\Session\Session */
+    /** @var \Symfony\Component\HttpFoundation\Session\Session|\Illuminate\Contracts\Session\Session|\Illuminate\Session\SessionManager */
     protected $session;
     /** @var \Symfony\Component\HttpFoundation\Response */
     protected $response;
@@ -51,7 +51,7 @@ class SymfonyHttpDriver implements HttpDriverInterface
         // In Laravel 5.4 the session changed to use their own custom implementation
         // instead of the one from Symfony. One of the changes was the set method
         // that was changed to put. Here we check if we are using the new one.
-        if ($this->session instanceof \Illuminate\Contracts\Session\Session) {
+        if (method_exists($this->session, 'driver') && $this->session->driver() instanceof \Illuminate\Contracts\Session\Session) {
             $this->session->put($name, $value);
             return;
         }


### PR DESCRIPTION
Fix for the error mentioned #583.
I can't really figure out why it worked for me before, looking at this now.
But the SymfonyHttpDriver is receiving a SessionManager and not directly the object implementing the new Session interface.
Not sure if this is the best or will work for all cases, but it's a start.