### PR TITLE
[L5.4] Fix views tab

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -198,8 +198,11 @@ class LaravelDebugbar extends DebugBar
                 $this->addCollector(new ViewCollector($collectData));
                 $this->app['events']->listen(
                     'composing:*',
-                    function ($name, $view) use ($debugbar) {
-                        $debugbar['views']->addView($view[0]);
+                    function ($view, $data = []) use ($debugbar) {
+                        if ($data) {
+                            $view = $data[0]; // For Laravel >= 5.4
+                        }
+                        $debugbar['views']->addView($view);
                     }
                 );
             } catch (\Exception $e) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -198,8 +198,8 @@ class LaravelDebugbar extends DebugBar
                 $this->addCollector(new ViewCollector($collectData));
                 $this->app['events']->listen(
                     'composing:*',
-                    function ($view) use ($debugbar) {
-                        $debugbar['views']->addView($view);
+                    function ($name, $view) use ($debugbar) {
+                        $debugbar['views']->addView($view[0]);
                     }
                 );
             } catch (\Exception $e) {


### PR DESCRIPTION
```
FatalThrowableError in ViewCollector.php line 53:
Type error: Argument 1 passed to Barryvdh\Debugbar\DataCollector\ViewCollector::addView() must be an instance of Illuminate\View\View, string given, called in /data/mld/prod/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php on line 202
```

You should bump the version of the package as it is probably a breaking change and won't work for 5.3.