### PR TITLE
Fix route middlewares list

### DIFF
--- a/src/DataCollector/IlluminateRouteCollector.php
+++ b/src/DataCollector/IlluminateRouteCollector.php
@@ -91,9 +91,7 @@ class IlluminateRouteCollector extends DataCollector implements Renderable
      */
     protected function getMiddleware($route)
     {
-        $middleware = array_keys($route->middleware());
-
-        return implode(', ', $middleware);
+        return implode(', ', $route->middleware());
     }
 
     /**


### PR DESCRIPTION
The route middlewares list (Route tab) is broken due to an useless call to `array_keys`, no idea why it was here in the first place, maybe legacy code?

Before: `middleware: 0, 1`
After: `middleware: web, auth`

Tested on Laravel 5.3 and 5.4.