### PR TITLE
Fix RedisStorage for Laravel 5.4

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -878,7 +878,11 @@ class LaravelDebugbar extends DebugBar
                     break;
                 case 'redis':
                     $connection = $config->get('debugbar.storage.connection');
-                    $storage = new RedisStorage($this->app['redis']->connection($connection));
+                    $client = $this->app['redis']->connection($connection);
+                    if (is_a($client, 'Illuminate\Redis\Connections\PredisConnection', false)) {
+                        $client = $client->client();
+                    }
+                    $storage = new RedisStorage($client);
                     break;
                 case 'custom':
                     $class = $config->get('debugbar.storage.provider');


### PR DESCRIPTION
In Laravel 5.4, `$this->app['redis']->connection($connection)` now returns an `Illuminate\Redis\Connections\PredisConnection` instead of the `Predis\Client` that `RedisStorage` is expecting.

This commit checks to see if a `PredisConnection` was returned from the service container instead of a `Predis\Client`, and if so gets the client from the connection to pass to `RedisStorage`.