### PR TITLE
Improve the queries tab

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataFormatter;
+
+use DebugBar\DataFormatter\DataFormatter;
+
+class QueryFormatter extends DataFormatter
+{
+
+    /**
+     * Removes extra spaces at the beginning and end of the SQL query and its lines.
+     *
+     * @param string $sql
+     * @return string
+     */
+    public function formatSql($sql)
+    {
+        return trim(preg_replace("/\s*\n\s*/", "\n", $sql));
+    }
+
+    /**
+     * Check bindings for illegal (non UTF-8) strings, like Binary data.
+     *
+     * @param $bindings
+     * @return mixed
+     */
+    public function checkBindings($bindings)
+    {
+        foreach ($bindings as &$binding) {
+            if (is_string($binding) && !mb_check_encoding($binding, 'UTF-8')) {
+                $binding = '[BINARY DATA]';
+            }
+        }
+        return $bindings;
+    }
+
+    /**
+     * Make the bindings safe for outputting.
+     *
+     * @param array $bindings
+     * @return array
+     */
+    public function escapeBindings($bindings)
+    {
+        foreach ($bindings as &$binding) {
+            $binding = htmlentities($binding, ENT_QUOTES, 'UTF-8', false);
+        }
+        return $bindings;
+    }
+
+    /**
+     * Format query bindings into an ordered list.
+     *
+     * @param  array  $bindings
+     * @return string
+     */
+    public function formatBindings(array $bindings)
+    {
+        $bindings = array_map(function ($binding, $index) {
+            return '<span class="phpdebugbar-text-muted">' . $index . '.</span> ' . $binding;
+        }, $bindings, array_keys($bindings));
+
+        return $this->formatList($bindings);
+    }
+
+    /**
+     * Format the hints into an list.
+     *
+     * @param  array  $hints
+     * @return string
+     */
+    public function formatHints(array $hints)
+    {
+        return $this->formatList($hints);
+    }
+
+    /**
+     * Format the backtrace sources into an ordered list.
+     *
+     * @param  array  $sources
+     * @return string
+     */
+    public function formatSources(array $sources)
+    {
+        $items = [];
+
+        foreach ($sources as $source) {
+            $parts = [
+                'index' => '<span class="phpdebugbar-text-muted">' . $source->index . '.</span>&nbsp;',
+            ];
+
+            if ($source->namespace) {
+                $parts['namespace'] = $source->namespace . '::';
+            }
+
+            $parts['name'] = $source->name;
+            $parts['line'] = '<span class="phpdebugbar-text-muted">:' . $source->line . '</span>';
+
+            $items[] = implode($parts);
+        }
+
+        return $this->formatList($items);
+    }
+
+    /**
+     * Format a source object.
+     *
+     * @param  object|null  $source  If the backtrace is disabled, the $source will be null.
+     * @return string
+     */
+    public function formatSource($source)
+    {
+        if (! is_object($source)) {
+            return '';
+        }
+
+        $parts = [];
+
+        if ($source->namespace) {
+            $parts['namespace'] = $source->namespace . '::';
+        }
+
+        $parts['name'] = $source->name;
+        $parts['line'] = ':' . $source->line;
+
+        return implode($parts);
+    }
+
+    /**
+     * Generate an array with metadata about the query.
+     *
+     * @param  array  $query
+     * @return object
+     */
+    public function formatMetadata(array $query)
+    {
+        $metadata = (object) [];
+
+        if ($query['bindings']) {
+            $metadata = $this->addMetadata(
+                $metadata, 'bindings', $this->formatBindings($query['bindings'])
+            );
+        }
+
+        if ($query['hints']) {
+            $metadata = $this->addMetadata(
+                $metadata, 'hints', $this->formatHints($query['hints'])
+            );
+        }
+
+        if ($query['source']) {
+            $metadata = $this->addMetadata(
+                $metadata, 'backtrace', $this->formatSources($query['source'])
+            );
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Append an item to the metadata.
+     *
+     * @param  object $metadata
+     * @param  string $name
+     * @param  string $parameter
+     * @return object
+     */
+    public function addMetadata($metadata, $name, $parameter)
+    {
+        $icons = [
+            'bindings' => 'thumb-tack',
+            'hints' => 'question-circle',
+            'backtrace' => 'list-ul',
+        ];
+
+        $icon = isset($icons[$name]) ? $icons[$name] : 'circle';
+
+        $key = ucfirst($name) . ' <i class="phpdebugbar-fa phpdebugbar-fa-' . $icon . ' phpdebugbar-text-muted"></i>';
+
+        $metadata->$key = $parameter;
+
+        return $metadata;
+    }
+
+    /**
+     * Format an array into a list.
+     *
+     * @param  array  $items
+     * @return string
+     */
+    protected function formatList(array $items)
+    {
+        $list = [];
+
+        foreach ($items as $item) {
+            $list[] = '<li class="phpdebugbar-widgets-table-list-item">' . $item . '</li>';
+        }
+
+        return '<ul class="phpdebugbar-widgets-table-list">' . implode($list) . '</ul>';
+    }
+}

--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -10,7 +10,7 @@ class QueryFormatter extends DataFormatter
     /**
      * Removes extra spaces at the beginning and end of the SQL query and its lines.
      *
-     * @param string $sql
+     * @param  string $sql
      * @return string
      */
     public function formatSql($sql)
@@ -31,6 +31,7 @@ class QueryFormatter extends DataFormatter
                 $binding = '[BINARY DATA]';
             }
         }
+
         return $bindings;
     }
 
@@ -45,61 +46,8 @@ class QueryFormatter extends DataFormatter
         foreach ($bindings as &$binding) {
             $binding = htmlentities($binding, ENT_QUOTES, 'UTF-8', false);
         }
+
         return $bindings;
-    }
-
-    /**
-     * Format query bindings into an ordered list.
-     *
-     * @param  array  $bindings
-     * @return string
-     */
-    public function formatBindings(array $bindings)
-    {
-        $bindings = array_map(function ($binding, $index) {
-            return '<span class="phpdebugbar-text-muted">' . $index . '.</span> ' . $binding;
-        }, $bindings, array_keys($bindings));
-
-        return $this->formatList($bindings);
-    }
-
-    /**
-     * Format the hints into an list.
-     *
-     * @param  array  $hints
-     * @return string
-     */
-    public function formatHints(array $hints)
-    {
-        return $this->formatList($hints);
-    }
-
-    /**
-     * Format the backtrace sources into an ordered list.
-     *
-     * @param  array  $sources
-     * @return string
-     */
-    public function formatSources(array $sources)
-    {
-        $items = [];
-
-        foreach ($sources as $source) {
-            $parts = [
-                'index' => '<span class="phpdebugbar-text-muted">' . $source->index . '.</span>&nbsp;',
-            ];
-
-            if ($source->namespace) {
-                $parts['namespace'] = $source->namespace . '::';
-            }
-
-            $parts['name'] = $source->name;
-            $parts['line'] = '<span class="phpdebugbar-text-muted">:' . $source->line . '</span>';
-
-            $items[] = implode($parts);
-        }
-
-        return $this->formatList($items);
     }
 
     /**
@@ -124,78 +72,5 @@ class QueryFormatter extends DataFormatter
         $parts['line'] = ':' . $source->line;
 
         return implode($parts);
-    }
-
-    /**
-     * Generate an array with metadata about the query.
-     *
-     * @param  array  $query
-     * @return object
-     */
-    public function formatMetadata(array $query)
-    {
-        $metadata = (object) [];
-
-        if ($query['bindings']) {
-            $metadata = $this->addMetadata(
-                $metadata, 'bindings', $this->formatBindings($query['bindings'])
-            );
-        }
-
-        if ($query['hints']) {
-            $metadata = $this->addMetadata(
-                $metadata, 'hints', $this->formatHints($query['hints'])
-            );
-        }
-
-        if ($query['source']) {
-            $metadata = $this->addMetadata(
-                $metadata, 'backtrace', $this->formatSources($query['source'])
-            );
-        }
-
-        return $metadata;
-    }
-
-    /**
-     * Append an item to the metadata.
-     *
-     * @param  object $metadata
-     * @param  string $name
-     * @param  string $parameter
-     * @return object
-     */
-    public function addMetadata($metadata, $name, $parameter)
-    {
-        $icons = [
-            'bindings' => 'thumb-tack',
-            'hints' => 'question-circle',
-            'backtrace' => 'list-ul',
-        ];
-
-        $icon = isset($icons[$name]) ? $icons[$name] : 'circle';
-
-        $key = ucfirst($name) . ' <i class="phpdebugbar-fa phpdebugbar-fa-' . $icon . ' phpdebugbar-text-muted"></i>';
-
-        $metadata->$key = $parameter;
-
-        return $metadata;
-    }
-
-    /**
-     * Format an array into a list.
-     *
-     * @param  array  $items
-     * @return string
-     */
-    protected function formatList(array $items)
-    {
-        $list = [];
-
-        foreach ($items as $item) {
-            $list[] = '<li class="phpdebugbar-widgets-table-list-item">' . $item . '</li>';
-        }
-
-        return '<ul class="phpdebugbar-widgets-table-list">' . implode($list) . '</ul>';
     }
 }

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -19,6 +19,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
 
         $this->cssFiles['laravel'] = __DIR__ . '/Resources/laravel-debugbar.css';
         $this->cssVendors['fontawesome'] = __DIR__ . '/Resources/vendor/font-awesome/style.css';
+        $this->jsFiles['laravel-sql'] = __DIR__ . '/Resources/sqlqueries/widget.js';
     }
 
     /**

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -22,6 +22,7 @@ use DebugBar\DataCollector\MessagesCollector;
 use DebugBar\DataCollector\PhpInfoCollector;
 use DebugBar\DataCollector\RequestDataCollector;
 use DebugBar\DataCollector\TimeDataCollector;
+use Barryvdh\Debugbar\DataFormatter\QueryFormatter;
 use Barryvdh\Debugbar\Support\Clockwork\ClockworkCollector;
 use DebugBar\DebugBar;
 use DebugBar\Storage\PdoStorage;
@@ -286,12 +287,15 @@ class LaravelDebugbar extends DebugBar
             }
             $queryCollector = new QueryCollector($timeCollector);
 
+            $queryCollector->setDataFormatter(new QueryFormatter());
+
             if ($this->app['config']->get('debugbar.options.db.with_params')) {
                 $queryCollector->setRenderSqlWithParams(true);
             }
 
             if ($this->app['config']->get('debugbar.options.db.backtrace')) {
-                $queryCollector->setFindSource(true);
+                $middleware = $this->app['router']->getMiddleware();
+                $queryCollector->setFindSource(true, $middleware);
             }
 
             if ($this->app['config']->get('debugbar.options.db.explain.enabled')) {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -200,25 +200,36 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
     font-family: inherit;
     overflow: visible;
     display: flex;
+    flex-wrap: wrap;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql {
-    flex: 1 1 auto;
+    flex: 1;
+    margin-right: 5px;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration {
-    flex: 0 0 auto;
+    /*flex: 0 0 auto;*/
+    margin-left: auto;
+    margin-right: 5px;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-database {
-    flex: 0 0 auto;
+    /*flex: 0 0 auto;*/
+    margin-left: auto;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-stmt-id {
+    /*flex: 0 0 auto;*/
+    margin-left: auto;
+    margin-right: 5px;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-params {
+    background-color: rgba(255, 255, 255, .5);
     flex: 1 1 auto;
-    order: -1;
-    width: auto;
-    max-width: 200px;
+    margin: 10px 100% 10px 0;
+    max-width: 100%;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:nth-child(even) {
@@ -243,8 +254,39 @@ div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugb
     color: #f1c40f;
 }
 
+div.phpdebugbar-widgets-sqlqueries {
+    line-height: 20px;
+}
+
 div.phpdebugbar-widgets-sqlqueries .phpdebugbar-widgets-status {
     background: none !important;
     font-family: inherit !important;
     font-weight: 400 !important;
+}
+
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params th,
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td {
+    padding: 5px 10px;
+}
+
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td.phpdebugbar-widgets-name {
+    text-align: right;
+    vertical-align: top;
+    white-space: nowrap;
+}
+
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td.phpdebugbar-widgets-value {
+    text-align: left;
+}
+
+ul.phpdebugbar-widgets-list ul.phpdebugbar-widgets-table-list {
+    text-align: left;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-table-list-item {
+    /*padding: 5px 10px;*/
+}
+
+.phpdebugbar-text-muted {
+    color: #888;
 }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -203,6 +203,10 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
     flex-wrap: wrap;
 }
 
+.phpdebugbar-widgets-sql.phpdebugbar-widgets-name {
+    font-weight: bold;
+}
+
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql {
     flex: 1;
     margin-right: 5px;

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -1,0 +1,225 @@
+(function($) {
+
+    var csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
+
+    /**
+     * Widget for the displaying sql queries
+     *
+     * Options:
+     *  - data
+     */
+    var LaravelSQLQueriesWidget = PhpDebugBar.Widgets.LaravelSQLQueriesWidget = PhpDebugBar.Widget.extend({
+
+        className: csscls('sqlqueries'),
+
+        onFilterClick: function(el) {
+            $(el).toggleClass(csscls('excluded'));
+
+            var excludedLabels = [];
+            this.$toolbar.find(csscls('.filter') + csscls('.excluded')).each(function() {
+                excludedLabels.push(this.rel);
+            });
+
+            this.$list.$el.find("li[connection=" + $(el).attr("rel") + "]").toggle();
+
+            this.set('exclude', excludedLabels);
+        },
+
+        render: function() {
+            this.$status = $('<div />').addClass(csscls('status')).appendTo(this.$el);
+
+            this.$toolbar = $('<div></div>').addClass(csscls('toolbar')).appendTo(this.$el);
+
+            var filters = [], self = this;
+
+            this.$list = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, stmt) {
+                if (stmt.type === 'transaction') {
+                    $('<strong />').addClass(csscls('sql')).addClass(csscls('name')).text(stmt.sql).appendTo(li);
+                } else {
+                    $('<code />').addClass(csscls('sql')).html(PhpDebugBar.Widgets.highlight(stmt.sql, 'sql')).appendTo(li);
+                }
+                if (stmt.duration_str) {
+                    $('<span title="Duration" />').addClass(csscls('duration')).text(stmt.duration_str).appendTo(li);
+                }
+                if (stmt.memory_str) {
+                    $('<span title="Memory usage" />').addClass(csscls('memory')).text(stmt.memory_str).appendTo(li);
+                }
+                if (typeof(stmt.row_count) != 'undefined') {
+                    $('<span title="Row count" />').addClass(csscls('row-count')).text(stmt.row_count).appendTo(li);
+                }
+                if (typeof(stmt.stmt_id) != 'undefined' && stmt.stmt_id) {
+                    $('<span title="Prepared statement ID" />').addClass(csscls('stmt-id')).text(stmt.stmt_id).appendTo(li);
+                }
+                if (stmt.connection) {
+                    $('<span title="Connection" />').addClass(csscls('database')).text(stmt.connection).appendTo(li);
+                    li.attr("connection",stmt.connection);
+                    if ( $.inArray(stmt.connection, filters) == -1 ) {
+                        filters.push(stmt.connection);
+                        $('<a />')
+                            .addClass(csscls('filter'))
+                            .text(stmt.connection)
+                            .attr('rel', stmt.connection)
+                            .on('click', function() { self.onFilterClick(this); })
+                            .appendTo(self.$toolbar);
+                        if (filters.length>1) {
+                            self.$toolbar.show();
+                            self.$list.$el.css("margin-bottom","20px");
+                        }
+                    }
+                }
+                if (typeof(stmt.is_success) != 'undefined' && !stmt.is_success) {
+                    li.addClass(csscls('error'));
+                    li.append($('<span />').addClass(csscls('error')).text("[" + stmt.error_code + "] " + stmt.error_message));
+                }
+
+                var table = $('<table><tr><th colspan="2">Metadata</th></tr></table>').addClass(csscls('params')).appendTo(li);
+
+                if (stmt.bindings && stmt.bindings.length) {
+                    table.append(function () {
+                        var icon = 'thumb-tack';
+                        var $icon = '<i class="phpdebugbar-fa phpdebugbar-fa-' + icon + ' phpdebugbar-text-muted"></i>';
+                        var $name = $('<td />').addClass(csscls('name')).html('Bindings ' + $icon);
+                        var $value = $('<td />').addClass(csscls('value'));
+                        var $span = $('<span />').addClass('phpdebugbar-text-muted');
+
+                        var index = 0;
+                        var $bindings = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, binding) {
+                            var $index = $span.clone().text(index++ + '.');
+                            li.append($index, '&nbsp;', binding).removeClass(csscls('list-item')).addClass(csscls('table-list-item'));
+                        }});
+
+                        $bindings.set('data', stmt.bindings);
+
+                        $bindings.$el
+                            .removeClass(csscls('list'))
+                            .addClass(csscls('table-list'))
+                            .appendTo($value);
+
+                        return $('<tr />').append($name, $value);
+                    });
+                }
+
+                if (stmt.hints && stmt.hints.length) {
+                    table.append(function () {
+                        var icon = 'question-circle';
+                        var $icon = '<i class="phpdebugbar-fa phpdebugbar-fa-' + icon + ' phpdebugbar-text-muted"></i>';
+                        var $name = $('<td />').addClass(csscls('name')).html('Hints ' + $icon);
+                        var $value = $('<td />').addClass(csscls('value'));
+
+                        var $hints = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, hint) {
+                            li.append(hint).removeClass(csscls('list-item')).addClass(csscls('table-list-item'));
+                        }});
+
+                        $hints.set('data', stmt.hints);
+                        $hints.$el
+                            .removeClass(csscls('list'))
+                            .addClass(csscls('table-list'))
+                            .appendTo($value);
+
+                        return $('<tr />').append($name, $value);
+                    });
+                }
+
+                if (stmt.backtrace && stmt.backtrace.length) {
+                    table.append(function () {
+                        var icon = 'list-ul';
+                        var $icon = '<i class="phpdebugbar-fa phpdebugbar-fa-' + icon + ' phpdebugbar-text-muted"></i>';
+                        var $name = $('<td />').addClass(csscls('name')).html('Backtrace ' + $icon);
+                        var $value = $('<td />').addClass(csscls('value'));
+                        var $span = $('<span />').addClass('phpdebugbar-text-muted');
+
+                        var $backtrace = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, source) {
+                            var $parts = [
+                                $span.clone().text(source.index + '.'),
+                                '&nbsp;',
+                            ];
+
+                            if (source.namespace) {
+                                $parts.push(source.namespace + '::');
+                            }
+
+                            $parts.push(source.name);
+                            $parts.push($span.clone().text(':' + source.line));
+
+                            li.append($parts).removeClass(csscls('list-item')).addClass(csscls('table-list-item'));
+                        }});
+
+                        $backtrace.set('data', stmt.backtrace);
+
+                        $backtrace.$el
+                            .removeClass(csscls('list'))
+                            .addClass(csscls('table-list'))
+                            .appendTo($value);
+
+                        return $('<tr />').append($name, $value);
+                    });
+                }
+
+                if (stmt.params && !$.isEmptyObject(stmt.params)) {
+                    for (var key in stmt.params) {
+                        if (typeof stmt.params[key] !== 'function') {
+                            table.append('<tr><td class="' + csscls('name') + '">' + key + '</td><td class="' + csscls('value') +
+                                '">' + stmt.params[key] + '</td></tr>');
+                        }
+                    }
+                }
+
+                li.css('cursor', 'pointer').click(function() {
+                    if (table.is(':visible')) {
+                        table.hide();
+                    } else {
+                        table.show();
+                    }
+                });
+            }});
+            this.$list.$el.appendTo(this.$el);
+
+            this.bindAttr('data', function(data) {
+                this.$list.set('data', data.statements);
+                this.$status.empty();
+                var stmt;
+
+                // Search for duplicate statements.
+                for (var sql = {}, duplicate = 0, i = 0; i < data.statements.length; i++) {
+                    if(data.statements[i].type === 'query') {
+                        stmt = data.statements[i].sql;
+                        if (data.statements[i].bindings && data.statements[i].bindings.length) {
+                            stmt += JSON.stringify(data.statements[i].bindings);
+                        }
+                        sql[stmt] = sql[stmt] || { keys: [] };
+                        sql[stmt].keys.push(i);
+                    }
+                }
+                // Add classes to all duplicate SQL statements.
+                for (stmt in sql) {
+                    if (sql[stmt].keys.length > 1) {
+                        duplicate += sql[stmt].keys.length;
+
+                        for (i = 0; i < sql[stmt].keys.length; i++) {
+                            this.$list.$el.find('.' + csscls('list-item')).eq(sql[stmt].keys[i])
+                                .addClass(csscls('sql-duplicate'))
+                                .addClass(csscls('sql-duplicate-'+duplicate));
+                        }
+                    }
+                }
+
+                var t = $('<span />').text(data.nb_statements + " statements were executed").appendTo(this.$status);
+                if (data.nb_failed_statements) {
+                    t.append(", " + data.nb_failed_statements + " of which failed");
+                }
+                if (duplicate) {
+                    t.append(", " + duplicate + " of which were duplicated");
+                    t.append(", " + (data.nb_statements - duplicate) + " unique");
+                }
+                if (data.accumulated_duration_str) {
+                    this.$status.append($('<span title="Accumulated duration" />').addClass(csscls('duration')).text(data.accumulated_duration_str));
+                }
+                if (data.memory_usage_str) {
+                    this.$status.append($('<span title="Memory usage" />').addClass(csscls('memory')).text(data.memory_usage_str));
+                }
+            });
+        }
+
+    });
+
+})(PhpDebugBar.$);


### PR DESCRIPTION
![laravel-debugbar-queries](https://cloud.githubusercontent.com/assets/667144/23093763/55c57862-f5f4-11e6-8c98-0ee358352eaf.png)

- Collect database transactions events (begin, commit, rollback).
- Display the stack of the backtrace when a query item is expanded.
- Model binding is detected explicitly in the `Router#substituteBindings` method.
- The backtrace now detects middleware.
- Redesigned the params table to display bindings, hints and backtrace nicely.
- The data formatting methods have been extracted to a `QueryFormatter`.

See https://github.com/barryvdh/laravel-debugbar/issues/483

P.S.: In the screenshot I have replaced the fonts with a system font stack. I plan to submit a PR to the [php-debugbar](https://github.com/maximebf/php-debugbar) repo about that.