### PR TITLE
Add route domain config option

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -180,4 +180,13 @@ return [
      */
     'route_prefix' => '_debugbar',
 
+    /*
+     |--------------------------------------------------------------------------
+     | DebugBar route domain
+     |--------------------------------------------------------------------------
+     |
+     | By default DebugBar route served from the same domain that request served.
+     | To override default domain, specify it as a non-empty value.
+     */
+    'route_domain' => null,
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -77,6 +77,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $routeConfig = [
             'namespace' => 'Barryvdh\Debugbar\Controllers',
             'prefix' => $this->app['config']->get('debugbar.route_prefix'),
+            'domain' => $this->app['config']->get('debugbar.route_domain'),
         ];
 
         $this->getRouter()->group($routeConfig, function($router) {


### PR DESCRIPTION
This PR adds `debugbar.route_domain` config option to allow specifying a custom domain name where debugbar is served from.

The use case is to deal with wildcard route conflicts.

This PR is fully BC compatible.