### PR TITLE
Open Handler Loaded at any Protocol Case

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -774,6 +774,7 @@ class LaravelDebugbar extends DebugBar
         $renderer = $this->getJavascriptRenderer();
         if ($this->getStorage()) {
             $openHandlerUrl = route('debugbar.openhandler');
+            $openHandlerUrl  = preg_replace('/\Ahttps?:/', '', $openHandlerUrl);
             $renderer->setOpenHandlerUrl($openHandlerUrl);
         }
 


### PR DESCRIPTION
Similar to #557 , currently if laravel is running in HTTP protocol behind a HTTPS reserve proxy, it will generate route of open handlers as HTTP. However, many browsers disallow this mixed content for security concerns. So, remove protocol prefix at the open handler, it will manage to load those to deal with AJAX requests.
