### PR TITLE
Minor CSS Tweaks

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -211,6 +211,7 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql {
     flex: 1;
     margin-right: 5px;
+    cursor: text;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -3,6 +3,7 @@ div.phpdebugbar {
     font-family: "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Verdana, sans-serif;
     direction: ltr;
     text-align: left;
+    z-index: 100000;
 }
 
 div.phpdebugbar-resize-handle {


### PR DESCRIPTION
Two small commits for a couple tweaks I've made to my local installations of the debugbar.

1) When I use dump() in my application, the `<pre>` elements where the data is displayed has a z-index of 99999; this covers up the debugbar. 

2) When viewing SQL queries in the debugbar, I sometimes want to copy them into my SQL editor for testing. This changes the cursor to 'text' for the elements where those queries are displayed. 