### PR TITLE
Fix Server-Timing headers

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1031,7 +1031,7 @@ class LaravelDebugbar extends DebugBar
 
             $headers = [];
             foreach ($collector->collect()['measures'] as $k => $m) {
-                $headers[] = sprintf('%d=%F; "%s"', $k, $m['duration'], str_replace('"', "'", $m['label']));
+                $headers[] = sprintf('%d=%F; "%s"', $k, $m['duration'] * 1000, str_replace('"', "'", $m['label']));
             }
 
             $response->headers->set('Server-Timing', $headers, false);


### PR DESCRIPTION
Chrome expects Server-Timing headers in milliseconds, not seconds.

This is how it looks right now:

![image](https://user-images.githubusercontent.com/1077520/29205770-11fff774-7e7f-11e7-826f-7cef4f9e2110.png)

This is how it looks after the change:

![image](https://user-images.githubusercontent.com/1077520/29205793-33215a4c-7e7f-11e7-84c3-1c6094d53c24.png)
