### PR TITLE
Show paths from "vendor/laravel/framework" folder in query traces

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -220,8 +220,11 @@ class QueryCollector extends PDOCollector
 
         if (isset($trace['class']) && isset($trace['file']) && strpos(
                 $trace['file'],
-                DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'laravel' . DIRECTORY_SEPARATOR . 'framework'
+                DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'laravel' . DIRECTORY_SEPARATOR . 'framework/src/Illuminate/Database'
             ) === false && strpos(
+               $trace['file'],
+               DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'laravel' . DIRECTORY_SEPARATOR . 'framework/src/Illuminate/Events'
+           ) === false && strpos(
                 $trace['file'],
                 DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'barryvdh' . DIRECTORY_SEPARATOR . 'laravel-debugbar'
             ) === false


### PR DESCRIPTION
Before this PR:

* all paths from "vendor/laravel/framework" folder were removed from query traces making it hard to figure out where a particular query originating from framework code comes from.

After this PR:

* all files from "vendor/laravel/framework" folder are shown in query traces
* files from `/vendor/laravel/framework/src/Illuminate/Database` folder are excluded, because we're not interested in query execution/building
* files from `/vendor/laravel/framework/src/Illuminate/Events` folder are excluded, because events are used to monitor actual executed queries and don't trigger any queries themselves

Closes #692