### PR TITLE
add load_debugbar flag and update the doc

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -7,11 +7,17 @@ return [
      | Debugbar Settings
      |--------------------------------------------------------------------------
      |
-     | Debugbar is enabled by default, when debug is set to true in app.php.
-     | You can override the value by setting enable to true or false instead of null.
+     | Debugbar is loaded by default, and will be enabled when debug is set to 
+     | true in app.php.You can override the value by setting enable to true or
+     | false instead of null.
+     | NEED TO KNOW:
+     |   1.when you don't use debugbar at all, like in production env, just set
+     |     load_debugbar to false, debugbar will not load.
+     |   2.when you need to disable debugbar and enable it later, set enabled
+     |     to false and keep load_debugbar true.
      |
      */
-
+    'load_debugbar' =>  env('LOAD_DEBUGBAR', true),
     'enabled' => env('DEBUGBAR_ENABLED', null),
 
     /*

--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ Note: Not using the auto-inject, will disable the Request information, because t
 You can add the default_request datacollector in the config as alternative.
 
 ## Enabling/Disabling on run time
-You can enable or disable the debugbar during run time.
+You can enable or disable the debugbar during run time.Just make sure you have loaded debugbar at first time.
 
 ```php
 \Debugbar::enable();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,14 +64,14 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
         // If enabled is null, set from the app.debug value
+        $load_debugbar = $this->app['config']->get('debugbar.load_debugbar');
         $enabled = $this->app['config']->get('debugbar.enabled');
 
+        if (! $load_debugbar) {
+            return;
+        }
         if (is_null($enabled)) {
             $enabled = $this->checkAppDebug();
-        }
-
-        if (! $enabled) {
-            return;
         }
 
         $routeConfig = [
@@ -108,7 +108,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         /** @var LaravelDebugbar $debugbar */
         $debugbar = $this->app['debugbar'];
-        $debugbar->enable();
         $debugbar->boot();
 
         $this->registerMiddleware('Barryvdh\Debugbar\Middleware\Debugbar');


### PR DESCRIPTION
sometimes i need to control debugbar at run time, i've tried following [the doc](https://github.com/barryvdh/laravel-debugbar#enablingdisabling-on-run-time),which means i need to do the following

```
# CANNOT disable debugbar in configuration, and make sure debugbar enabled
# disable debugbar at app/Http/Controllers/Controller.php
# and then enable debugbar somewhere at run time
```

that's quite strange i think. so i made changes in this pr, hope you guys will like it.