### PR TITLE
as of Laravel 5.5 fire() must be renamed to handle()

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -16,7 +16,7 @@ class ClearCommand extends Command
         parent::__construct();
     }
 
-    public function fire()
+    public function handle()
     {
         $this->debugbar->boot();
 


### PR DESCRIPTION
https://laravel.com/docs/5.5/upgrade

Artisan
The fire Method

Any fire methods present on your Artisan commands should be renamed to handle