### PR TITLE
Ignore explain query for clockwork

### DIFF
--- a/src/Support/Clockwork/Converter.php
+++ b/src/Support/Clockwork/Converter.php
@@ -91,6 +91,9 @@ class Converter {
         if (isset($data['queries'])) {
             $queries = $data['queries'];
             foreach($queries['statements'] as $statement){
+                if ($statement['type'] === 'explain') {
+                    continue;
+                }
                 $output['databaseQueries'][] = [
                     'query' => $statement['sql'],
                     'bindings' => $statement['params'],


### PR DESCRIPTION
Because the data structure is different from the sql type query.
Explain query has not `duration` and `connection` column, so raised `Undefined index` Notice.
This is only workaround.