### PR TITLE
Resolve Problem with relocation of Router in Lumen

### DIFF
--- a/src/LumenServiceProvider.php
+++ b/src/LumenServiceProvider.php
@@ -14,7 +14,7 @@ class LumenServiceProvider extends ServiceProvider
      */
     protected function getRouter()
     {
-        return $this->app;
+        return $this->app->router;
     }
 
     /**


### PR DESCRIPTION
Due to this commit https://github.com/laravel/lumen-framework/commit/7018d57d684e7e63bcef9576bc718e9ad75feb0c on the Lumen 5.5 branch, the core methods required for Routing have been moved to Laravel\Lumen\Routing\Router rather than it residing within the Lumen Application.