### PR TITLE
Don't flag identical queries on different databases as duplicates

### DIFF
--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -186,6 +186,9 @@
                         if (data.statements[i].bindings && data.statements[i].bindings.length) {
                             stmt += JSON.stringify(data.statements[i].bindings);
                         }
+                        if (data.statements[i].connection) {
+                            stmt += '@' + data.statements[i].connection;
+                        }
                         sql[stmt] = sql[stmt] || { keys: [] };
                         sql[stmt].keys.push(i);
                     }


### PR DESCRIPTION
I run the same query on two different databases, and it's currently flagged as a duplicate. This adds the connection ID to the key so that it's not.