### PR TITLE
Use Authorizable in GateCollector

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 
 use DebugBar\DataCollector\MessagesCollector;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
 
 /**
@@ -25,14 +25,14 @@ class GateCollector extends MessagesCollector
         $gate->after([$this, 'addCheck']);
     }
 
-    public function addCheck(Authenticatable $user, $ability, $result, $arguments = [])
+    public function addCheck(Authorizable $user, $ability, $result, $arguments = [])
     {
         $label = $result ? 'success' : 'error';
 
         $this->addMessage([
             'ability' => $ability,
             'result' => $result,
-            'user' => $user->getAuthIdentifier(),
+            snake_case(class_basename($user)) => $user->id,
             'arguments' => $this->exporter->exportValue($arguments),
         ], $label, false);
     }


### PR DESCRIPTION
addCheck assumed that the authorized model was the authenticated App\User. In my case I have a App\User, App\Account and an App\AccountUser. The App\User is authenticated but authorizations are on the App\AccountUser which does not implement Authenticatable.

This change type hints $user to Authorizable because thats what is actually relevant in this collector. It also uses the Authorizable's base class name in the message instead of assuming 'user'.