### PR TITLE
Force injecting with special content types

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -179,6 +179,19 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Force Inject Content Types
+     |--------------------------------------------------------------------------
+     |
+     | Debugbar would be injected in Response if the type string appear in the
+     | Content-Type field of the Response header, and the Content-Type would be
+     | overridden.
+     |
+     */
+
+    'force_inject_content_types' => [],   // ['json', 'xml', 'text', ...]
+
+    /*
+     |--------------------------------------------------------------------------
      | DebugBar route prefix
      |--------------------------------------------------------------------------
      |

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -874,7 +874,7 @@ class LaravelDebugbar extends DebugBar
         $response->headers->remove('Content-Length');
 
         if ($overrideType) {
-            $response->headers->set('Content-Type', 'text/html; charset='.$response->getCharset());
+            $response->headers->set('Content-Type', 'text/html; charset='.($response->getCharset() ?: 'UTF-8'));
         }
     }
 


### PR DESCRIPTION
Our project is mainly used as a app server, which returns json format data in most cases.

However,   debugbar would be injected only with `html` content type by default refer [here](https://github.com/barryvdh/laravel-debugbar/blob/master/src/LaravelDebugbar.php#L720). I need to modifying my code to show debugbar.

So I would like to add a config item `force_inject_content_types`,  with which debugbar could be injected with some special content types. 

Signed-off-by: tianhe1986 <w1s2j3229@163.com>