### PR TITLE
Loosen maximebf/debugbar constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "maximebf/debugbar": "~1.14.0",
+        "maximebf/debugbar": "~1.14",
         "illuminate/routing": "5.5.x",
         "illuminate/session": "5.5.x",
         "illuminate/support": "5.5.x",


### PR DESCRIPTION
This will simply allow a more recent version of the library to be used - `1.15.0`.