### PR TITLE
Laravel 5.6 support added

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -5,7 +5,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 use DebugBar\DataCollector\MessagesCollector;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Access\Authorizable;
-use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**
  * Collector for Laravel's Auth provider
@@ -20,7 +20,7 @@ class GateCollector extends MessagesCollector
     public function __construct(Gate $gate)
     {
         parent::__construct('gate');
-        $this->exporter = new ValueExporter();
+        $this->exporter = new VarCloner();
 
         $gate->after([$this, 'addCheck']);
     }
@@ -33,7 +33,7 @@ class GateCollector extends MessagesCollector
             'ability' => $ability,
             'result' => $result,
             snake_case(class_basename($user)) => $user->id,
-            'arguments' => $this->exporter->exportValue($arguments),
+            'arguments' => $this->exporter->cloneVar($arguments),
         ], $label, false);
     }
 }

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 
 use DebugBar\Bridge\Twig\TwigCollector;
 use Illuminate\View\View;
-use Symfony\Component\HttpKernel\DataCollector\Util\ValueExporter;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class ViewCollector extends TwigCollector
 {
@@ -21,7 +21,7 @@ class ViewCollector extends TwigCollector
         $this->collect_data = $collectData;
         $this->name = 'views';
         $this->templates = [];
-        $this->exporter = new ValueExporter();
+        $this->exporter = new VarCloner();
     }
 
     public function getName()
@@ -75,7 +75,7 @@ class ViewCollector extends TwigCollector
         } else {
             $data = [];
             foreach ($view->getData() as $key => $value) {
-                $data[$key] = $this->exporter->exportValue($value);
+                $data[$key] = $this->exporter->cloneVar($value);
             }
             $params = $data;
         }


### PR DESCRIPTION
Laravel 5.6 uses Symfony's http-kernel 4.0, exportValue has been deprecated since 3.2 and fully removed in 4.0