### PR TITLE
Allow to use nullable user

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -25,14 +25,14 @@ class GateCollector extends MessagesCollector
         $gate->after([$this, 'addCheck']);
     }
 
-    public function addCheck(Authorizable $user, $ability, $result, $arguments = [])
+    public function addCheck(Authorizable $user = null, $ability, $result, $arguments = [])
     {
         $label = $result ? 'success' : 'error';
 
         $this->addMessage([
             'ability' => $ability,
             'result' => $result,
-            snake_case(class_basename($user)) => $user->id,
+            ($user ? snake_case(class_basename($user)) : 'user') => ($user ? $user->id : null),
             'arguments' => $this->exporter->cloneVar($arguments),
         ], $label, false);
     }


### PR DESCRIPTION
I believe this will allow to use Gates also when user is not logged.

I was updating my app from Laravel 5.3 to 5.5 and debugbar causes exception being thrown when user  is not logged in (in previous version there was no such problem) because  passed argument is not instance of Authenticatable but null (this is before https://github.com/barryvdh/laravel-debugbar/pull/735 version).

I believe this was also mentioned here: https://github.com/barryvdh/laravel-debugbar/issues/677

In my app as temporary solution (just for development), I've updated  code from

    public function addCheck(Authenticatable $user, $ability, $result, $arguments = [])
    {
        $label = $result ? 'success' : 'error';

        $this->addMessage([
            'ability' => $ability,
            'result' => $result,
            'user' => $user->getAuthIdentifier(),
            'arguments' => $this->exporter->exportValue($arguments),
        ], $label, false);
    }

to


    public function addCheck(Authenticatable $user = null, $ability, $result, $arguments = [])
    {
        $label = $result ? 'success' : 'error';

        $this->addMessage([
            'ability' => $ability,
            'result' => $result,
            'user' => $user ? $user->getAuthIdentifier() : null,
            'arguments' => $this->exporter->exportValue($arguments),
        ], $label, false);
    }

to get rid of this issue