### PR TITLE
If user is instance of Authenticatable call getAuthIdentifier()

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -6,6 +6,7 @@ use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
 use DebugBar\DataCollector\MessagesCollector;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 /**
@@ -25,12 +26,20 @@ class GateCollector extends MessagesCollector
 
     public function addCheck(Authorizable $user = null, $ability, $result, $arguments = [])
     {
+        $userKey = 'user';
+        $userId = null;
+
+        if ($user) {
+            $userKey = snake_case(class_basename($user));
+            $userId = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->id;
+        }
+
         $label = $result ? 'success' : 'error';
 
         $this->addMessage([
             'ability' => $ability,
             'result' => $result,
-            ($user ? snake_case(class_basename($user)) : 'user') => ($user ? $user->id : null),
+            $userKey => $userId,
             'arguments' => $this->getDataFormatter()->formatVar($arguments),
         ], $label, false);
     }


### PR DESCRIPTION
PR #735 introduced a loss of functionality, `GateCollector` was previously type hinted with `Authenticatable` and called `getAuthIdentifier()` to retrieve the id of the `User`. PR #735 replaced the type hint with `Authorizable` to allow more flexibility but at cost of requiring the `User` object to have a public `id` field. This PR maintains the `Authorizable` type hint but checks if the `User` object is an instance of `Authenticatable` and calls `getAuthIdentifier()` to retrieve the id.

Fixes #798