### PR TITLE
#776 - Check if we're still collecting in the listen handler

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -319,6 +319,9 @@ class LaravelDebugbar extends DebugBar
             try {
                 $db->listen(
                     function ($query, $bindings = null, $time = null, $connectionName = null) use ($db, $queryCollector) {
+                        if ($this->shouldCollect('db', true)) {
+                            return; // Issue 776 : We've turned off collecting after the listener was attached
+                        }
                         // Laravel 5.2 changed the way some core events worked. We must account for
                         // the first argument being an "event object", where arguments are passed
                         // via object properties, instead of individual arguments.


### PR DESCRIPTION
Running `config(["debugbar.collectors.db" => false ]);` should now stop the collection of DB queries until we turn it back on via `config(["debugbar.collectors.db" => true ]);`