### PR TITLE
Config flag to log request global stats

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -163,7 +163,7 @@ return [
             'values' => true // collect cache values
         ],
         'log' => [
-            'request_global_stats' => true // log route, memory_usage, request_duration, number of queries & views
+            'request_global_stats' => false // log route uri, request_duration, memory_usage, number of queries & views
         ]
     ],
 

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -162,6 +162,9 @@ return [
         'cache' => [
             'values' => true // collect cache values
         ],
+        'log' => [
+            'request_global_stats' => true // log route, memory_usage, request_duration, number of queries & views
+        ]
     ],
 
     /*

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -828,6 +828,10 @@ class LaravelDebugbar extends DebugBar
             $this->storage->save($this->getCurrentRequestId(), $this->data);
         }
 
+        if ($this->app['config']->get('debugbar.options.log.request_global_stats')){
+            $this->logRequestGlobalStats($this->data);
+        }
+
         return $this->data;
     }
 
@@ -940,6 +944,10 @@ class LaravelDebugbar extends DebugBar
 
         if ($this->storage !== null) {
             $this->storage->save($this->getCurrentRequestId(), $this->data);
+        }
+
+        if ($this->app['config']->get('debugbar.options.log.request_global_stats')){
+            $this->logRequestGlobalStats($this->data);
         }
 
         return $this->data;
@@ -1061,5 +1069,22 @@ class LaravelDebugbar extends DebugBar
 
             $response->headers->set('Server-Timing', $headers, false);
         }
+    }
+
+    /**
+     * Log each request global stats
+     *
+     * @param $data
+     */
+    protected function logRequestGlobalStats($data)
+    {
+        $log = array_filter([
+            'route' => array_get($data, 'route.uri'),
+            'duration' => array_get($data, 'time.duration_str'),
+            'memory' => array_get($data, 'memory.peak_usage_str'),
+            'queries' => array_get($data, 'queries.nb_statements'),
+            'views' => array_get($data, 'views.nb_templates'),
+        ]);
+        \Log::info('LaravelDebugbar-RequestStats', $log);
     }
 }


### PR DESCRIPTION
A config flag that when set to `true` will log something like this:
`[2018-06-06 14:16:08] local.INFO: LaravelDebugbar-RequestStats {"route":"GET embedded/products","duration":"6.41s","memory":"8.94MB","queries":58,"views":93}`