### PR TITLE
Enable export all queries to csv

### DIFF
--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -241,7 +241,10 @@
                     t.append(", " + duplicate + " of which were duplicated");
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
                 }
-                this.$status.append($('<span title="Copy to Clipboard" />').addClass(csscls('copy-clipboard')).text('Export')
+                this.$status.append($('<span title="Copy to Clipboard" />')
+                    .css('cursor','pointer')
+                    .addClass(csscls('copy-clipboard'))
+                    .text('Export')
                     .on('click', function(){
                         let $this = $(this),
                             csvContent = "id,sql,duration (ms),stmt_id\r\n",

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -1,5 +1,32 @@
 (function($) {
 
+    PhpDebugBar.utils.copyToClipboard = function(text) {
+        var doc = document;
+
+        // Create temp element
+        var textarea = doc.createElement('textarea');
+        textarea.style.position = 'absolute';
+        textarea.style.opacity  = '0';
+        textarea.textContent    = text;
+
+        doc.body.appendChild(textarea);
+
+        textarea.focus();
+        textarea.setSelectionRange(0, textarea.value.length);
+
+        // copy the selection
+        var success;
+        try {
+            success = doc.execCommand("copy");
+        } catch(e) {
+            success = false;
+        }
+
+        textarea.remove();
+
+        return success;
+    };
+
     var csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
 
     /**
@@ -214,18 +241,18 @@
                     t.append(", " + duplicate + " of which were duplicated");
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
                 }
-                this.$status.append($('<span title="Export Queries to CSV" />').addClass(csscls('export-to-csv')).text('Export Queries')).on('click', function(){
-                    let csvContent = "data:text/csv;charset=utf-8,";
-                    for (let i = 0; i < data.statements.length; i++) {
-                        csvContent += data.statements[i].sql +",\r\n";
-                    }
-                    let link = document.createElement("a");
-                    link.setAttribute("style", "display: none");
-                    link.setAttribute("href", encodeURI(csvContent));
-                    link.setAttribute("download", "queries.csv");
-                    link.innerHTML= "Click Here to download";
-                    document.body.appendChild(link);
-                    link.click();
+                this.$status.append($('<span title="Export Queries to CSV" />').addClass(csscls('copy-clipboard')).text('Copy Queries'))
+                    .on('click', function(){
+                        // let csvContent = "data:text/csv;charset=utf-8,";
+                        // for (let i = 0; i < data.statements.length; i++) {
+                        //     csvContent += data.statements[i].sql +",\r\n";
+                        // }
+                        let csvContent = "";
+                        for (let i = 0; i < data.statements.length; i++) {
+                            csvContent += data.statements[i].sql +",\r\n";
+                        }
+                        $(this).text(PhpDebugBar.utils.copyToClipboard(csvContent) ? 'Copied to clipboard' : 'Error copying to clipboard')
+                             .delay(2000).text('Copy Queries');
                 });
                 if (data.accumulated_duration_str) {
                     this.$status.append($('<span title="Accumulated duration" />').addClass(csscls('duration')).text(data.accumulated_duration_str));
@@ -235,6 +262,7 @@
                 }
             });
         }
+
 
     });
 

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -241,19 +241,19 @@
                     t.append(", " + duplicate + " of which were duplicated");
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
                 }
-                this.$status.append($('<span title="Export Queries to CSV" />').addClass(csscls('copy-clipboard')).text('Copy Queries'))
+                this.$status.append($('<span title="Copy to Clipboard" />').addClass(csscls('copy-clipboard')).text('Export')
                     .on('click', function(){
-                        // let csvContent = "data:text/csv;charset=utf-8,";
-                        // for (let i = 0; i < data.statements.length; i++) {
-                        //     csvContent += data.statements[i].sql +",\r\n";
-                        // }
-                        let csvContent = "";
+                        let $this = $(this),
+                            csvContent = "";
                         for (let i = 0; i < data.statements.length; i++) {
                             csvContent += data.statements[i].sql +",\r\n";
                         }
-                        $(this).text(PhpDebugBar.utils.copyToClipboard(csvContent) ? 'Copied to clipboard' : 'Error copying to clipboard')
-                             .delay(2000).text('Copy Queries');
-                });
+                        $this
+                            .text(PhpDebugBar.utils.copyToClipboard(csvContent) ? 'Copied to clipboard' : 'Error copying to clipboard')
+                            .delay(2000).queue(function () {
+                                $this.text('Export');
+                            });
+                }));
                 if (data.accumulated_duration_str) {
                     this.$status.append($('<span title="Accumulated duration" />').addClass(csscls('duration')).text(data.accumulated_duration_str));
                 }

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -244,9 +244,11 @@
                 this.$status.append($('<span title="Copy to Clipboard" />').addClass(csscls('copy-clipboard')).text('Export')
                     .on('click', function(){
                         let $this = $(this),
-                            csvContent = "";
+                            csvContent = "id,sql,duration (ms),stmt_id\r\n",
+                            st;
                         for (let i = 0; i < data.statements.length; i++) {
-                            csvContent += data.statements[i].sql +",\r\n";
+                            st = data.statements[i];
+                            csvContent += [i, '"' + st.sql + '"', st.duration, st.stmt_id, "\r\n"].join(',');
                         }
                         $this
                             .text(PhpDebugBar.utils.copyToClipboard(csvContent) ? 'Copied to clipboard' : 'Error copying to clipboard')

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -214,6 +214,19 @@
                     t.append(", " + duplicate + " of which were duplicated");
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
                 }
+                this.$status.append($('<span title="Export Queries to CSV" />').addClass(csscls('export-to-csv')).text('Export Queries')).on('click', function(){
+                    let csvContent = "data:text/csv;charset=utf-8,";
+                    for (let i = 0; i < data.statements.length; i++) {
+                        csvContent += data.statements[i].sql +",\r\n";
+                    }
+                    let link = document.createElement("a");
+                    link.setAttribute("style", "display: none");
+                    link.setAttribute("href", encodeURI(csvContent));
+                    link.setAttribute("download", "queries.csv");
+                    link.innerHTML= "Click Here to download";
+                    document.body.appendChild(link);
+                    link.click();
+                });
                 if (data.accumulated_duration_str) {
                     this.$status.append($('<span title="Accumulated duration" />').addClass(csscls('duration')).text(data.accumulated_duration_str));
                 }


### PR DESCRIPTION
This will add a link to the top-left corner of the queries widget.
![image](https://user-images.githubusercontent.com/11543163/42974178-13b5fcfc-8bae-11e8-86fa-c1d59e6b1e5a.png)

When clicked all the queries will be copied to the clipboard in csv format.
Allowing the user to paste that data into a spreadsheet and easily: check for duplicates, check for slow queries,....




![image](https://user-images.githubusercontent.com/11543163/42974065-b72ea54c-8bad-11e8-82db-13f65842194b.png)
