### PR TITLE
Fix for policies

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -5,7 +5,6 @@ namespace Barryvdh\Debugbar\DataCollector;
 use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
 use DebugBar\DataCollector\MessagesCollector;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
@@ -24,7 +23,7 @@ class GateCollector extends MessagesCollector
         $gate->after([$this, 'addCheck']);
     }
 
-    public function addCheck(Authorizable $user = null, $ability, $result, $arguments = [])
+    public function addCheck(Authenticatable $user = null, $ability, $result, $arguments = [])
     {
         $userKey = 'user';
         $userId = null;


### PR DESCRIPTION
Policies cannot be used now due to this reason. And additionally, the method `Auth::user()` returns the class `Authenticatable` (which is used in gates), not `Authorizable`.

Also, I believe the class `Authenticatable` should be used since it is checking its instance on the line 33.