### PR TITLE
Fix call GateCollector using callback instead of array

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -20,7 +20,9 @@ class GateCollector extends MessagesCollector
     {
         parent::__construct('gate');
         $this->setDataFormatter(new SimpleFormatter());
-        $gate->after([$this, 'addCheck']);
+        $gate->after(function (Authenticatable $user = null, $ability, $result, $arguments = []) {
+            $this->addCheck($user, $ability, $result, $arguments);
+        });
     }
 
     public function addCheck(Authenticatable $user = null, $ability, $result, $arguments = [])


### PR DESCRIPTION
This fixes #864  & #863

Pre Laravel 5.7 the the `$gate->after` would not explicity check for optional / null. Laravel 5.7 the Gate class in Laravel will explicity check the callback signature this does not work with array arguments.

Gate Class (Laravel 5.7)

```php
protected function callbackAllowsGuests($callback)
{
        $parameters = (new ReflectionFunction($callback))->getParameters();

        return isset($parameters[0]) && $this->parameterAllowsGuests($parameters[0]);
}
```

The `$callable` will be array  as argument, The `ReflectionFunction` can only take callable argument.

The reason we get this far into the code and is not cuaght by the Gate contract is the fact that the contract expects a `callable` type since an array is considered callable if you use a object reference as the first argument and string argument as second argument as method name.

This is a bit of breaking change between Laravel 5.6 - Laravel 5.6. My fix is backwards compatible with Laravel 5.6.