### PR TITLE
Mimic bindValue and only quote non-integer and non-float data type

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -109,7 +109,13 @@ class QueryCollector extends PDOCollector
                 $regex = is_numeric($key)
                     ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
                     : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
-                $query = preg_replace($regex, $pdo->quote($binding), $query, 1);
+
+                // Mimic bindValue and only quote non-integer and non-float data types
+                if (!is_int($binding) && !is_float($binding)) {
+                    $binding = $pdo->quote($binding);
+                }
+
+                $query = preg_replace($regex, $binding, $query, 1);
             }
         }
 


### PR DESCRIPTION
This fixes an issue when viewing queries they do not directly match what is actually ran against the database.  For my particular use case I am on Laravel 5.5 and MySQL 5.7.  

My use case where this caused a headache involved a query that was running much slower than expected because an integer was utilized in the bound parameter but the indexed column on MySQL was varchar and the non quoted integer value caused the query to bypass the index.  The actual query used by Laravel Query Builder was not quoting the parameter, however, the query shown on Debugbar had the parameter quoted incorrectly.  This was confusing because running the query as seen in Debugbar against the database with a quoted parameter would run much faster than Debugbar execution time would indicate.

Example Query actually ran not utilizing index on varchar column:
`select * from table where varchar_column = 7`

What Debugbar would show which would correctly utilize index:
`select * from table where varchar_column = '7'`