### PR TITLE
Remove .pull-left, .pull-right from FA css

### DIFF
--- a/src/Resources/vendor/font-awesome/style.css
+++ b/src/Resources/vendor/font-awesome/style.css
@@ -63,12 +63,6 @@
   border: solid 0.08em #eeeeee;
   border-radius: .1em;
 }
-.pull-right {
-  float: right;
-}
-.pull-left {
-  float: left;
-}
 .phpdebugbar-fa.pull-left {
   margin-right: .3em;
 }


### PR DESCRIPTION
Avoid polluting CSS's 'global namespace'.
#855