### PR TITLE
Fix exception on fetching Auth api user info

### DIFF
--- a/src/DataCollector/MultiAuthCollector.php
+++ b/src/DataCollector/MultiAuthCollector.php
@@ -111,7 +111,7 @@ class MultiAuthCollector extends DataCollector implements Renderable
 
         // The default auth identifer is the ID number, which isn't all that
         // useful. Try username and email.
-        $identifier = $user->getAuthIdentifier();
+        $identifier = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->id;
         if (is_numeric($identifier)) {
             try {
                 if ($user->username) {


### PR DESCRIPTION
I noticed such exception in my log during debugging API queries
```
[2018-11-23 01:25:43] local.ERROR: Debugbar exception: Method Illuminate\Database\Query\Builder::getAuthIdentifier does not exist.  
```
So I've found a problem and fixed it