### PR TITLE
Allow non-Authenticatable gate users

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -20,12 +20,12 @@ class GateCollector extends MessagesCollector
     {
         parent::__construct('gate');
         $this->setDataFormatter(new SimpleFormatter());
-        $gate->after(function (Authenticatable $user = null, $ability, $result, $arguments = []) {
+        $gate->after(function ($user = null, $ability, $result, $arguments = []) {
             $this->addCheck($user, $ability, $result, $arguments);
         });
     }
 
-    public function addCheck(Authenticatable $user = null, $ability, $result, $arguments = [])
+    public function addCheck($user = null, $ability, $result, $arguments = [])
     {
         $userKey = 'user';
         $userId = null;


### PR DESCRIPTION
`addCheck` was requiring `$user` parameter to conform to `Authenticatable` and I was experiencing a crash due to providing non-conforming type.

Line 35 has check for `Authenticatable`, both requiring `Authenticatable` and having it is probably not what's meant. One should not exist and it's parameter type hint.

https://github.com/barryvdh/laravel-debugbar/blob/94a12a5c27119e46e15cb96a31eb0f7670828d44/src/DataCollector/GateCollector.php#L35