### PR TITLE
Dont register routes and middleware if we are not in debug mode

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -63,6 +63,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function boot()
     {
+        if (!$this->app['config']->get('app.debug')) {
+            return;
+        }
+        
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 


### PR DESCRIPTION
ServiceProvider as is now, register routes and middleware even when we are not on debug mode `APP_DEBUG=false`

This patch allows ServiceProvider to boot only when `app.debug` is `TRUE` 