### PR TITLE
Avoid to hook debugbar in response if its an ajax request

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -723,7 +723,7 @@ class LaravelDebugbar extends DebugBar
                 strpos($response->headers->get('Content-Type'), 'html') === false)
             || $request->getRequestFormat() !== 'html'
             || $response->getContent() === false
-            || $request->isXmlHttpRequest()
+            || $this->isJsonRequest($request)
         ) {
             try {
                 // Just collect + store data, don't inject it.

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -723,6 +723,7 @@ class LaravelDebugbar extends DebugBar
                 strpos($response->headers->get('Content-Type'), 'html') === false)
             || $request->getRequestFormat() !== 'html'
             || $response->getContent() === false
+            || $request->isXmlHttpRequest()
         ) {
             try {
                 // Just collect + store data, don't inject it.

--- a/src/Middleware/InjectDebugbar.php
+++ b/src/Middleware/InjectDebugbar.php
@@ -70,8 +70,10 @@ class InjectDebugbar
             $response = $this->handleException($request, $e);
         }
 
-        // Modify the response to add the Debugbar
-        $this->debugbar->modifyResponse($request, $response);
+        if(!$request->isXmlHttpRequest()) {
+            // Modify the response to add the Debugbar
+            $this->debugbar->modifyResponse($request, $response);
+        }
 
         return $response;
 

--- a/src/Middleware/InjectDebugbar.php
+++ b/src/Middleware/InjectDebugbar.php
@@ -70,10 +70,8 @@ class InjectDebugbar
             $response = $this->handleException($request, $e);
         }
 
-        if(!$request->isXmlHttpRequest()) {
-            // Modify the response to add the Debugbar
-            $this->debugbar->modifyResponse($request, $response);
-        }
+        // Modify the response to add the Debugbar
+        $this->debugbar->modifyResponse($request, $response);
 
         return $response;
 


### PR DESCRIPTION
InjectDebugbar middleware modifies response without detecting if its an ajax call or not.

There are cases where we return views via ajax call for templating (Angular etc).
Injecting Debugbar on that response is useless.

This patch checks if its an`isXmlHttpRequest` before inject Debugbar