### PR TITLE
Fix broken table representation in Views

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -243,7 +243,7 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-params {
     background-color: rgba(255, 255, 255, .5);
     flex: 1 1 auto;
-    margin: 10px 100% 10px 0;
+    margin: 10px 60% 10px 0;
     max-width: 100%;
 }
 


### PR DESCRIPTION
under Chrome 74.0.3729.157 the params table in view tab is broken.
It seems that changing the margin to 60% doesn't affect Firefox and IE(where it worked with 100%) but fixes Chrome.

Before:
![params_before](https://user-images.githubusercontent.com/1086496/58639529-ac5a2f00-8329-11e9-8305-40f9dd667c2f.png)

After:
![params_fix](https://user-images.githubusercontent.com/1086496/58639568-c09e2c00-8329-11e9-90cc-adfbc76cc0fd.png)

