### PR TITLE
Fix DocBlock: `message` parameter type

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -3,17 +3,17 @@
 /**
  * @method static \Barryvdh\Debugbar\LaravelDebugbar addCollector(\DebugBar\DataCollector\DataCollectorInterface $collector)
  * @method static void addMessage(mixed $message, string $label = 'info')
- * @method static void alert(string $message)
- * @method static void critical(string $message)
- * @method static void debug(string $message)
- * @method static void emergency(string $message)
- * @method static void error(string $message)
+ * @method static void alert(mixed $message)
+ * @method static void critical(mixed $message)
+ * @method static void debug(mixed $message)
+ * @method static void emergency(mixed $message)
+ * @method static void error(mixed $message)
  * @method static \Barryvdh\Debugbar\LaravelDebugbar getCollector(string $name)
  * @method static bool hasCollector(string $name)
- * @method static void info(string $message)
- * @method static void log(string $message)
- * @method static void notice(string $message)
- * @method static void warning(string $message)
+ * @method static void info(mixed $message)
+ * @method static void log(mixed $message)
+ * @method static void notice(mixed $message)
+ * @method static void warning(mixed $message)
  *
  * @see \Barryvdh\Debugbar\LaravelDebugbar
  */


### PR DESCRIPTION
Hello, Thanks for this awesome project!

On the Facade the `$message` parameter is typehinted as a string, while it should be mixed ([A message can be anything from an object to a string](https://github.com/barryvdh/laravel-debugbar/blob/2d195779ea4f809f69764a795e2ec371dbb76a96/src/LaravelDebugbar.php#L969)).

Discovered this when using a static analysis tool, (I used [larastan](https://github.com/nunomaduro/larastan)), an error message like this will be collected:
```
Parameter #1 $message of static method Barryvdh\Debugbar\Facade::info() expects string, array<string, string> given.
```
