### PR TITLE
Allow additional excluded paths for db backtrace

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -140,6 +140,7 @@ return [
         'db' => [
             'with_params'       => true,   // Render SQL with the parameters substituted
             'backtrace'         => true,   // Use a backtrace to find the origin of the query in your files.
+            'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
             'timeline'          => false,  // Add the queries to the timeline
             'explain' => [                 // Show EXPLAIN output on queries
                 'enabled' => false,

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -19,6 +19,11 @@ class QueryCollector extends PDOCollector
     protected $explainTypes = ['SELECT']; // ['SELECT', 'INSERT', 'UPDATE', 'DELETE']; for MySQL 5.6.3+
     protected $showHints = false;
     protected $reflection = [];
+    protected $backtraceExcludePaths = [
+        '/vendor/laravel/framework/src/Illuminate/Database',
+        '/vendor/laravel/framework/src/Illuminate/Events',
+        '/vendor/barryvdh/laravel-debugbar',
+    ];
 
     /**
      * @param TimeDataCollector $timeCollector
@@ -59,6 +64,16 @@ class QueryCollector extends PDOCollector
     {
         $this->findSource = (bool) $value;
         $this->middleware = $middleware;
+    }
+
+    /**
+     * Set additional paths to exclude from the backtrace
+     *
+     * @param array $excludePaths Array of file paths to exclude from backtrace
+     */
+    public function mergeBacktraceExcludePaths(array $excludePaths)
+    {
+        $this->backtraceExcludePaths = array_merge($this->backtraceExcludePaths, $excludePaths);
     }
 
     /**
@@ -272,15 +287,9 @@ class QueryCollector extends PDOCollector
      */
     protected function fileIsInExcludedPath($file)
     {
-        $excludedPaths = [
-            '/vendor/laravel/framework/src/Illuminate/Database',
-            '/vendor/laravel/framework/src/Illuminate/Events',
-            '/vendor/barryvdh/laravel-debugbar',
-        ];
-
         $normalizedPath = str_replace('\\', '/', $file);
 
-        foreach ($excludedPaths as $excludedPath) {
+        foreach ($this->backtraceExcludePaths as $excludedPath) {
             if (strpos($normalizedPath, $excludedPath) !== false) {
                 return true;
             }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -305,6 +305,11 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setFindSource(true, $middleware);
             }
 
+            if ($this->app['config']->get('debugbar.options.db.backtrace_exclude_paths')) {
+                $excludePaths = $this->app['config']->get('debugbar.options.db.backtrace_exclude_paths');
+                $queryCollector->mergeBacktraceExcludePaths($excludePaths);
+            }
+
             if ($this->app['config']->get('debugbar.options.db.explain.enabled')) {
                 $types = $this->app['config']->get('debugbar.options.db.explain.types');
                 $queryCollector->setExplainSource(true, $types);


### PR DESCRIPTION
Our project uses a custom database connection and it was always listed as the file source in the backtrace. Adding this feature allowed us to make use of the very helpful backtraces.