### PR TITLE
Add new models collector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -9,7 +9,7 @@ return [
      |
      | Debugbar is enabled by default, when debug is set to true in app.php.
      | You can override the value by setting enable to true or false instead of null.
-     | 
+     |
      | You can provide an array of URI's that must be ignored (eg. 'api/*')
      |
      */
@@ -79,7 +79,7 @@ return [
      |
      */
     'error_handler' => false,
-    
+
     /*
      |--------------------------------------------------------------------------
      | Clockwork integration
@@ -122,6 +122,7 @@ return [
         'files'           => false, // Show the included files
         'config'          => false, // Display config settings
         'cache'           => false, // Display cache events
+        'models'          => false, // Display models
     ],
 
     /*

--- a/src/DataCollector/ModelsCollector.php
+++ b/src/DataCollector/ModelsCollector.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
+use DebugBar\DataCollector\MessagesCollector;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Str;
+
+/**
+ * Collector for Models.
+ */
+class ModelsCollector extends MessagesCollector
+{
+    public $models = [];
+
+    /**
+     * @param Dispatcher $events
+     */
+    public function __construct(Dispatcher $events)
+    {
+        parent::__construct('models');
+        $this->setDataFormatter(new SimpleFormatter());
+
+        $events->listen('eloquent.*', function ($event, $models) {
+            if (Str::contains($event, 'eloquent.retrieved')) {
+                foreach ($models as $model) {
+                    $class = get_class($model);
+                    $this->models[$class] = ($this->models[$class] ?? 0) + 1;
+                }
+            }
+        });
+    }
+
+    public function collect()
+    {
+        foreach ($this->models as $type => $count) {
+            $this->addMessage($count, $type);
+        }
+
+        return [
+            'count' => array_sum($this->models),
+            'messages' => $this->getMessages(),
+        ];
+    }
+
+    public function getWidgets()
+    {
+        $widgets = parent::getWidgets();
+        $widgets['models']['icon'] = 'cubes';
+
+        return $widgets;
+    }
+}

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -7,6 +7,7 @@ use Barryvdh\Debugbar\DataCollector\FilesCollector;
 use Barryvdh\Debugbar\DataCollector\GateCollector;
 use Barryvdh\Debugbar\DataCollector\LaravelCollector;
 use Barryvdh\Debugbar\DataCollector\LogsCollector;
+use Barryvdh\Debugbar\DataCollector\ModelsCollector;
 use Barryvdh\Debugbar\DataCollector\MultiAuthCollector;
 use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\DataCollector\SessionCollector;
@@ -401,6 +402,15 @@ class LaravelDebugbar extends DebugBar
                         $e
                     )
                 );
+            }
+        }
+
+        if ($this->shouldCollect('models', false)) {
+            try {
+                $modelsCollector = $this->app->make('Barryvdh\Debugbar\DataCollector\ModelsCollector');
+                $this->addCollector($modelsCollector);
+            } catch (\Exception $e){
+                // No Models collector
             }
         }
 


### PR DESCRIPTION
This PR adds a new "models" collector. It essentially listens for `eloquent.retrieved` events, and totals them by model type. This provides a super helpful insight into how many Eloquent models are being generated for a request...something that can have a huge impact on performance.

At first I had it where you could click on each model type to view all the loaded models. However, after chatting with @barryvdh, we decided it was probably better to just show the totals, to keep things snappy.

![image](https://user-images.githubusercontent.com/882133/62077039-2b2ef380-b217-11e9-8dc2-2c7eef056452.png)

By default this metric is disabled, but I could honestly see this being enabled by default in the future, if folks find it as useful as I do.