### PR TITLE
Update laravel-debugbar.css

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -3,7 +3,7 @@ div.phpdebugbar {
     font-family: "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Verdana, sans-serif;
     direction: ltr;
     text-align: left;
-    z-index: 100000;
+    z-index: 9999999999;
 }
 
 div.phpdebugbar-resize-handle {


### PR DESCRIPTION
'div.phpdebugbar' must have z-index value great or equal than '.Whoops.container' one to show on Whoops error pages 
https://github.com/filp/whoops/blob/master/src/Whoops/Resources/css/whoops.base.css#L15