### PR TITLE
Prefer Str:: class for Laravel 6 compatability.

### DIFF
--- a/src/DataCollector/RequestCollector.php
+++ b/src/DataCollector/RequestCollector.php
@@ -5,6 +5,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\Renderable;
+use Illuminate\Support\Str;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
 use Symfony\Component\HttpFoundation\Response;
@@ -115,8 +116,8 @@ class RequestCollector extends DataCollector implements DataCollectorInterface, 
         }
 
         foreach ($data['request_server'] as $key => $value) {
-            if (str_is('*_KEY', $key) || str_is('*_PASSWORD', $key)
-                    || str_is('*_SECRET', $key) || str_is('*_PW', $key)) {
+            if (Str::is('*_KEY', $key) || Str::is('*_PASSWORD', $key)
+                    || Str::is('*_SECRET', $key) || Str::is('*_PW', $key)) {
                 $data['request_server'][$key] = '******';
             }
         }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -34,6 +34,7 @@ use Exception;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Session\SessionManager;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -98,7 +99,7 @@ class LaravelDebugbar extends DebugBar
         }
         $this->app = $app;
         $this->version = $app->version();
-        $this->is_lumen = str_contains($this->version, 'Lumen');
+        $this->is_lumen = Str::contains($this->version, 'Lumen');
     }
 
     /**


### PR DESCRIPTION
Updated the two files that used the `str_*` helper functions that Laravel 6 removed.