### PR TITLE
Protect against possible null values in `$models` array.

### DIFF
--- a/src/DataCollector/ModelsCollector.php
+++ b/src/DataCollector/ModelsCollector.php
@@ -24,9 +24,7 @@ class ModelsCollector extends MessagesCollector
 
         $events->listen('eloquent.*', function ($event, $models) {
             if (Str::contains($event, 'eloquent.retrieved')) {
-                $models = array_filter($models);
-
-                foreach ($models as $model) {
+                foreach (array_filter($models) as $model) {
                     $class = get_class($model);
                     $this->models[$class] = ($this->models[$class] ?? 0) + 1;
                 }

--- a/src/DataCollector/ModelsCollector.php
+++ b/src/DataCollector/ModelsCollector.php
@@ -24,6 +24,8 @@ class ModelsCollector extends MessagesCollector
 
         $events->listen('eloquent.*', function ($event, $models) {
             if (Str::contains($event, 'eloquent.retrieved')) {
+                $models = array_filter($models);
+
                 foreach ($models as $model) {
                     $class = get_class($model);
                     $this->models[$class] = ($this->models[$class] ?? 0) + 1;


### PR DESCRIPTION
I came across this error today after enabling models collector. (Thanks btw for this awesome feature @reinink!):

```
get_class() expects parameter 1 to be object, null given (View: /private/var/tmp/homepage-articles.indexmKf4EN)
```

<img width="775" alt="Screen Shot 2019-08-27 at 8 09 41 AM" src="https://user-images.githubusercontent.com/1791050/63783545-0a070480-c8a2-11e9-8296-87513d50a669.png">