### PR TITLE
Fixed get_class() for empty model

### DIFF
--- a/src/DataCollector/ModelsCollector.php
+++ b/src/DataCollector/ModelsCollector.php
@@ -25,8 +25,12 @@ class ModelsCollector extends MessagesCollector
         $events->listen('eloquent.*', function ($event, $models) {
             if (Str::contains($event, 'eloquent.retrieved')) {
                 foreach (array_filter($models) as $model) {
-                    $class = get_class($model);
-                    $this->models[$class] = ($this->models[$class] ?? 0) + 1;
+                    try {
+                        $class = get_class($model);
+                        $this->models[$class] = ($this->models[$class] ?? 0) + 1;
+                    } catch (\ErrorException $exception) {
+                        // eloquent model retrieved can be null
+                    }
                 }
             }
         });


### PR DESCRIPTION
In Laravel 5.7.x it is possible the event retrieves an empty model - so the `get_class()` call throws an `ErrorException`. By catching this it stays working, but it does not count the try of retrieving.