### PR TITLE
Fetch support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "maximebf/debugbar": "^1.15",
+        "maximebf/debugbar": "^1.15.1",
         "illuminate/routing": "^5.5|^6",
         "illuminate/session": "^5.5|^6",
         "illuminate/support": "^5.5|^6",

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -498,6 +498,7 @@ class LaravelDebugbar extends DebugBar
 
         $renderer = $this->getJavascriptRenderer();
         $renderer->setIncludeVendors($this->app['config']->get('debugbar.include_vendors', true));
+        $renderer->setBindAjaxHandlerToFetch($app['config']->get('debugbar.capture_ajax', true));
         $renderer->setBindAjaxHandlerToXHR($app['config']->get('debugbar.capture_ajax', true));
 
         $this->booted = true;


### PR DESCRIPTION
Adds support for fetch in addition to xhr, depends on: https://github.com/maximebf/php-debugbar/pull/422

Most notably (for me anyway) this gets debugbar working in Apollo-based SPA's and GraphiQL.