### PR TITLE
Fix issue with MonologCollector collector for Laravel >= v5.6

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -272,7 +272,7 @@ class LaravelDebugbar extends DebugBar
                         }
                     );
                 } else {
-                    $this->addCollector(new MonologCollector($this->app['log']->getMonolog()));
+                    $this->addCollector(new MonologCollector($this->getMonologLogger()));
                 }
             } catch (\Exception $e) {
                 $this->addThrowable(
@@ -1073,5 +1073,25 @@ class LaravelDebugbar extends DebugBar
 
             $response->headers->set('Server-Timing', $headers, false);
         }
+    }
+
+    /**
+     * @return \Monolog\Logger
+     * @throws Exception
+     */
+    private function getMonologLogger()
+    {
+        // The logging was refactored in Laravel 5.6
+        if ($this->checkVersion('5.6')) {
+            $logger = $this->app['log']->getLogger();
+        } else {
+            $logger = $this->app['log']->getMonolog();
+        }
+
+        if (get_class($logger) !== 'Monolog\Logger') {
+            throw new Exception('Logger is not a Monolog\Logger instance');
+        }
+
+        return $logger;
     }
 }


### PR DESCRIPTION
There is an issue if you set `debugbar.collectors.messages => false` and `debugbar.collectors.log => true`. The problem occurs because logging was refactored in Laravel 5.6 and `getMonolog()` method does not exist on a new `Illuminate\Log\Logger` (PR: https://github.com/laravel/framework/pull/22635). Related issue: https://github.com/barryvdh/laravel-debugbar/issues/972

This PR solves this problem for Laravel versions 5.6, 5.7 and 5.8.

However the problem with Laravel 6.0 still exists, if `monolog/monolog ^2.0` is used, because the method signature was changed in `AbstractProcessingHandler ` and `maximebf/php-debugbar` does not support it yet.(https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/AbstractProcessingHandler.php#L50). There is an open PR for this issue: https://github.com/maximebf/php-debugbar/pull/427. However, this issue with Laravel 6.x maybe could be solved in a separate PR.
