### PR TITLE
allow semantic versioning for maximebf/debugbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "maximebf/debugbar": "~1.15.0",
+        "maximebf/debugbar": "^1.15",
         "illuminate/routing": "^5.5|^6",
         "illuminate/session": "^5.5|^6",
         "illuminate/support": "^5.5|^6",


### PR DESCRIPTION
I don't believe there's a reason to lock to a minor version, so let's allow a caret dependency.