### PR TITLE
Make sure controller action is string before using strpos

### DIFF
--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -58,7 +58,7 @@ class RouteCollector extends DataCollector implements Renderable
         $result = array_merge($result, $action);
 
 
-        if (isset($action['controller']) && strpos($action['controller'], '@') !== false) {
+        if (isset($action['controller']) && is_string($action['controller']) && strpos($action['controller'], '@') !== false) {
 			list($controller, $method) = explode('@', $action['controller']);
 			if(class_exists($controller) && method_exists($controller, $method)) {
 			    $reflector = new \ReflectionMethod($controller, $method);


### PR DESCRIPTION
This fixes a [problem with Livewire](https://github.com/livewire/livewire/issues/217). 

In a few words, when using livewire you can set a route to map to a specific Livewire component ([docs](https://laravel-livewire.com/docs/spa-mode/)).

When doing so, debugbar failed to load in that particular page with an error message in the log file
```
local.ERROR: Debugbar exception: strpos() expects parameter 1 to be string, object given
```

No stack trace or anything. (This might be a separate PR someday)

This PR makes sure the route action is a string before using the strpos function.

Closes https://github.com/livewire/livewire/issues/217