### PR TITLE
Add timing information to events

### DIFF
--- a/src/DataCollector/EventCollector.php
+++ b/src/DataCollector/EventCollector.php
@@ -3,7 +3,7 @@ namespace Barryvdh\Debugbar\DataCollector;
 
 use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
 use DebugBar\DataCollector\TimeDataCollector;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Str;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
@@ -12,16 +12,20 @@ class EventCollector extends TimeDataCollector
     /** @var Dispatcher */
     protected $events;
 
+    /** @var integer */
+    protected $previousTime;
+
     public function __construct($requestStartTime = null)
     {
         parent::__construct($requestStartTime);
+        $this->previousTime = microtime(true);
         $this->setDataFormatter(new SimpleFormatter());
     }
 
     public function onWildcardEvent($name = null, $data = [])
     {
         $params = $this->prepareParams($data);
-        $time = microtime(true);
+        $currentTime = microtime(true);
 
         // Find all listeners for the current event
         foreach ($this->events->getListeners($name) as $i => $listener) {
@@ -57,7 +61,8 @@ class EventCollector extends TimeDataCollector
 
             $params['listeners.' . $i] = $listener;
         }
-        $this->addMeasure($name, $time, $time, $params);
+        $this->addMeasure($name, $this->previousTime, $currentTime, $params);
+        $this->previousTime = $currentTime;
     }
 
     public function subscribe(Dispatcher $events)


### PR DESCRIPTION
This fixes #390 and expands on #392. Additionally, the change to referencing the Dispatcher contract rather than the implementation allows for greater flexibility (specifically I'm using it with October CMS, which has its own event dispatcher that implements the Dispatcher contract).

While the timing information isn't 100% accurate, as the first event will be tracked if it took all of the time from when the collector was setup to when the event fired, and any future events are really just tracking the time between itself and the previous event, this is still valuable information that is close enough to reality to act upon. Additionally, this collector was setup from the start to track event timings, but was never actually implemented properly as it would record the start and end of the event as being the same time, always resulting in a timing of 0.