### PR TITLE
Enabled models collector by default

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -111,7 +111,7 @@ return [
         'views'           => true,  // Views with their data
         'route'           => true,  // Current route information
         'auth'            => false, // Display Laravel authentication status
-        'gate'            => true, // Display Laravel Gate checks
+        'gate'            => true,  // Display Laravel Gate checks
         'session'         => true,  // Display session data
         'symfony_request' => true,  // Only one can be enabled..
         'mail'            => true,  // Catch mail messages
@@ -122,7 +122,7 @@ return [
         'files'           => false, // Show the included files
         'config'          => false, // Display config settings
         'cache'           => false, // Display cache events
-        'models'          => false, // Display models
+        'models'          => true,  // Display models
     ],
 
     /*


### PR DESCRIPTION
Back in July of 2019 we added the models collector (#947). I have found this to be a *very* useful collector on my Laravel projects, since models are such a key part of the framework. These model metrics give insight into performance issues that's not always obvious from the queries or memory usage.

I'd suggest that we enable this by default. 🙏