### PR TITLE
Utilize the screen space for easier reading

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -301,11 +301,11 @@ dl.phpdebugbar-widgets-kvlist dd.phpdebugbar-widgets-value.phpdebugbar-widgets-p
 }
 
 dl.phpdebugbar-widgets-kvlist dt {
-    width: 200px;
+    width: 25%;
 }
 
 dl.phpdebugbar-widgets-kvlist dd {
-    margin-left: 210px;
+    margin-left: 25%;
 }
 
 ul.phpdebugbar-widgets-timeline .phpdebugbar-widgets-measure {


### PR DESCRIPTION
Most developers when working have screens that well exceed 200px. Given that many models, route middlewares, session names etc can exceed 200px in length. It seems reasonable to give them space for readability. 