### PR TITLE
Add returned value to measure()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "maximebf/debugbar": "^1.15.1",
+        "maximebf/debugbar": "^1.16.3",
         "illuminate/routing": "^5.5|^6|^7",
         "illuminate/session": "^5.5|^6|^7",
         "illuminate/support": "^5.5|^6|^7",

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -900,16 +900,18 @@ class LaravelDebugbar extends DebugBar
      *
      * @param string $label
      * @param \Closure $closure
+     * @return mixed
      */
     public function measure($label, \Closure $closure)
     {
         if ($this->hasCollector('time')) {
             /** @var \DebugBar\DataCollector\TimeDataCollector $collector */
             $collector = $this->getCollector('time');
-            $collector->measure($label, $closure);
+            $result = $collector->measure($label, $closure);
         } else {
-            $closure();
+            $result = $closure();
         }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This PR is the followup to this one:

[https://github.com/maximebf/php-debugbar/pull/443](https://github.com/maximebf/php-debugbar/pull/443)

It simply aim to return the returned value from the Closure executed by LaravelDebugbar::measure().