### PR TITLE
Basic Livewire collector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -123,6 +123,7 @@ return [
         'config'          => false, // Display config settings
         'cache'           => false, // Display cache events
         'models'          => true,  // Display models
+        'livewire'        => true,  // Display Livewire (when available)
     ],
 
     /*

--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\DataCollectorInterface;
+use DebugBar\DataCollector\Renderable;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+/**
+ * Collector for Models.
+ */
+class LivewireCollector extends DataCollector implements DataCollectorInterface, Renderable
+{
+    public $data = [];
+
+    public function __construct(Request $request)
+    {
+        // Listen to Livewire views
+        Livewire::listen('view:render', function(View $view) use ($request) {
+            /** @var \Livewire\Component $component */
+            $component = $view->getData()['_instance'];
+
+            // Create an unique name for each compoent
+            $key = $component->getName() . ' #' .$component->id;
+
+            $data = [
+                'data' => $component->getPublicPropertiesDefinedBySubClass(),
+            ];
+
+            if ($request->request->get('id') == $component->id) {
+                $data['oldData'] = $request->request->get('data');
+                $data['actionQueue'] = $request->request->get('actionQueue');
+            }
+
+            $data['name'] = $component->getName();
+            $data['view'] = $view->name();
+            $data['component'] = get_class($component);
+            $data['id'] = $component->id;
+
+            $this->data[$key] = $this->formatVar($data);
+        });
+    }
+
+    public function collect()
+    {
+        return ['data' => $this->data, 'count' => count($this->data)];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'livewire';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        return [
+            "livewire" => [
+                "icon" => "bolt",
+                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
+                "map" => "livewire.data",
+                "default" => "{}"
+            ],
+            'livewire:badge' => [
+                'map' => 'livewire.count',
+                'default' => 0
+            ]
+        ];
+    }
+}

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -412,6 +412,17 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
+        if ($this->shouldCollect('livewire', true) && $this->app->bound('livewire')) {
+            try {
+                $livewireCollector = $this->app->make('Barryvdh\Debugbar\DataCollector\LivewireCollector');
+                $this->addCollector($livewireCollector);
+            } catch (\Exception $e){
+                $this->addThrowable(
+                    new Exception('Cannot add Livewire Collector: ' . $e->getMessage(), $e->getCode(), $e)
+                );
+            }
+        }
+
         if ($this->shouldCollect('mail', true) && class_exists('Illuminate\Mail\MailServiceProvider')) {
             try {
                 $mailer = $this->app['mailer']->getSwiftMailer();


### PR DESCRIPTION
Adds a collector for Livewire to show the rendered components. When calling actions, it also shows the old data (from the request) and the action queue.

Simple counter
![ezgif-2-2f225348c337](https://user-images.githubusercontent.com/973269/82727227-83287080-9ce9-11ea-9aaf-173b6a3e560e.gif)

https://github.com/breadthe/laravel-livewire-demo
![ezgif-2-dd10b656a07d](https://user-images.githubusercontent.com/973269/82727367-57f25100-9cea-11ea-8c65-23cc48cad41c.gif)
