### PR TITLE
Move route definition into separate file

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,6 +26,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->mergeConfigFrom($configPath, 'debugbar');
+        
+        $this->loadRoutesFrom(realpath(__DIR__.'/debugbar-routes.php'));
 
         $this->app->alias(
             DataFormatter::class,
@@ -65,45 +67,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
-
-        $routeConfig = [
-            'namespace' => 'Barryvdh\Debugbar\Controllers',
-            'prefix' => $this->app['config']->get('debugbar.route_prefix'),
-            'domain' => $this->app['config']->get('debugbar.route_domain'),
-            'middleware' => [DebugbarEnabled::class],
-        ];
-
-        $this->getRouter()->group($routeConfig, function($router) {
-            $router->get('open', [
-                'uses' => 'OpenHandlerController@handle',
-                'as' => 'debugbar.openhandler',
-            ]);
-
-            $router->get('clockwork/{id}', [
-                'uses' => 'OpenHandlerController@clockwork',
-                'as' => 'debugbar.clockwork',
-            ]);
-
-            $router->get('telescope/{id}', [
-                'uses' => 'TelescopeController@show',
-                'as' => 'debugbar.telescope',
-            ]);
-            
-            $router->get('assets/stylesheets', [
-                'uses' => 'AssetController@css',
-                'as' => 'debugbar.assets.css',
-            ]);
-
-            $router->get('assets/javascript', [
-                'uses' => 'AssetController@js',
-                'as' => 'debugbar.assets.js',
-            ]);
-
-            $router->delete('cache/{key}/{tags?}', [
-                'uses' => 'CacheController@delete',
-                'as' => 'debugbar.cache.delete',
-            ]);
-        });
 
         $this->registerMiddleware(InjectDebugbar::class);
     }

--- a/src/debugbar-routes.php
+++ b/src/debugbar-routes.php
@@ -1,3 +1,5 @@
+<?php
+
 $routeConfig = [
     'namespace' => 'Barryvdh\Debugbar\Controllers',
     'prefix' => $this->app['config']->get('debugbar.route_prefix'),

--- a/src/debugbar-routes.php
+++ b/src/debugbar-routes.php
@@ -1,0 +1,38 @@
+$routeConfig = [
+    'namespace' => 'Barryvdh\Debugbar\Controllers',
+    'prefix' => $this->app['config']->get('debugbar.route_prefix'),
+    'domain' => $this->app['config']->get('debugbar.route_domain'),
+    'middleware' => [DebugbarEnabled::class],
+];
+
+$this->app['router']->group($routeConfig, function($router) {
+    $router->get('open', [
+        'uses' => 'OpenHandlerController@handle',
+        'as' => 'debugbar.openhandler',
+    ]);
+
+    $router->get('clockwork/{id}', [
+        'uses' => 'OpenHandlerController@clockwork',
+        'as' => 'debugbar.clockwork',
+    ]);
+
+    $router->get('telescope/{id}', [
+        'uses' => 'TelescopeController@show',
+        'as' => 'debugbar.telescope',
+    ]);
+
+    $router->get('assets/stylesheets', [
+        'uses' => 'AssetController@css',
+        'as' => 'debugbar.assets.css',
+    ]);
+
+    $router->get('assets/javascript', [
+        'uses' => 'AssetController@js',
+        'as' => 'debugbar.assets.js',
+    ]);
+
+    $router->delete('cache/{key}/{tags?}', [
+        'uses' => 'CacheController@delete',
+        'as' => 'debugbar.cache.delete',
+    ]);
+});


### PR DESCRIPTION
I have a use-case where I need to flush and reload different routes to change context. When doing this, you lose any routes that can't be manually reloaded.  Since these routes are defined in the provider itself, I have no way to re-register them.

As a solution, I've moved the routes into their own file.