### PR TITLE
[queries] Support double question mark

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -126,7 +126,6 @@ class QueryCollector extends PDOCollector
                     ? "/(?<!\?)\?(?=(?:[^'\\\']*'[^'\\']*')*[^'\\\']*$)(?!\?)/"
                     : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
-
                 // Mimic bindValue and only quote non-integer and non-float data types
                 if (!is_int($binding) && !is_float($binding)) {
                     $binding = $pdo->quote($binding);
@@ -195,8 +194,8 @@ class QueryCollector extends PDOCollector
             $hints[] = '<code>LIMIT</code> without <code>ORDER BY</code> causes non-deterministic results, depending on the query execution plan';
         }
         if (preg_match('/LIKE\\s[\'"](%.*?)[\'"]/i', $query, $matches)) {
-            $hints[] = 	'An argument has a leading wildcard character: <code>' . $matches[1]. '</code>.
-                                The predicate with this argument is not sargable and cannot use an index if one exists.';
+            $hints[] = 'An argument has a leading wildcard character: <code>' . $matches[1]. '</code>.
+                The predicate with this argument is not sargable and cannot use an index if one exists.';
         }
         return $hints;
     }

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -123,8 +123,9 @@ class QueryCollector extends PDOCollector
                 // nested in quotes, while we iterate through the bindings
                 // and substitute placeholders by suitable values.
                 $regex = is_numeric($key)
-                    ? "/\?(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/"
+                    ? "/(?<!\?)\?(?=(?:[^'\\\']*'[^'\\']*')*[^'\\\']*$)(?!\?)/"
                     : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
+
 
                 // Mimic bindValue and only quote non-integer and non-float data types
                 if (!is_int($binding) && !is_float($binding)) {
@@ -181,8 +182,8 @@ class QueryCollector extends PDOCollector
         }
         if (preg_match('/ORDER BY RAND()/i', $query)) {
             $hints[] = '<code>ORDER BY RAND()</code> is slow, try to avoid if you can.
-				You can <a href="http://stackoverflow.com/questions/2663710/how-does-mysqls-order-by-rand-work" target="_blank">read this</a>
-				or <a href="http://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function" target="_blank">this</a>';
+                You can <a href="http://stackoverflow.com/questions/2663710/how-does-mysqls-order-by-rand-work" target="_blank">read this</a>
+                or <a href="http://stackoverflow.com/questions/1244555/how-can-i-optimize-mysqls-order-by-rand-function" target="_blank">this</a>';
         }
         if (strpos($query, '!=') !== false) {
             $hints[] = 'The <code>!=</code> operator is not standard. Use the <code>&lt;&gt;</code> operator to test for inequality instead.';
@@ -195,7 +196,7 @@ class QueryCollector extends PDOCollector
         }
         if (preg_match('/LIKE\\s[\'"](%.*?)[\'"]/i', $query, $matches)) {
             $hints[] = 	'An argument has a leading wildcard character: <code>' . $matches[1]. '</code>.
-								The predicate with this argument is not sargable and cannot use an index if one exists.';
+                                The predicate with this argument is not sargable and cannot use an index if one exists.';
         }
         return $hints;
     }

--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -15,7 +15,10 @@ class QueryFormatter extends DataFormatter
      */
     public function formatSql($sql)
     {
-        return trim(preg_replace("/\s*\n\s*/", "\n", $sql));
+		$sql = preg_replace("/\?(?=(?:[^'\\\']*'[^'\\']*')*[^'\\\']*$)(?:\?)/", '?', $sql);
+		$sql = trim(preg_replace("/\s*\n\s*/", "\n", $sql));
+
+		return $sql;
     }
 
     /**

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -20,7 +20,7 @@ class QueryCollectorTest extends TestCase
         /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
         $collector  = $this->debugbar()->getCollector('queries');
         $collector->addQuery(
-            "SELECT ('[1, 2, 3]'::jsonb ?? ?) as a, ('[4, 5, 6]'::jsonb ??| ?) as b, 'hello world ?' as c",
+            "SELECT ('[1, 2, 3]'::jsonb ?? ?) as a, ('[4, 5, 6]'::jsonb ??| ?) as b, 'hello world ? example ??' as c",
             [3, '{4}'],
             0,
             $this->app['db']->connection()
@@ -31,7 +31,7 @@ class QueryCollectorTest extends TestCase
 
             tap(Arr::first($collection['statements']), function (array $statement) {
                 $this->assertEquals([3, '{4}'], $statement['bindings']);
-                $this->assertEquals("SELECT ('[1, 2, 3]'::jsonb ? 3) as a, ('[4, 5, 6]'::jsonb ?| '{4}') as b, 'hello world ?' as c", $statement['sql']);
+                $this->assertEquals("SELECT ('[1, 2, 3]'::jsonb ? 3) as a, ('[4, 5, 6]'::jsonb ?| '{4}') as b, 'hello world ? example ??' as c", $statement['sql']);
             });
         });
     }

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -2,14 +2,9 @@
 
 namespace Barryvdh\Debugbar\Tests\DataCollector;
 
-use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\Tests\TestCase;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 
 class QueryCollectorTest extends TestCase
 {

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -31,7 +31,7 @@ class QueryCollectorTest extends TestCase
 
             tap(Arr::first($collection['statements']), function (array $statement) {
                 $this->assertEquals([3, '{4}'], $statement['bindings']);
-                $this->assertEquals("SELECT ('[1, 2, 3]'::jsonb ?? 3) as a, ('[4, 5, 6]'::jsonb ??| '{4}') as b, 'hello world ?' as c", $statement['sql']);
+                $this->assertEquals("SELECT ('[1, 2, 3]'::jsonb ? 3) as a, ('[4, 5, 6]'::jsonb ?| '{4}') as b, 'hello world ?' as c", $statement['sql']);
             });
         });
     }

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\DataCollector\QueryCollector;
+use Barryvdh\Debugbar\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class QueryCollectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_replaces_question_marks_bindings_correctly()
+    {
+        $this->loadLaravelMigrations();
+
+        $this->debugbar()->boot();
+
+        /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
+        $collector  = $this->debugbar()->getCollector('queries');
+        $collector->addQuery(
+            "SELECT ('[1, 2, 3]'::jsonb ?? ?) as a, ('[4, 5, 6]'::jsonb ??| ?) as b, 'hello world ?' as c",
+            [3, '{4}'],
+            0,
+            $this->app['db']->connection()
+        );
+
+        tap($collector->collect(), function (array $collection) {
+            $this->assertEquals(1, $collection['nb_statements']);
+
+            tap(Arr::first($collection['statements']), function (array $statement) {
+                $this->assertEquals([3, '{4}'], $statement['bindings']);
+                $this->assertEquals("SELECT ('[1, 2, 3]'::jsonb ?? 3) as a, ('[4, 5, 6]'::jsonb ??| '{4}') as b, 'hello world ?' as c", $statement['sql']);
+            });
+        });
+    }
+}


### PR DESCRIPTION
As you may know, since PHP 7.4, it is now possible to use special operators (known mainly under PostgreSQL as `?`, `?|`, `?&`...) by doubling the question mark (`??`, `??|`, `??&`...). The formatter didn't support this feature, it's done now.

In addition, the formatter replaces the question mark escape so that it can be easily copied and pasted to debug a query. I also implemented a test on this feature.

```sql
SELECT ('[1, 2, 3]'::jsonb ?? ?) as a, ('[4, 5, 6]'::jsonb ??| ?) as b, 'hello world ? example ??' as c

Bindings : [3, '{4}']
```
```diff
-SELECT ('[1, 2, 3]'::jsonb 3'{4}' ?) as a, ('[4, 5, 6]'::jsonb ??| ?) as b, 'hello world ? example ??' as c
+SELECT ('[1, 2, 3]'::jsonb ? 3) as a, ('[4, 5, 6]'::jsonb ?| '{4}') as b, 'hello world ? example ??' as c
```