### PR TITLE
Option to show copy button for SQL queries

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -150,6 +150,7 @@ return [
                 'types' => ['SELECT'],     // // workaround ['SELECT'] only. https://github.com/barryvdh/laravel-debugbar/issues/888 ['SELECT', 'INSERT', 'UPDATE', 'DELETE']; for MySQL 5.6.3+
             ],
             'hints'             => false,    // Show hints for common mistakes
+            'show_copy'         => false,    // Show copy button next to the query
         ],
         'mail' => [
             'full_log' => false

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -18,6 +18,7 @@ class QueryCollector extends PDOCollector
     protected $explainQuery = false;
     protected $explainTypes = ['SELECT']; // ['SELECT', 'INSERT', 'UPDATE', 'DELETE']; for MySQL 5.6.3+
     protected $showHints = false;
+    protected $showCopyButton = false;
     protected $reflection = [];
     protected $backtraceExcludePaths = [
         '/vendor/laravel/framework/src/Illuminate/Database',
@@ -52,6 +53,16 @@ class QueryCollector extends PDOCollector
     public function setShowHints($enabled = true)
     {
         $this->showHints = $enabled;
+    }
+
+    /**
+     * Show or hide copy button next to the queries
+     *
+     * @param boolean $enabled
+     */
+    public function setShowCopyButton($enabled = true)
+    {
+        $this->showCopyButton = $enabled;
     }
 
     /**
@@ -162,6 +173,7 @@ class QueryCollector extends PDOCollector
             'explain' => $explainResults,
             'connection' => $connection->getDatabaseName(),
             'hints' => $this->showHints ? $hints : null,
+            'show_copy' => $this->showCopyButton,
         ];
 
         if ($this->timeCollector !== null) {
@@ -425,6 +437,7 @@ class QueryCollector extends PDOCollector
             'explain' => [],
             'connection' => $connection->getDatabaseName(),
             'hints' => null,
+            'show_copy' => false,
         ];
     }
 
@@ -454,6 +467,7 @@ class QueryCollector extends PDOCollector
                 'params' => [],
                 'bindings' => $query['bindings'],
                 'hints' => $query['hints'],
+                'show_copy' => $query['show_copy'],
                 'backtrace' => array_values($query['source']),
                 'duration' => $query['time'],
                 'duration_str' => ($query['type'] == 'transaction') ? '' : $this->formatDuration($query['time']),

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -321,6 +321,10 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setShowHints(true);
             }
 
+            if ($this->app['config']->get('debugbar.options.db.show_copy', false)) {
+                $queryCollector->setShowCopyButton(true);
+            }
+
             $this->addCollector($queryCollector);
 
             try {

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -25,6 +25,33 @@
             this.set('exclude', excludedLabels);
         },
 
+        onCopyToClipboard: function (el) {
+            var code = $(el).parent('li').find('code').get(0);
+            var copy = function () {
+                try {
+                    document.execCommand('copy');
+                    alert('Query copied to the clipboard');
+                } catch (err) {
+                    console.log('Oops, unable to copy');
+                }
+            };
+            var select = function (node) {
+                if (document.selection) {
+                    var range = document.body.createTextRange();
+                    range.moveToElementText(node);
+                    range.select();
+                } else if (window.getSelection) {
+                    var range = document.createRange();
+                    range.selectNodeContents(node);
+                    window.getSelection().removeAllRanges();
+                    window.getSelection().addRange(range);
+                }
+                copy();
+                window.getSelection().removeAllRanges();
+            };
+            select(code);
+        },
+
         render: function() {
             this.$status = $('<div />').addClass(csscls('status')).appendTo(this.$el);
 
@@ -70,6 +97,16 @@
                 if (typeof(stmt.is_success) != 'undefined' && !stmt.is_success) {
                     li.addClass(csscls('error'));
                     li.append($('<span />').addClass(csscls('error')).text("[" + stmt.error_code + "] " + stmt.error_message));
+                }
+                if (stmt.show_copy) {
+                    $('<span title="Copy to clipboard" />')
+                        .addClass(csscls('copy-clipboard'))
+                        .css('cursor', 'pointer')
+                        .on('click', function (event) {
+                            self.onCopyToClipboard(this);
+                            event.stopPropagation();
+                        })
+                        .appendTo(li);
                 }
 
                 var table = $('<table><tr><th colspan="2">Metadata</th></tr></table>').addClass(csscls('params')).appendTo(li);


### PR DESCRIPTION
Displays copy button for each SQL query. Base functionality taken from parent maximebf/debugbar package. Related to https://github.com/barryvdh/laravel-debugbar/issues/702

![image](https://user-images.githubusercontent.com/3586184/89102501-2db7c080-d40a-11ea-8c84-3a22f9b85e18.png)
