### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "3.2-dev"
+            "dev-master": "3.5-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Related: #1095

Allows us to run this:

`composer require barryvdh/laravel-debugbar:"^3.5" --dev`

Instead of:

`composer require barryvdh/laravel-debugbar:"dev-master" --dev`

Examples:
https://semver.mwl.be/#!?package=barryvdh%2Flaravel-debugbar&version=^3.5&minimum-stability=dev
https://semver.mwl.be/#!?package=barryvdh%2Flaravel-debugbar&version=dev-master&minimum-stability=dev
