### PR TITLE
Fix "array to string conversion" in 3.5.0

### DIFF
--- a/src/DataFormatter/SimpleFormatter.php
+++ b/src/DataFormatter/SimpleFormatter.php
@@ -61,7 +61,7 @@ class SimpleFormatter extends DataFormatter
 
             if ($deep) {
                 $args = [$indent, implode(sprintf(", \n%s", $indent), $a), str_repeat('  ', $depth - 1)];
-                return sprintf("[\n%s%s\n%s]", $args);
+                return sprintf("[\n%s%s\n%s]", ...$args);
             }
 
             $s = sprintf('[%s]', implode(', ', $a));


### PR DESCRIPTION
This commit broke the debugbar: https://github.com/barryvdh/laravel-debugbar/commit/51c8ea3ab2c56664ebc9718ca68e342827bd7851#diff-8a2d53e88e43b04de0cc4f64882d91feR63 since sprintf() uses multiple arguments, it doesn't accept an array of arguments.

@barryvdh if you could review this ASAP that would be great