### PR TITLE
Add debug_backtrace_limit configuration option

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -219,8 +219,8 @@ return [
      | Backtrace stack limit
      |--------------------------------------------------------------------------
      |
-	 | By default, the DebugBar limits the number of frames returned by the 'debug_backtrace()' function.
-	 | If you need larger stacktraces, you can increase this number. Setting it to 0 will result in no limit.
+     | By default, the DebugBar limits the number of frames returned by the 'debug_backtrace()' function.
+     | If you need larger stacktraces, you can increase this number. Setting it to 0 will result in no limit.
      */
     'debug_backtrace_limit' => 50,
 ];

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -213,4 +213,14 @@ return [
      | Possible values: auto, light, dark
      */
     'theme' => 'auto',
+
+    /*
+     |--------------------------------------------------------------------------
+     | Backtrace stack limit
+     |--------------------------------------------------------------------------
+     |
+	 | By default, the DebugBar limits the number of frames returned by the 'debug_backtrace()' function.
+	 | If you need larger stacktraces, you can increase this number. Setting it to 0 will result in no limit.
+     */
+    'debug_backtrace_limit' => 50,
 ];

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -245,7 +245,7 @@ class QueryCollector extends PDOCollector
      */
     protected function findSource()
     {
-        $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT, 50);
+        $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT, app('config')->get('debugbar.debug_backtrace_limit', 50));
 
         $sources = [];
 


### PR DESCRIPTION
This adds a configuration option for the debug_backtrace_limit. In some cases 50 is too low.