### PR TITLE
Add explanation to config for how Ajax requests are identified.

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -65,6 +65,9 @@ return [
      | you can use this option to disable sending the data through the headers.
      |
      | Optionally, you can also send ServerTiming headers on ajax requests for the Chrome DevTools.
+     |
+     | Note for your request to be identified as ajax requests they must either send the header
+     | X-Requested-With with the value XMLHttpRequest (most JS libraries send this), or have application/json as a Accept header.
      */
 
     'capture_ajax' => true,


### PR DESCRIPTION
I was having an issue where my ajax requested were not being added to the Ajax dropdown, even though I had capture_ajax set to true etc.

Turned out to be because ajax requests were ```application/vnd.siren+json``` rather than ```application/json``` and `X-Requested-With` was not set in the JS library I was using.