### PR TITLE
Exclude higher order proxy by default

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -21,6 +21,7 @@ class QueryCollector extends PDOCollector
     protected $showCopyButton = false;
     protected $reflection = [];
     protected $backtraceExcludePaths = [
+        '/vendor/laravel/framework/src/Illuminate/Support/HigherOrderTapProxy',
         '/vendor/laravel/framework/src/Illuminate/Database',
         '/vendor/laravel/framework/src/Illuminate/Events',
         '/vendor/barryvdh/laravel-debugbar',


### PR DESCRIPTION
When running query inside `tap()`:

```php
<?php
use App\User;
use Illuminate\Http\Request;

public function patch(User $user, Request $request)
{
  return tap($user)->update($request->input('user'));
}
```

backtrace will contains `Illuminate\Support\HigherOrderTapProxy`` ,

although we can set custom exclude path in our config file, I think it's good to have default exclude rules include all stuffs that shipped with Laravel :)