### PR TITLE
Remove unnecessary, deprecated defer codes

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,13 +14,6 @@ use Illuminate\Support\Collection;
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Register the service provider.
      *
      * @return void
@@ -118,15 +111,5 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $kernel = $this->app[Kernel::class];
         $kernel->pushMiddleware($middleware);
-    }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return ['debugbar', 'command.debugbar.clear', DataFormatterInterface::class, LaravelDebugbar::class];
     }
 }


### PR DESCRIPTION
Since Laravel 5.8 , deferred providers should implement DeferrableProvider contract instead of using $defer . $defer is deprecated.
https://laravel.com/docs/5.8/upgrade#deferred-service-providers

Also since this provider is not deferred It is unnecessary to have a provides method
Ref : https://laravel.com/docs/8.x/providers#deferred-providers