### PR TITLE
Add AppStorage driver

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -34,12 +34,12 @@ return [
      */
     'storage' => [
         'enabled'    => true,
-        'driver'     => 'file', // redis, file, pdo, app, custom
+        'driver'     => 'file', // redis, file, pdo, socket, custom
         'path'       => storage_path('debugbar'), // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)
         'provider'   => '', // Instance of StorageInterface for custom driver
-        'hostname'   => '127.0.0.1', // Hostname to use with the "app" driver
-        'port'       => 2304, // Port to use with the "app" driver
+        'hostname'   => '127.0.0.1', // Hostname to use with the "socket" driver
+        'port'       => 2304, // Port to use with the "socket" driver
     ],
 
     /*

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -34,10 +34,12 @@ return [
      */
     'storage' => [
         'enabled'    => true,
-        'driver'     => 'file', // redis, file, pdo, custom
+        'driver'     => 'file', // redis, file, pdo, app, custom
         'path'       => storage_path('debugbar'), // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)
         'provider'   => '', // Instance of StorageInterface for custom driver
+        'hostname'   => '127.0.0.1', // Hostname to use with the "app" driver
+        'port'       => 2304, // Port to use with the "app" driver
     ],
 
     /*

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -15,6 +15,7 @@ use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\DataCollector\SessionCollector;
 use Barryvdh\Debugbar\DataCollector\RequestCollector;
 use Barryvdh\Debugbar\DataCollector\ViewCollector;
+use Barryvdh\Debugbar\Storage\AppStorage;
 use Barryvdh\Debugbar\Storage\FilesystemStorage;
 use DebugBar\Bridge\MonologCollector;
 use DebugBar\Bridge\SwiftMailer\SwiftLogCollector;
@@ -1098,6 +1099,11 @@ class LaravelDebugbar extends DebugBar
                 case 'custom':
                     $class = $config->get('debugbar.storage.provider');
                     $storage = $this->app->make($class);
+                    break;
+                case 'app':
+                    $hostname = $config->get('debugbar.storage.hostname', '127.0.0.1');
+                    $port = $config->get('debugbar.storage.port', 2304);
+                    $storage = new AppStorage($hostname, $port);
                     break;
                 case 'file':
                 default:

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -15,7 +15,7 @@ use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\DataCollector\SessionCollector;
 use Barryvdh\Debugbar\DataCollector\RequestCollector;
 use Barryvdh\Debugbar\DataCollector\ViewCollector;
-use Barryvdh\Debugbar\Storage\AppStorage;
+use Barryvdh\Debugbar\Storage\SocketStorage;
 use Barryvdh\Debugbar\Storage\FilesystemStorage;
 use DebugBar\Bridge\MonologCollector;
 use DebugBar\Bridge\SwiftMailer\SwiftLogCollector;
@@ -1103,7 +1103,7 @@ class LaravelDebugbar extends DebugBar
                 case 'app':
                     $hostname = $config->get('debugbar.storage.hostname', '127.0.0.1');
                     $port = $config->get('debugbar.storage.port', 2304);
-                    $storage = new AppStorage($hostname, $port);
+                    $storage = new SocketStorage($hostname, $port);
                     break;
                 case 'file':
                 default:

--- a/src/Storage/AppStorage.php
+++ b/src/Storage/AppStorage.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Barryvdh\Debugbar\Storage;
+
+use DebugBar\Storage\StorageInterface;
+
+class AppStorage implements StorageInterface
+{
+
+    protected $hostname;
+    protected $port;
+    protected $socket;
+
+    /**
+     * @param string $hostname The hostname to use for the socket
+     * @param int $port The port to use for the socket
+     */
+    public function __construct($hostname, $port)
+    {
+        $this->hostname = $hostname;
+        $this->port = $port;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    function save($id, $data)
+    {
+        $socketIsFresh = !$this->socket;
+
+        if (!$this->socket = $this->socket ?: $this->createSocket()) {
+            return false;
+        }
+
+        $encodedPayload = json_encode([
+            'id' => $id,
+            'base_path' => base_path(),
+            'app' => config('app.name'),
+            'data' => $data,
+        ]);
+
+        $encodedPayload = strlen($encodedPayload).'#'.$encodedPayload;
+
+        set_error_handler([self::class, 'nullErrorHandler']);
+        try {
+            if (-1 !== stream_socket_sendto($this->socket, $encodedPayload)) {
+                return true;
+            }
+            if (!$socketIsFresh) {
+                stream_socket_shutdown($this->socket, \STREAM_SHUT_RDWR);
+                fclose($this->socket);
+                $this->socket = $this->createSocket();
+            }
+            if (-1 !== stream_socket_sendto($this->socket, $encodedPayload)) {
+                return true;
+            }
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private static function nullErrorHandler($t, $m)
+    {
+        // no-op
+    }
+
+    protected function createSocket()
+    {
+        set_error_handler([self::class, 'nullErrorHandler']);
+        try {
+            return stream_socket_client("tcp://{$this->hostname}:{$this->port}");
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    function get($id)
+    {
+        //
+    }
+
+    /**
+     * @inheritDoc
+     */
+    function find(array $filters = array(), $max = 20, $offset = 0)
+    {
+        //
+    }
+
+    /**
+     * @inheritDoc
+     */
+    function clear()
+    {
+        //
+    }
+}

--- a/src/Storage/SocketStorage.php
+++ b/src/Storage/SocketStorage.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Debugbar\Storage;
 
 use DebugBar\Storage\StorageInterface;
 
-class AppStorage implements StorageInterface
+class SocketStorage implements StorageInterface
 {
 
     protected $hostname;


### PR DESCRIPTION
This PR adds an additional "AppStorage" driver, which allows you to connect to the open-source Laravel DebugBar [companion app](https://github.com/beyondcode/laravel-debugbar-companion)

![Screenshot 2021-01-05 at 12 18 16](https://user-images.githubusercontent.com/804684/103641086-76dbe580-4f51-11eb-8974-2b6d61afcc1c.png)

The companion app works by opening a socket on the computer running the application. The Laravel DebugBar then sends the collected data JSON encoded to this socket, where the app listens for the data and displays it.

Since finding, clearing, or getting stored data does not apply in this case, I left those methods empty. The app/UI takes care of this.

The socket sending implementation itself is taken from the Symfony Dump Server, which works in a similar way.