### PR TITLE
Fix storage name when creating the storage instance

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1100,7 +1100,7 @@ class LaravelDebugbar extends DebugBar
                     $class = $config->get('debugbar.storage.provider');
                     $storage = $this->app->make($class);
                     break;
-                case 'app':
+                case 'socket':
                     $hostname = $config->get('debugbar.storage.hostname', '127.0.0.1');
                     $port = $config->get('debugbar.storage.port', 2304);
                     $storage = new SocketStorage($hostname, $port);


### PR DESCRIPTION
This is a follow up of #1141 - I forgot to rename the key in the switch/case statement. This fixes the issue :) 
Sorry about that