### PR TITLE
Fix Closure Middleware Can't Converted As String

### DIFF
--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -2,6 +2,7 @@
 
 namespace Barryvdh\Debugbar\DataCollector;
 
+use Closure;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\Renderable;
 use Illuminate\Http\Request;
@@ -95,7 +96,9 @@ class RouteCollector extends DataCollector implements Renderable
      */
     protected function getMiddleware($route)
     {
-        return implode(', ', $route->middleware());
+        return implode(', ', array_map(function ($middleware) {
+            return $middleware instanceof Closure ? 'Closure' : $middleware;
+        }, $route->middleware()));
     }
 
     /**


### PR DESCRIPTION
The PR based on an error I encountered when used a Closure middleware.

![error](https://user-images.githubusercontent.com/37969970/104092823-66b16680-52c1-11eb-8473-03eaab25bd7f.png)
![route](https://user-images.githubusercontent.com/37969970/104092827-6dd87480-52c1-11eb-8668-f2e98c30cca6.png)
