### PR TITLE
Fix route:list middleware full classes

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -76,7 +76,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
-        if (!$this->app->runningInConsole()) {
+        if (!$this->app->runningInConsole() && !$this->app->runningUnitTests()) {
             $this->registerMiddleware(InjectDebugbar::class);
         }
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -76,7 +76,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
-        $this->registerMiddleware(InjectDebugbar::class);
+        if (!$this->app->runningInConsole()) {
+            $this->registerMiddleware(InjectDebugbar::class);
+        }
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -76,9 +76,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
-        if (!$this->app->runningInConsole() && !$this->app->runningUnitTests()) {
-            $this->registerMiddleware(InjectDebugbar::class);
-        }
+        // See if unit tests fail on reason
+        $this->registerMiddleware(InjectDebugbar::class);
     }
 
     /**


### PR DESCRIPTION
https://github.com/barryvdh/laravel-debugbar/issues/1107

Currently with installed debug bar `route:list` expands  middleware aliases (at least `auth` one) to a full class name. This is because the debug bar runs Http\Kernel in CLI scope and adds middlewares.

![зображення](https://user-images.githubusercontent.com/422942/108648336-a3c56700-74c3-11eb-9f7f-a4d3206c3d93.png)
