### PR TITLE
Add view generation time to timeline tab when 'time' and 'view' collectors are enabled.

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -158,6 +158,7 @@ return [
             'full_log' => false,
         ],
         'views' => [
+            'timeline' => false,  // Add the views to the timeline (Experimental)
             'data' => false,    //Note: Can slow down the application, because the data can be quite large..
         ],
         'route' => [

--- a/src/DebugbarViewEngine.php
+++ b/src/DebugbarViewEngine.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\Debugbar;
+
+use Illuminate\Contracts\View\Engine;
+
+class DebugbarViewEngine implements Engine
+{
+    /**
+     * @var Engine
+     */
+    protected $engine;
+
+    /**
+     * @var LaravelDebugbar
+     */
+    protected $laravelDebugbar;
+
+    /**
+     * @param  Engine  $engine
+     * @param  LaravelDebugbar  $laravelDebugbar
+     */
+    public function __construct(Engine $engine, LaravelDebugbar $laravelDebugbar)
+    {
+        $this->engine = $engine;
+        $this->laravelDebugbar = $laravelDebugbar;
+    }
+
+    /**
+     * @param  string  $path
+     * @param  array  $data
+     * @return string
+     */
+    public function get($path, array $data = [])
+    {
+        return $this->laravelDebugbar->measure($path, function () use ($path, $data) {
+            return $this->engine->get($path, $data);
+        });
+    }
+
+    /**
+     * NOTE: This is done to support other Engine swap (example: Livewire).
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        return $this->engine->$name(...$arguments);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -68,7 +68,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
                 $shouldTrackViewTime = $laravelDebugbar->isEnabled() &&
                     $laravelDebugbar->shouldCollect('time', true) &&
-                    $laravelDebugbar->shouldCollect('views', true);
+                    $laravelDebugbar->shouldCollect('views', true) && 
+                    $application['config']->get('debugbar.options.views.timeline', false);
 
                 if (! $shouldTrackViewTime) {
                     /* Do not swap the engine to save performance */


### PR DESCRIPTION
Hi,

This pull request is a proposition to add the time spent generating views to the timeline tab.

I implemented this feature a while ago in this package: https://github.com/vdauchy/laravel-debugbar-view-meter so anybody can check it already.

I just thinks that this might be good to nativelly support it.

Thanks :-)