### PR TITLE
fix: db collector octane compatibility

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -342,7 +342,7 @@ class LaravelDebugbar extends DebugBar
                         $db,
                         $queryCollector
                     ) {
-                        if (!$this->shouldCollect('db', true)) {
+                        if (!app(static::class)->shouldCollect('db', true)) {
                             return; // Issue 776 : We've turned off collecting after the listener was attached
                         }
                         // Laravel 5.2 changed the way some core events worked. We must account for
@@ -359,7 +359,7 @@ class LaravelDebugbar extends DebugBar
                         }
 
                         //allow collecting only queries slower than a specified amount of milliseconds
-                        $threshold = $this->app['config']->get('debugbar.options.db.slow_threshold', false);
+                        $threshold = app('config')->get('debugbar.options.db.slow_threshold', false);
                         if (!$threshold || $time > $threshold) {
                             $queryCollector->addQuery((string)$query, $bindings, $time, $connection);
                         }


### PR DESCRIPTION
This patch should address #1174, although it does so rather crudely. A better solution would maybe be to re-register the listeners every request? I'm interested to hear any feedback on this.