### PR TITLE
Queries tab: show duration as a progressbar on a background

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -207,7 +207,7 @@ class QueryCollector extends PDOCollector
      * @version $Id$
      * @access public
      * @param string $query
-     * @return string
+     * @return string[]
      */
     protected function performQueryAnalysis($query)
     {
@@ -489,6 +489,19 @@ class QueryCollector extends PDOCollector
                     'row_count' => $explain->rows,
                     'stmt_id' => $explain->id,
                 ];
+            }
+        }
+
+        if ($totalTime > 0) {
+            // For showing background measure on Queries tab
+            $start_percent = 0;
+            foreach ($statements as $i => $statement) {
+                $width_percent = $statement['duration'] / $totalTime * 100;
+                $statements[$i] = array_merge($statement, [
+                    'start_percent' => round($start_percent, 3),
+                    'width_percent' => round($width_percent, 3),
+                ]);
+                $start_percent += $width_percent;
             }
         }
 

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -777,3 +777,19 @@ div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-stmt-id:before,
 div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before {
     margin-right: 6px!important;
 }
+
+.phpdebugbar-widgets-list-item .phpdebugbar-widgets-bg-measure {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.phpdebugbar-widgets-bg-measure .phpdebugbar-widgets-value {
+    position: absolute;
+    height: 100%;
+    opacity: 0.2;
+    background: red;
+}

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -65,6 +65,14 @@
                 } else {
                     $('<code />').addClass(csscls('sql')).html(PhpDebugBar.Widgets.highlight(stmt.sql, 'sql')).appendTo(li);
                 }
+                if (stmt.width_percent) {
+                    $('<div></div>').addClass(csscls('bg-measure')).append(
+                        $('<div></div>').addClass(csscls('value')).css({
+                            left: stmt.start_percent + '%',
+                            width: Math.max(stmt.width_percent, 0.01) + '%',
+                        })
+                    ).appendTo(li);
+                }
                 if (stmt.duration_str) {
                     $('<span title="Duration" />').addClass(csscls('duration')).text(stmt.duration_str).appendTo(li);
                 }


### PR DESCRIPTION
Hi guys, 

This change makes it easy to notice long queries:

<img width="1397" alt="Screen Shot 2021-05-31 at 8 54 28 PM" src="https://user-images.githubusercontent.com/331627/120257472-52fda100-c25e-11eb-93b5-0dbc8218f014.png">

Please let me know what I can improve,
Thanks!