### PR TITLE
Fix: Skip the loop when the 'duration' key is not set in the '' array…

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -481,7 +481,7 @@ class QueryCollector extends PDOCollector
                 'connection' => $query['connection'],
             ];
 
-            //Add the results from the explain as new rows
+            // Add the results from the explain as new rows
             foreach ($query['explain'] as $explain) {
                 $statements[] = [
                     'sql' => " - EXPLAIN # {$explain->id}: `{$explain->table}` ({$explain->select_type})",
@@ -496,18 +496,26 @@ class QueryCollector extends PDOCollector
         if ($totalTime > 0) {
             // For showing background measure on Queries tab
             $start_percent = 0;
+
             foreach ($statements as $i => $statement) {
+                
+                if (! isset($statement['duration'])) {
+                    continue;
+                }
+                
                 $width_percent = $statement['duration'] / $totalTime * 100;
+
                 $statements[$i] = array_merge($statement, [
                     'start_percent' => round($start_percent, 3),
                     'width_percent' => round($width_percent, 3),
                 ]);
+
                 $start_percent += $width_percent;
             }
         }
 
         $nb_statements = array_filter($queries, function ($query) {
-            return $query['type'] == 'query';
+            return $query['type'] === 'query';
         });
 
         $data = [


### PR DESCRIPTION
This PR should fix the issue: https://github.com/barryvdh/laravel-debugbar/issues/1191

We've noticed that for the statements of the type 'explain' the 'duration' key is not set. 

So, the solution agreed is just to skip the loop when this key is not there.