### PR TITLE
Handle array and object bindings

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -33,6 +33,16 @@ class QueryFormatter extends DataFormatter
             if (is_string($binding) && !mb_check_encoding($binding, 'UTF-8')) {
                 $binding = '[BINARY DATA]';
             }
+
+            if (is_array($binding)) {
+                $binding = $this->checkBindings($binding);
+                $binding = '[' . implode(',', $binding) . ']';
+            }
+
+            if (is_object($binding)) {
+                $binding =  json_encode($binding);
+            }
+
         }
 
         return $bindings;

--- a/tests/DataFormatter/QueryFormatterTest.php
+++ b/tests/DataFormatter/QueryFormatterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataFormatter;
+
+use Barryvdh\Debugbar\DataFormatter\QueryFormatter;
+use Barryvdh\Debugbar\Tests\TestCase;
+
+class QueryFormatterTest extends TestCase
+{
+    public function testItFormatsArrayBindings()
+    {
+
+        $bindings = [
+            'some string',
+            [
+                'string',
+                "Another ' string",
+                [
+                    'nested',
+                    'array'
+                ]
+            ],
+        ];
+
+        $queryFormatter = new QueryFormatter;
+
+        $output = $queryFormatter->checkBindings($bindings);
+
+        $this->assertSame($output, ["some string", "[string,Another ' string,[nested,array]]"]);
+    }
+
+    public function testItFormatsObjectBindings()
+    {
+        $object = new \StdClass;
+        $object->attribute1 = 'test';
+
+        $bindings = [
+            'some string',
+            $object
+        ];
+
+        $queryFormatter = new QueryFormatter;
+
+        $output = $queryFormatter->checkBindings($bindings);
+
+        $this->assertSame($output, ['some string', '{"attribute1":"test"}']);
+    }
+
+}


### PR DESCRIPTION
The additions in this PR allow non-scalar bindings which are possible with ArangoDB (and perhaps other NoSQL databases as well).

In version 3.6 the Debugbar would generate errors trying to use array's as strings for example.

In this fix arrays are recursively mapped to strings and objects are JSON encoded so they deliver strings. These will then be processed as before.