### PR TITLE
Fix SQL binding with $ not presented correctly in full query

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -164,7 +164,7 @@ class QueryCollector extends PDOCollector
                     }
                 }
 
-                $query = preg_replace($regex, $binding, $query, 1);
+                $query = preg_replace($regex, addcslashes($binding, '$'), $query, 1);
             }
         }
 

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -37,4 +37,25 @@ SQL
             });
         });
     }
+
+    public function testDollarBindingsArePresentedCorrectly()
+    {
+        debugbar()->boot();
+
+        /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
+        $collector = debugbar()->getCollector('queries');
+        $collector->addQuery(
+            "SELECT a FROM b WHERE c = ? AND d = ? AND e = ?",
+            ['$10', '$2y$10_DUMMY_BCRYPT_HASH', '$_$$_$$$_$2_$3'],
+            0,
+            $this->app['db']->connection()
+        );
+
+        tap(Arr::first($collector->collect()['statements']), function (array $statement) {
+            $this->assertEquals(
+                "SELECT a FROM b WHERE c = '$10' AND d = '$2y$10_DUMMY_BCRYPT_HASH' AND e = '\$_$\$_$$\$_$2_$3'", 
+                $statement['sql']
+            );
+        });
+    }
 }


### PR DESCRIPTION
### Background 
In `QueryCollector`, `preg_replace` is used with a SQL parameter `binding` as the `replacement` variable, where dollar characters followed by an integer from 0–99 are interpreted as references to captures, and not displayed literally. 

### The issue
This causes the *displayed* query in Debugbar to be incorrect, even though the bindings are correct. See the image below for an example, where the bindings for `firstName` and `lastName` are presented incorrectly when displaying the full query.
![image](https://user-images.githubusercontent.com/25909128/122634308-b8b2af80-d0dd-11eb-96cd-6627277027e5.png)

The test included in this PR fails prior to the PR:
![image](https://user-images.githubusercontent.com/25909128/122634343-f1eb1f80-d0dd-11eb-9950-9fea39247064.png)

I noticed the problem while working with re-hashing passwords, since the bcrypt hash format is `$2y$ROUNDS$SALT_HASH`. I'm guessing this issue hasn't been noticed before since it is not very common in other cases to store `$n` values, for instance money is usually stored with the currency separately.

### Solution
Add `addcslashes($binding, '$')` to escape any dollar signs and present these literally.
