### PR TITLE
Register Telescope route only when Telescope is installed

### DIFF
--- a/src/debugbar-routes.php
+++ b/src/debugbar-routes.php
@@ -18,10 +18,12 @@ app('router')->group($routeConfig, function ($router) {
         'as' => 'debugbar.clockwork',
     ]);
 
-    $router->get('telescope/{id}', [
-        'uses' => 'TelescopeController@show',
-        'as' => 'debugbar.telescope',
-    ]);
+    if (class_exists(\Laravel\Telescope\Telescope::class)) {
+        $router->get('telescope/{id}', [
+            'uses' => 'TelescopeController@show',
+            'as' => 'debugbar.telescope',
+        ]);
+    }
 
     $router->get('assets/stylesheets', [
         'uses' => 'AssetController@css',


### PR DESCRIPTION
This PR adds a `class_exists(\Laravel\Telescope\Telescope::class)` check so that the `debugbar.telescope` route is only registered if Telescope is actually installed.

Although there is **usually** no way to access this route when Telescope isn't installed, because the UI for it is hidden, the route is still registered and available to the application and to other packages. This causes "Class `Laravel\Telescope\Contracts\EntriesRepository` does not exist" errors in code that tries to instantiate or inspect route actions, like Tighten's [Ziggy](https://github.com/tighten/ziggy) package—we inspect route parameter argument types to resolve route-model bindings, but this leads to issues like tighten/ziggy#358 and tighten/ziggy#437 when Debugbar is installed but Telescope is not, because the route is registered even though the classes it uses don't exist.