### PR TITLE
Add support Lumen

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Session\SessionManager;
 use Illuminate\Support\Collection;
 use Illuminate\View\Engines\EngineResolver;
 use Barryvdh\Debugbar\Facade as DebugBar;
+use Illuminate\Container\Container;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -56,7 +57,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->app->extend(
             'view.engine.resolver',
-            function (EngineResolver $resolver, Application $application): EngineResolver {
+            function (EngineResolver $resolver, Container $application): EngineResolver {
                 $laravelDebugbar = $application->make(LaravelDebugbar::class);
 
                 $shouldTrackViewTime = $laravelDebugbar->isEnabled() &&


### PR DESCRIPTION
To works debugbar in lumen (and fix issue #1200), i'm suggest to use `\Illuminate\Container\Container` instead `Illuminate\Foundation\Application` (that not support  `Laravel\Lumen\Application`) in function argument on extend 'view.engine.resolver'. `\Illuminate\Container\Container` extends both `Laravel` and `Lumen` Applications.