### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "maximebf/debugbar": "^1.16.3",
+        "maximebf/debugbar": "^1.17.0",
         "illuminate/routing": "^6|^7|^8",
         "illuminate/session": "^6|^7|^8",
         "illuminate/support": "^6|^7|^8",


### PR DESCRIPTION
hi.
i updated composer.json.
because current master use 

```
 "maximebf/debugbar": "^1.16.3",
```

this version.but it has a bug

in src/DebugBar/DataFormatter/DebugBarVarDumper.php#getAssets method

```
/**
     * Returns assets required for rendering variables.
     *
     * @return array
     */
    public function getAssets() {
        $dumper = $this->getDumper();
        $dumper->setDumpHeader(null); // this will cause the default dump header to regenerate
        return array(
            'inline_head' => array(
                'html_var_dumper' => $dumper->getDumpHeaderByDebugBar(),
            ),
        );
    }
```

$dumper->setDumpHeader(null) throw error,because this arg 'null' isn't accepted on laravel newest version.

with v1.17.0 on php-debugbar  it works properly.

could you accept?