### PR TITLE
Rename Facade to Debugbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
                 "Barryvdh\\Debugbar\\ServiceProvider"
             ],
             "aliases": {
-                "Debugbar": "Barryvdh\\Debugbar\\Facade"
+                "Debugbar": "Barryvdh\\Debugbar\\Facades\\Debugbar"
             }
         }
     },

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ And the default collectors:
  - MemoryCollector
  - ExceptionsCollector
 
-It also provides a Facade interface for easy logging Messages, Exceptions and Time
+It also provides a facade interface (`Debugbar`) for easy logging Messages, Exceptions and Time
 
 ## Installation
 
@@ -65,7 +65,7 @@ Barryvdh\Debugbar\ServiceProvider::class,
 If you want to use the facade to log messages, add this to your facades in app.php:
 
 ```php
-'Debugbar' => Barryvdh\Debugbar\Facade::class,
+'Debugbar' => Barryvdh\Debugbar\Facades\Debugbar::class,
 ```
 
 The profiler is enabled by default, if you have APP_DEBUG=true. You can override that in the config (`debugbar.enabled`) or by setting `DEBUGBAR_ENABLED` in your `.env`. See more options in `config/debugbar.php`

--- a/src/Facades/Debugbar.php
+++ b/src/Facades/Debugbar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Barryvdh\Debugbar;
+namespace Barryvdh\Debugbar\Facades;
 
 use DebugBar\DataCollector\DataCollectorInterface;
 
@@ -19,11 +19,15 @@ use DebugBar\DataCollector\DataCollectorInterface;
  * @method static void notice(mixed $message)
  * @method static void warning(mixed $message)
  *
- * @deprecated Renamed to \Barryvdh\Debugbar\Facades\Debugbar
- * @see \Barryvdh\Debugbar\Facades\Debugbar
- *
  * @see \Barryvdh\Debugbar\LaravelDebugbar
  */
-class Facade extends \Barryvdh\Debugbar\Facades\Debugbar
+class Debugbar extends \Illuminate\Support\Facades\Facade
 {
+    /**
+     * {@inheritDoc}
+     */
+    protected static function getFacadeAccessor()
+    {
+        return LaravelDebugbar::class;
+    }
 }

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Barryvdh\Debugbar\Tests;
 
-use Barryvdh\Debugbar\Facade;
+use Barryvdh\Debugbar\Facades\Debugbar;
 use Barryvdh\Debugbar\ServiceProvider;
 
 class BrowserTestCase extends \Orchestra\Testbench\Dusk\TestCase
@@ -31,6 +31,6 @@ class BrowserTestCase extends \Orchestra\Testbench\Dusk\TestCase
      */
     protected function getPackageAliases($app)
     {
-        return ['Debugbar' => Facade::class];
+        return ['Debugbar' => Debugbar::class];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Barryvdh\Debugbar\Tests;
 
-use Barryvdh\Debugbar\Facade;
+use Barryvdh\Debugbar\Facades\Debugbar;
 use Barryvdh\Debugbar\ServiceProvider;
 use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -31,7 +31,7 @@ class TestCase extends Orchestra
      */
     protected function getPackageAliases($app)
     {
-        return ['Debugbar' => Facade::class];
+        return ['Debugbar' => Debugbar::class];
     }
 
     /**


### PR DESCRIPTION
Creating the facade as a class named Debugbar enables better auto completion for IDEs and the like.
To avoid naming conflicts it exists in a separate folder Facades.

For backwards compatibility of existing code the current Facade persists as a class that extends the Debugbar facade class. This should allow for a minor update to the package with a deprecation notice on existing code importing the Facade explicitly.

Closes https://github.com/barryvdh/laravel-debugbar/issues/1216