### PR TITLE
[fix] Emulate quote bindings for drivers that don't support quoting

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -158,7 +158,13 @@ class QueryCollector extends PDOCollector
                 // Mimic bindValue and only quote non-integer and non-float data types
                 if (!is_int($binding) && !is_float($binding)) {
                     if ($pdo) {
-                        $binding = $pdo->quote($binding);
+                        // Emulate quote bindings when the PDO driver doesn't
+                        // support quoting.
+                        try {
+                            $binding = $pdo->quote($binding);
+                        } catch (\Exception $e) {
+                            $binding = $this->emulateQuote($binding);
+                        }
                     } else {
                         $binding = $this->emulateQuote($binding);
                     }


### PR DESCRIPTION
Some PDO drivers (in my case an ODBC driver) don't support quoting, in which case `QueryCollector` will throw on line 161.

Since we already have an `emulateQuote` method available, this PR simply catches the exception and uses the `emulateQuote` method instead.