### PR TITLE
Feature/ide links full path

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -89,7 +89,7 @@ class ViewCollector extends TwigCollector
         ];
 
         if ($this->getXdebugLink($path)) {
-            $template['xdebug_link'] = $this->getXdebugLink($path);
+            $template['xdebug_link'] = $this->getXdebugLink(realpath($view->getPath()));
         }
 
         $this->templates[] = $template;

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -22,7 +22,7 @@ class ViewCollectorTest extends TestCase
 
         tap(Arr::first($collector->collect()['templates']), function (array $template) {
             $this->assertEquals(
-                'vscode://file'.realpath(__DIR__.'/../resources/views/dashboard.blade.php').':1',
+                'vscode://file/'.realpath(__DIR__.'/../resources/views/dashboard.blade.php').':1',
                 $template['xdebug_link']['url'],
             );
         });

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+
+class ViewCollectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testIdeLinksAreAbsolutePaths()
+    {
+        debugbar()->boot();
+
+        /** @var \Barryvdh\Debugbar\DataCollector\ViewCollector $collector */
+        $collector = debugbar()->getCollector('views');
+        $collector->addView(
+            view('dashboard')
+        );
+
+        tap(Arr::first($collector->collect()['templates']), function (array $template) {
+            $this->assertEquals(
+                'vscode://file'.realpath(__DIR__.'/../resources/views/dashboard.blade.php').':1',
+                $template['xdebug_link']['url'],
+            );
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,6 +48,7 @@ class TestCase extends Orchestra
 
         $this->addWebRoutes($router);
         $this->addApiRoutes($router);
+        $this->addViewPaths();
     }
 
     /**
@@ -78,5 +79,10 @@ class TestCase extends Orchestra
                 return response()->json(['status' => 'pong']);
             }
         ]);
+    }
+
+    protected function addViewPaths()
+    {
+        config(['view.paths' => array_merge(config('view.paths'), [__DIR__.'/resources/views'])]);
     }
 }

--- a/tests/resources/views/dashboard.blade.php
+++ b/tests/resources/views/dashboard.blade.php
@@ -1,0 +1,3 @@
+<div>
+    <p>Basic view</p>
+</div>


### PR DESCRIPTION
Thanks for an awesome dev helper utility! This is a minor suggestion to improve DX for the Views panel.

Problem: the “link” icon to an IDE (VS Code specifically) contains a relative path to the project root, but VS Code tells me that a file does not exist. It seems to expect an absolute path on the filesystem.

Solution: provide an absolute path to the file instead of a relative path.