### PR TITLE
Add information about Laravel Octane

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,16 @@ You can also only display the js or css vendors, by setting it to 'js' or 'css'.
 php artisan vendor:publish --provider="Barryvdh\Debugbar\ServiceProvider"
 ```
 
+### Laravel with Octane:
+
+Make sure to add LaravelDebugbar to your flush list in `config/octane.php`.
+
+```php
+    'flush' => [
+        \Barryvdh\Debugbar\LaravelDebugbar::class,
+    ],
+```
+
 ### Lumen:
 
 For Lumen, register a different Provider in `bootstrap/app.php`:


### PR DESCRIPTION
Not including the LaravelDebugbar in the "flush" list results in the debugbar displaying data for older requests. (When using the Swoole driver) 
I have not tested with Roadrunner but it should avoid any eventual problems there as well.

So just adding some info to the installation process. Please feel free to change anything if necessary.