### PR TITLE
fix: #1236 maximebf/debugbar version issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "maximebf/debugbar": "^1.16.3",
+        "maximebf/debugbar": "^1.17.1",
         "illuminate/routing": "^6|^7|^8",
         "illuminate/session": "^6|^7|^8",
         "illuminate/support": "^6|^7|^8",


### PR DESCRIPTION
Issue #1236 was occurring due to the stale version of the maximebf/php-debugbar package. In this PR, I've simply updated the version of that package.