### PR TITLE
Add file:line location, to each item in the messages panel, from where the function call was made

### DIFF
--- a/src/DataCollector/MessagesCollector.php
+++ b/src/DataCollector/MessagesCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+use Illuminate\Support\Str;
+use DebugBar\DataCollector\MessagesCollector as DebugBarMessagesCollector;
+
+class MessagesCollector extends DebugBarMessagesCollector
+{
+    /**
+     * Adds a message
+     *
+     * A message can be anything from an object to a string
+     *
+     * @param mixed $message
+     * @param string $label
+     */
+    public function addMessage($message, $label = 'info', $isString = true)
+    {
+        $messageText = $message;
+        $messageHtml = null;
+
+        if (!is_string($message)) {
+            // Send both text and HTML representations; the text version is used for searches
+            $messageText = $this->getDataFormatter()->formatVar($message);
+            if ($this->isHtmlVarDumperUsed()) {
+                $messageHtml = $this->getVarDumper()->renderVar($message);
+            }
+            $isString = false;
+        }
+
+        $stacktrace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
+        $calledFromStackItem = array_pop($stacktrace);
+
+        $stackFile = Str::of($calledFromStackItem['file']);
+        // when called from views, resolve to non-cached versions of the same
+        $calledFromFile = $stackFile->contains('storage/framework/views')
+            ? Str::of(
+                debugbar()->getCollector('views')->collect()['templates'][0]['name']
+            )->match('/\(([\w\.\/]+)/')
+            : $stackFile;
+
+        $calledFileBasePath = str_replace(base_path() . '/', '', $calledFromFile);
+        $calledFromLine = $calledFromStackItem['line'];
+
+        if ($label === 'error') {
+            $isString = true;
+        }
+
+        $this->messages[] = array(
+            'file_name' => $calledFromFile->basename(),
+            'file_path' => $calledFromFile->remove(base_path() . '/'),
+            'file_line' => $calledFromLine,
+            'message' => $messageText,
+            'message_html' => $messageHtml,
+            'is_string' => $isString,
+            'label' => $label,
+            'time' => microtime(true)
+        );
+    }
+}

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -23,6 +23,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
         $this->cssVendors['fontawesome'] = __DIR__ . '/Resources/vendor/font-awesome/style.css';
         $this->jsFiles['laravel-sql'] = __DIR__ . '/Resources/sqlqueries/widget.js';
         $this->jsFiles['laravel-cache'] = __DIR__ . '/Resources/cache/widget.js';
+        $this->jsFiles['laravel-messages'] = __DIR__ . '/Resources/messages/widget.js';
 
         $theme = config('debugbar.theme', 'auto');
         switch ($theme) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -9,6 +9,7 @@ use Barryvdh\Debugbar\DataCollector\FilesCollector;
 use Barryvdh\Debugbar\DataCollector\GateCollector;
 use Barryvdh\Debugbar\DataCollector\LaravelCollector;
 use Barryvdh\Debugbar\DataCollector\LogsCollector;
+use Barryvdh\Debugbar\DataCollector\MessagesCollector;
 use Barryvdh\Debugbar\DataCollector\ModelsCollector;
 use Barryvdh\Debugbar\DataCollector\MultiAuthCollector;
 use Barryvdh\Debugbar\DataCollector\QueryCollector;
@@ -24,7 +25,6 @@ use DebugBar\DataCollector\ConfigCollector;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\ExceptionsCollector;
 use DebugBar\DataCollector\MemoryCollector;
-use DebugBar\DataCollector\MessagesCollector;
 use Barryvdh\Debugbar\DataCollector\PhpInfoCollector;
 use DebugBar\DataCollector\RequestDataCollector;
 use DebugBar\DataCollector\TimeDataCollector;
@@ -1049,7 +1049,7 @@ class LaravelDebugbar extends DebugBar
     public function addMessage($message, $label = 'info')
     {
         if ($this->hasCollector('messages')) {
-            /** @var \DebugBar\DataCollector\MessagesCollector $collector */
+            /** @var \Barryvdh\DebugBar\DataCollector\MessagesCollector $collector */
             $collector = $this->getCollector('messages');
             $collector->addMessage($message, $label);
         }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -353,6 +353,20 @@ div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar input {
     height: 15px;
 }
 
+div.phpdebugbar-widgets-messages li .phpdebugbar-widgets-label-separator,
+div.phpdebugbar-widgets-messages li .phpdebugbar-widgets-label-called-from {
+    float: right;
+    color: #666;
+    margin-bottom: 1px;
+    padding-left: 5px;
+    text-transform: lowercase;
+}
+
+div.phpdebugbar-widgets-messages li .phpdebugbar-widgets-label-called-from {
+    border-bottom: 1px dotted #666;
+    cursor: help;
+}
+
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-label,
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector {
     padding: 1px 0px 0px 10px;
@@ -404,6 +418,10 @@ div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-w
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter[rel="warning"],
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded[rel="warning"] {
     background-color: #f99400;
+}
+
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter-file {
+    background-color: #b56500;
 }
 
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter:hover {

--- a/src/Resources/messages/widget.js
+++ b/src/Resources/messages/widget.js
@@ -1,0 +1,149 @@
+(function ($) {
+
+    var csscls = PhpDebugBar.utils.makecsscls('phpdebugbar-widgets-');
+
+    /**
+     * Widget for the MessagesCollector
+     *
+     * Extends the original MessagesCollector class under the hood
+     */
+    var MessagesWidget = PhpDebugBar.Widgets.MessagesWidget = PhpDebugBar.Widgets.MessagesWidget.extend({
+
+        render: function() {
+            var self = this;
+
+            this.$list = new PhpDebugBar.Widgets.ListWidget({ itemRenderer: function(li, value) {
+                    if (value.message_html) {
+                        var val = $('<span />').addClass(csscls('value')).html(value.message_html).appendTo(li);
+                    } else {
+                        var m = value.message;
+                        if (m.length > 100) {
+                            m = m.substr(0, 100) + "...";
+                        }
+
+                        var val = $('<span />').addClass(csscls('value')).text(m).appendTo(li);
+                        if (!value.is_string || value.message.length > 100) {
+                            var prettyVal = value.message;
+                            if (!value.is_string) {
+                                prettyVal = null;
+                            }
+                            li.css('cursor', 'pointer').click(function () {
+                                if (val.hasClass(csscls('pretty'))) {
+                                    val.text(m).removeClass(csscls('pretty'));
+                                } else {
+                                    prettyVal = prettyVal || createCodeBlock(value.message, 'php');
+                                    val.addClass(csscls('pretty')).empty().append(prettyVal);
+                                }
+                            });
+                        }
+                    }
+
+                    if (value.collector) {
+                        $('<span />').addClass(csscls('collector')).text(value.collector).prependTo(li);
+                    }
+                    if (value.label) {
+                        val.addClass(csscls(value.label));
+
+                        var $wrapper = $('<div />').addClass(csscls('label-wrap'));
+
+                        $('<span />').addClass(csscls('label-called-from'))
+                            .attr('title', value.file_path)
+                            .text(value.file_name + ':' + value.file_line)
+                            .appendTo($wrapper);
+                        $('<span />').addClass(csscls('label-separator')).text('// ').appendTo($wrapper);
+                        $('<span />').addClass(csscls('label')).text(value.label).appendTo($wrapper);
+
+                        $wrapper.prependTo(li);
+                    }
+                }});
+
+            this.$list.$el.appendTo(this.$el);
+            this.$toolbar = $('<div><i class="phpdebugbar-fa phpdebugbar-fa-search"></i></div>').addClass(csscls('toolbar')).appendTo(this.$el);
+
+            $('<input type="text" />')
+                .on('change', function() { self.set('search', this.value); })
+                .appendTo(this.$toolbar);
+
+            this.bindAttr('data', function(data) {
+                this.set({ exclude: [], search: '' });
+                this.$toolbar.find(csscls('.filter')).remove();
+
+                var filters = [], self = this;
+                for (var i = 0; i < data.length; i++) {
+                    if (!data[i].label || $.inArray(data[i].label, filters) > -1) {
+                        continue;
+                    }
+                    filters.push(data[i].label);
+                    $('<a />')
+                        .addClass(csscls('filter'))
+                        .text(data[i].label)
+                        .attr('rel', data[i].label)
+                        .on('click', function() { self.onFilterClick(this); })
+                        .appendTo(this.$toolbar);
+                }
+
+                for (var i = 0; i < data.length; i++) {
+                    if (!data[i].file_name || $.inArray(data[i].file_name, filters) > -1) {
+                        continue;
+                    }
+                    filters.push(data[i].file_name);
+                    $('<a />')
+                        .addClass(csscls('filter') + ' ' + csscls('filter-file'))
+                        .text(data[i].file_name)
+                        .attr('rel', data[i].label)
+                        .attr('data-file_name', data[i].file_name)
+                        .on('click', function() { self.onFilterClick(this); })
+                        .appendTo(this.$toolbar);
+                }
+            });
+
+            this.bindAttr(['exclude', 'excludeFiles', 'search'], function() {
+                var data = this.get('data'),
+                    exclude = this.get('exclude'),
+                    excludeFiles = this.get('excludeFiles'),
+                    search = this.get('search'),
+                    caseless = false,
+                    fdata = [];
+
+                if (search && search === search.toLowerCase()) {
+                    caseless = true;
+                }
+
+                for (var i = 0; i < data.length; i++) {
+                    var message = caseless ? data[i].message.toLowerCase() : data[i].message;
+
+                    if ((!search || message.indexOf(search) > -1)) {
+
+                        if ((!data[i].label || $.inArray(data[i].label, exclude) === -1)
+                                && (!data[i].file_name || $.inArray(data[i].file_name, excludeFiles) === -1)
+                        ) {
+                            fdata.push(data[i]);
+                        }
+
+                    }
+                }
+
+                this.$list.set('data', fdata);
+            });
+        },
+
+        onFilterClick: function(el) {
+            $(el).toggleClass(csscls('excluded'));
+
+            var excludedLabels = [];
+            var excludedFiles = [];
+            this.$toolbar.find(csscls('.filter') + csscls('.excluded')).each(function() {
+                if (this.dataset.file_name) {
+                    excludedFiles.push(this.dataset.file_name);
+                    return;
+                }
+
+                excludedLabels.push(this.rel);
+            });
+
+            this.set('exclude', $.unique(excludedLabels));
+            this.set('excludeFiles', $.unique(excludedFiles));
+        }
+    });
+
+})(PhpDebugBar.$);


### PR DESCRIPTION
This PR fixes issue #1206.

Adds `<file>:<line>` info to each message item that is dumped.
When called from a view, resolves path to the non-compiled view path.

Additional changes:
- hovering over the added info, gives full path to the file, relative to the application route (2nd screenshot)
- files that are called are added to the clickable filter, so they can be used standalone, or be combined with other filters

![PR1](https://user-images.githubusercontent.com/2469719/136272285-b1663534-f1a3-4e91-acc8-ad22d55c7262.png)

![PR2](https://user-images.githubusercontent.com/2469719/136272289-78f37aa5-abbe-494c-98df-99692684f95e.png)