### PR TITLE
Avoid passing null to internal functions as it is deprecated in PHP 8.1

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -147,7 +147,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             return $uris;
         }
 
-        if (substr($uri, 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri)) {
+        if (substr($uri ?? '', 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri ?? '')) {
             return $uri;
         }
         return rtrim($root, '/') . "/$uri";


### PR DESCRIPTION
Added this null checks to prevent those 2 warnings in PHP 8.1 when passing null to internal functions.
Using the resolution 2 as proposed in the RFC: https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

<img width="1686" alt="Screen Shot 2021-10-27 at 23 29 01" src="https://user-images.githubusercontent.com/3855603/139086271-197faaa6-f5a3-4187-85d4-cba9db35cbe5.png">


