### PR TITLE
Return the result from the callback in `measure` helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -73,9 +73,10 @@ if (!function_exists('measure')) {
      *
      * @param string $label
      * @param \Closure $closure
+     * @return mixed
      */
     function measure($label, \Closure $closure)
     {
-        debugbar()->measure($label, $closure);
+        return debugbar()->measure($label, $closure);
     }
 }


### PR DESCRIPTION
This updates the helper to match the measure function in `src/LaravelDebugbar.php`.

I came across this while attempting to use the helper function to measure the time it takes to receive data from an API.

With this change, the following function will now work (where it doesn't without):

```php
$data = measure('Api request', function() {  
    return Http::get("https://api.example.com/api/stats");
});                                                                       
```