### PR TITLE
Make service provider deferrable to allow for custom (filesystem) service provider

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -109,7 +109,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider implements Def
     {
         return [
             LaravelDebugbar::class,
-            'command.debugbar.clear'
+            'command.debugbar.clear',
+            'view.engine.resolver'
         ];
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Barryvdh\Debugbar\Middleware\InjectDebugbar;
 use DebugBar\DataFormatter\DataFormatter;
 use DebugBar\DataFormatter\DataFormatterInterface;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Session\SessionManager;
@@ -14,7 +15,7 @@ use Illuminate\Support\Collection;
 use Illuminate\View\Engines\EngineResolver;
 use Barryvdh\Debugbar\Facade as DebugBar;
 
-class ServiceProvider extends \Illuminate\Support\ServiceProvider
+class ServiceProvider extends \Illuminate\Support\ServiceProvider implements DeferrableProvider
 {
     /**
      * Register the service provider.

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -101,6 +101,19 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider implements Def
     }
 
     /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            LaravelDebugbar::class,
+            'command.debugbar.clear'
+        ];
+    }
+
+    /**
      * Bootstrap the application events.
      *
      * @return void


### PR DESCRIPTION
As described on a [similar PR in the ide-helper](https://github.com/barryvdh/laravel-ide-helper/pull/914), when a serviceprovider is not deferrable, the service provider of a package is registered before any custom service providers in a project are registered.

I am currently working on a project with a custom FileSystemServiceProvider, where requiring the debugbar causes an error in Container.php on line 879 `Target class [files] does not exist` and Container.php on line 877 `Class "files" does not exist`. This issue was also mentioned in #1112.

<details>
    <summary>Simplest bug reproduction in code</summary>

## ./app/Providers/CustomFileSystemProvider.php

```php
<?php
declare(strict_types=1);

namespace App\Providers;

use Illuminate\Filesystem\FilesystemServiceProvider;

class CustomFileSystemServiceProvider extends FilesystemServiceProvider
{
    // Overwrite anything in here, or keep this empty for a simple reproduction
}
```

## ./config/app.php

```php
'providers' => [
    //Illuminate\Filesystem\FilesystemServiceProvider::class,
    App\Providers\CustomFileSystemServiceProvider::class,
```
</details>

This PR adds the DeferrableProvider interface to the package's service provider, and adds the provided services to a `provides` method so these services can be registered when needed.