### PR TITLE
set xdebug ini

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,5 +28,6 @@
     <php>
         <env name="DEBUGBAR_ENABLED" value="true"/>
         <env name="DB_CONNECTION" value="testing"/>
+        <ini name="xdebug.file_link_format" value="vscode://file/%f:%l"/>
     </php>
 </phpunit>

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -10,6 +10,13 @@ class ViewCollectorTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ini_set('xdebug.file_link_format', 'vscode://file/%f:%l');
+    }
+
     public function testIdeLinksAreAbsolutePaths()
     {
         debugbar()->boot();

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -12,13 +12,6 @@ class ViewCollectorTest extends TestCase
 
     public function testIdeLinksAreAbsolutePaths()
     {
-        if (!ini_get('xdebug.file_link_format')) {
-            $this->markTestSkipped(
-                'The Xdebug extension is not available.'
-            );
-            return;
-        }
-
         debugbar()->boot();
 
         /** @var \Barryvdh\Debugbar\DataCollector\ViewCollector $collector */

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -19,6 +19,13 @@ class ViewCollectorTest extends TestCase
 
     public function testIdeLinksAreAbsolutePaths()
     {
+        if (!ini_get('xdebug.file_link_format')) {
+            $this->markTestSkipped(
+                'The Xdebug extension is not available.'
+            );
+            return;
+        }
+
         debugbar()->boot();
 
         /** @var \Barryvdh\Debugbar\DataCollector\ViewCollector $collector */


### PR DESCRIPTION
Context: https://github.com/barryvdh/laravel-debugbar/pull/1224#issuecomment-966907943, #1256

> The tests didn't run properly, skipped them with #1256 for now. I think it relies on the specific format being available, so maybe set that in the setUp()?

@barryvdh I tried using `ini_set('xdebug.file_link_format', 'vscode://file/%f:%l')` in `setUp()` and it just wouldn’t set it. I also tried the `setUpBeforeClass()` method from phpunit to hook in a bit earlier and that didn’t work either.

Setting it in the phpunit.xml.dist file was the only way I was able to add that in so it would run.