### PR TITLE
Fix substr and preg_replace parameter warnings on PHP 8.1

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -147,6 +147,8 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             return $uris;
         }
 
+	$uri = $uri ?? '';
+
         if (substr($uri ?? '', 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri ?? '')) {
             return $uri;
         }

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -147,7 +147,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             return $uris;
         }
 
-	$uri = $uri ?? '';
+        $uri = $uri ?? '';
 
         if (substr($uri ?? '', 0, 1) === '/' || preg_match('/^([a-zA-Z]+:\/\/|[a-zA-Z]:\/|[a-zA-Z]:\\\)/', $uri ?? '')) {
             return $uri;


### PR DESCRIPTION
This implements my fix for the substr and preg_replace parameter warning messages which have appeared on PHP 8.1, as described in #1261 .