### PR TITLE
Fix direction rtl for children of debugbar div

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -11,7 +11,7 @@ div.phpdebugbar {
     z-index: 6000000;
 }
 
-div.phpdebugbar *  {
+div.phpdebugbar * {
     direction: ltr;
     text-align: left;
 }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -11,6 +11,11 @@ div.phpdebugbar {
     z-index: 6000000;
 }
 
+div.phpdebugbar *  {
+    direction: ltr;
+    text-align: left;
+}
+
 div.phpdebugbar-openhandler-overlay {
     z-index: 6000001;
     cursor: pointer;


### PR DESCRIPTION
By default if I want to use rtl:

```css
* {
    direction: rtl;
    text-align: right;
}
```
But it'll override ```direction: ltr``` given to ```div.phpdebugbar ``` 's childrens.

![debugbar](https://user-images.githubusercontent.com/68776630/143781307-6574453c-744f-473e-9c3e-2d23bc395a90.png)
![overriten](https://user-images.githubusercontent.com/68776630/143781380-569160e2-50d5-4b7f-adab-d45183779703.png)

So i gave direction to the children directly.
