### PR TITLE
Update Debugbar.php

### DIFF
--- a/src/Facades/Debugbar.php
+++ b/src/Facades/Debugbar.php
@@ -28,6 +28,6 @@ class Debugbar extends \Illuminate\Support\Facades\Facade
      */
     protected static function getFacadeAccessor()
     {
-        return LaravelDebugbar::class;
+        return \Barryvdh\Debugbar\LaravelDebugbar::class;
     }
 }


### PR DESCRIPTION
corrected the namespace for LaravelDebugbar in Barryvdh\Debugbar\Facades\Debugbar. This was causing the error "Target class [Barryvdh\Debugbar\Facades\LaravelDebugbar] does not exist"