### PR TITLE
Add editor support for vscode remote links

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -49,7 +49,8 @@ return [
     |
     | Choose your preferred editor to use when clicking file name.
     |
-    | Supported: "phpstorm", "vscode", "vscode-insiders", "vscodium", "textmate", "emacs",
+    | Supported: "phpstorm", "vscode", "vscode-insiders", "vscode-remote",
+    |            "vscode-insiders-remote", "vscodium", "textmate", "emacs",
     |            "sublime", "atom", "nova", "macvim", "idea", "netbeans",
     |            "xdebug", "espresso"
     |

--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -39,6 +39,8 @@ class RouteCollector extends DataCollector implements Renderable
         'idea' => 'idea://open?file=%file&line=%line',
         'vscode' => 'vscode://file/%file:%line',
         'vscode-insiders' => 'vscode-insiders://file/%file:%line',
+        'vscode-remote' => 'vscode://vscode-remote/%file:%line',
+        'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/%file:%line',
         'vscodium' => 'vscodium://file/%file:%line',
         'nova' => 'nova://core/open/file?filename=%file&line=%line',
         'xdebug' => 'xdebug://%file@%line',


### PR DESCRIPTION
This PR adds editor support for vscode remote (WSL or SSH) (including insiders).

### Example configuration

```
DEBUGBAR_EDITOR=vscode-remote
DEBUGBAR_REMOTE_SITES_PATH=/home/user/project
DEBUGBAR_LOCAL_SITES_PATH=wsl+Ubuntu-20.04/home/user/project
```

See https://github.com/facade/ignition/pull/420 for more examples.