### PR TITLE
Fix htmlentities PHP warning

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -55,7 +55,9 @@ class QueryFormatter extends DataFormatter
     public function escapeBindings($bindings)
     {
         foreach ($bindings as &$binding) {
-            $binding = htmlentities($binding, ENT_QUOTES, 'UTF-8', false);
+            if (is_string($binding) === true) {
+                $binding = htmlentities($binding, ENT_QUOTES, 'UTF-8', false);
+            }
         }
 
         return $bindings;

--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -55,9 +55,7 @@ class QueryFormatter extends DataFormatter
     public function escapeBindings($bindings)
     {
         foreach ($bindings as &$binding) {
-            if (is_string($binding) === true) {
-                $binding = htmlentities($binding, ENT_QUOTES, 'UTF-8', false);
-            }
+            $binding = htmlentities((string) $binding, ENT_QUOTES, 'UTF-8', false);
         }
 
         return $bindings;


### PR DESCRIPTION
Hi,

this commit fixes PHP Warning on PHP 8.1, when $binding is not a string.