### PR TITLE
Update maximebf/debugbar version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "maximebf/debugbar": "^1.17.2",
+        "maximebf/debugbar": "^1.18.0",
         "illuminate/routing": "^6|^7|^8|^9",
         "illuminate/session": "^6|^7|^8|^9",
         "illuminate/support": "^6|^7|^8|^9",


### PR DESCRIPTION
Update maximebf/debugbar version to 1.18.0 to allow installation on Laravel 9.