### PR TITLE
Add connection name to Queries Tab

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -189,7 +189,7 @@ class QueryCollector extends PDOCollector
             'time' => $time,
             'source' => $source,
             'explain' => $explainResults,
-            'connection' => $connection->getDatabaseName(),
+            'connection' => '[' . $connection->getName() . '] ' . $connection->getDatabaseName(),
             'driver' => $connection->getConfig('driver'),
             'hints' => $this->showHints ? $hints : null,
             'show_copy' => $this->showCopyButton,
@@ -478,6 +478,7 @@ class QueryCollector extends PDOCollector
      */
     public function collect()
     {
+
         $totalTime = 0;
         $queries = $this->queries;
 

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -478,7 +478,6 @@ class QueryCollector extends PDOCollector
      */
     public function collect()
     {
-
         $totalTime = 0;
         $queries = $this->queries;
 


### PR DESCRIPTION
This PR add the connection name before the database name in the query tab. This is super usefull when working with multiple connection (eg master/readonly).

![image](https://user-images.githubusercontent.com/29306492/153717232-d9636a86-61e1-479b-b52a-100c1c8b1cc6.png)
