### PR TITLE
Move registering routes to boot method of ServiceProvider

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,8 +26,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->mergeConfigFrom($configPath, 'debugbar');
 
-        $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
-
         $this->app->alias(
             DataFormatter::class,
             DataFormatterInterface::class
@@ -109,6 +107,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
         $this->registerMiddleware(InjectDebugbar::class);
+
+        $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
     }
 
     /**


### PR DESCRIPTION
According to [Laravel docs](https://laravel.com/docs/9.x/providers#writing-service-providers), registering routes should never happen within the `register` method, as only binding should happen there. In practice, this causes a problem when trying to override/extend the base Laravel `FilesystemServiceProvider`, which combined with registering this package triggers an `Illuminate\Contracts\Container\BindingResolutionException` with message `Target class [files] does not exist.`.

Therefore, moving the registering of routes to the `boot` method looks like a more robust approach to me. See also the example from the [Laravel docs on the `loadRoutesFrom` method](https://laravel.com/docs/9.x/packages#routes).