### PR TITLE
Update Querycollector with SQLite Explain support

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -511,6 +511,41 @@ class QueryCollector extends PDOCollector
                         'type' => 'explain',
                     ];
                 }
+            } elseif ($query['driver'] === 'sqlite') {
+                $vmi  = '<table style="margin:-5px -11px !important;width: 100% !important">';
+                $vmi .= "<thead><tr>
+                    <td>Address</td>
+                    <td>Opcode</td>
+                    <td>P1</td>
+                    <td>P2</td>
+                    <td>P3</td>
+                    <td>P4</td>
+                    <td>P5</td>
+                    <td>Comment</td>
+                    </tr></thead>";
+
+                foreach ($query['explain'] as $explain) {
+                    $vmi .= "<tr>
+                        <td>{$explain->addr}</td>
+                        <td>{$explain->opcode}</td>
+                        <td>{$explain->p1}</td>
+                        <td>{$explain->p2}</td>
+                        <td>{$explain->p3}</td>
+                        <td>{$explain->p4}</td>
+                        <td>{$explain->p5}</td>
+                        <td>{$explain->comment}</td>
+                        </tr>";
+                }
+
+                $vmi .= '</table>';
+
+                $statements[] = [
+                    'sql' => " - EXPLAIN:",
+                    'type' => 'explain',
+                    'params' => [
+                        'Virtual Machine Instructions' => $vmi,
+                    ]
+                ];                
             } else {
                 foreach ($query['explain'] as $explain) {
                     $statements[] = [


### PR DESCRIPTION
This adds support for SQLite EXPLAIN statement. There is no support for EXPLAIN QUERY PLAN yet, as this would require further adjustments to the package config.

I'm not happy with adding HTML to the collector class, maybe we can find a better way of adding it to the widget?

Regarding config changes, I would like to add an option that allows to set which kind of SQL EXPLAIN to use and change the output of explain accordingly.

<img width="1616" alt="sqlite-explain-support" src="https://user-images.githubusercontent.com/85063626/169405201-372121f5-f6b4-4fec-8961-717f42420a4e.png">
