### PR TITLE
Remove symfony/debug dependency

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -19,13 +19,11 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 7.4, 7.3, 7.2]
-                lumen: [8.*, 7.*, 6.*]
+                lumen: [8.*, 7.*]
                 exclude:
                   - lumen: 8.*
                     php: 7.2
                   - lumen: 7.*
-                    php: 8.0
-                  - lumen: 6.*
                     php: 8.0
         name: P${{ matrix.php }} - Lumen${{ matrix.lumen }}
         steps:
@@ -69,7 +67,7 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 7.4, 7.3, 7.2]
-                laravel: [8.*, 7.*, 6.*]
+                laravel: [8.*, 7.*]
                 exclude:
                   - laravel: 8.*
                     php: 7.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 7.4, 7.3, 7.2]
-        laravel: [9.*, 8.*, 6.*, 7.*]
+        laravel: [9.*, 8.*, 7.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 8.*

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "illuminate/routing": "^7|^8|^9",
         "illuminate/session": "^7|^8|^9",
         "illuminate/support": "^7|^8|^9",
-        "symfony/error-handler": "^5|^6",
         "symfony/finder": "^5|^6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "illuminate/routing": "^6|^7|^8|^9",
         "illuminate/session": "^6|^7|^8|^9",
         "illuminate/support": "^6|^7|^8|^9",
-        "symfony/debug": "^4.3|^5|^6",
-        "symfony/finder": "^4.3|^5|^6"
+        "symfony/error-handler": "^4.3|^5|^6",
+        "symfony/finder": "^4.4|^5|^6"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "illuminate/routing": "^6|^7|^8|^9",
         "illuminate/session": "^6|^7|^8|^9",
         "illuminate/support": "^6|^7|^8|^9",
-        "symfony/error-handler": "^4.3|^5|^6",
-        "symfony/finder": "^4.4|^5|^6"
+        "symfony/error-handler": "^4.4|^5|^6",
+        "symfony/finder": "^4.3|^5|^6"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.2.5",
         "maximebf/debugbar": "^1.17.2",
-        "illuminate/routing": "^6|^7|^8|^9",
-        "illuminate/session": "^6|^7|^8|^9",
-        "illuminate/support": "^6|^7|^8|^9",
-        "symfony/error-handler": "^4.4|^5|^6",
-        "symfony/finder": "^4.3|^5|^6"
+        "illuminate/routing": "^7|^8|^9",
+        "illuminate/session": "^7|^8|^9",
+        "illuminate/support": "^7|^8|^9",
+        "symfony/error-handler": "^5|^6",
+        "symfony/finder": "^5|^6"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench-dusk": "^4|^5|^6|^7",
+        "orchestra/testbench-dusk": "^5|^6|^7",
         "phpunit/phpunit": "^8.5|^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },

--- a/src/Middleware/InjectDebugbar.php
+++ b/src/Middleware/InjectDebugbar.php
@@ -2,14 +2,13 @@
 
 namespace Barryvdh\Debugbar\Middleware;
 
-use Error;
 use Closure;
 use Exception;
 use Illuminate\Http\Request;
 use Barryvdh\Debugbar\LaravelDebugbar;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Throwable;
 
 class InjectDebugbar
 {
@@ -65,10 +64,7 @@ class InjectDebugbar
         try {
             /** @var \Illuminate\Http\Response $response */
             $response = $next($request);
-        } catch (Exception $e) {
-            $response = $this->handleException($request, $e);
-        } catch (Error $error) {
-            $e = new FatalThrowableError($error);
+        } catch (Throwable $e) {
             $response = $this->handleException($request, $e);
         }
 
@@ -84,11 +80,11 @@ class InjectDebugbar
      * (Copy from Illuminate\Routing\Pipeline by Taylor Otwell)
      *
      * @param $passable
-     * @param  Exception $e
+     * @param  Throwable $e
      * @return mixed
      * @throws Exception
      */
-    protected function handleException($passable, Exception $e)
+    protected function handleException($passable, $e)
     {
         if (! $this->container->bound(ExceptionHandler::class) || ! $passable instanceof Request) {
             throw $e;


### PR DESCRIPTION
Solves #1319 

The Class `Symfony\Component\Debug\Exception\FatalThrowableError` no longer exists, therefor I just removed it and directly throw the Error instead of wrapping it in another Exception.

From Laravel 7 onwards the report and render function also support `Throwable` instead of only `Exception`

This may also be a point where support for Laravel 7 can be dropped. (If you want only PHP ^8.0 Support, than it could also be considered to drop Laravel 8)
Laravel 6 gets security fixes until September 6th, 2022
Laravel 8 gets bugfixes until July 26th, 2022, security fixes until January 24th, 2023
See https://laravel.com/docs/9.x/releases#support-policy

How you can test these changes:
```json
{
    "repositories": [
        {
            "type": "git",
            "url": "https://github.com/Jubeki/laravel-debugbar"
        }
    ],
    "require-dev": {
        "barryvdh/laravel-debugbar": "dev-migrate-to-symfony-error-handler"
    },
    "minimum-stability": "dev",
    "prefer-stable": true
}
```