### PR TITLE
Fix PHP 8.2 deprecation

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -5,7 +5,6 @@ namespace Barryvdh\Debugbar\DataCollector;
 use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
 use DebugBar\Bridge\Twig\TwigCollector;
 use Illuminate\View\View;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class ViewCollector extends TwigCollector
 {

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -21,7 +21,6 @@ class ViewCollector extends TwigCollector
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
-        $this->name = 'views';
         $this->templates = [];
     }
 


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 8.2 and will be removed in PHP 9.0. This PR fixes a deprecation error on `Barryvdh\Debugbar\DataCollector\ViewCollector` where a dynamic `name` property is created, by removing this property.

Also I took the liberty to remove an unused import in this file.

Note: technically this is a BC, because it removes a public property. Since it was not used internally and there is a `getName` method for this purpose, I felt this was the best option. Alternatively, I can adjust to add a (deprecated?) public property `name`  to the class definition.

Reference: https://wiki.php.net/rfc/deprecate_dynamic_properties