### PR TITLE
Add config option to exclude paths from ViewCollector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -206,6 +206,7 @@ return [
         'views' => [
             'timeline' => false,  // Add the views to the timeline (Experimental)
             'data' => false,    //Note: Can slow down the application, because the data can be quite large..
+            'exclude_paths' => [], // Add the paths which you don't want to appear in the views
         ],
         'route' => [
             'label' => true,  // show complete route on bar

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -75,7 +75,7 @@ class ViewCollector extends TwigCollector
         }
 
         foreach ($this->exclude_paths as $excludePath) {
-            if (str_contains($path, $excludePath)) {
+            if (strpos($path, $excludePath) !== false) {
                 return;
             }
         }

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -74,6 +74,12 @@ class ViewCollector extends TwigCollector
             $path = '';
         }
 
+        foreach ($this->exclude_paths as $excludePath) {
+            if (str_contains($path, $excludePath)) {
+                return;
+            }
+        }
+
         if (!$this->collect_data) {
             $params = array_keys($view->getData());
         } else {

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -11,18 +11,21 @@ class ViewCollector extends TwigCollector
 {
     protected $templates = [];
     protected $collect_data;
+    protected $exclude_paths;
 
     /**
      * Create a ViewCollector
      *
      * @param bool $collectData Collects view data when tru
+     * @param string[] $excludePaths Paths to exclude from collection
      */
-    public function __construct($collectData = true)
+    public function __construct($collectData = true, $excludePaths = [])
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
         $this->name = 'views';
         $this->templates = [];
+        $this->exclude_paths = $excludePaths;
     }
 
     public function getName()

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -204,7 +204,8 @@ class LaravelDebugbar extends DebugBar
         if ($this->shouldCollect('views', true) && isset($this->app['events'])) {
             try {
                 $collectData = $this->app['config']->get('debugbar.options.views.data', true);
-                $this->addCollector(new ViewCollector($collectData));
+                $excludePaths = $this->app['config']->get('debugbar.options.views.exclude_paths', []);
+                $this->addCollector(new ViewCollector($collectData, $excludePaths));
                 $this->app['events']->listen(
                     'composing:*',
                     function ($view, $data = []) use ($debugbar) {


### PR DESCRIPTION
As mentioned in #1033 ([This comment in particular](https://github.com/barryvdh/laravel-debugbar/issues/1033#issuecomment-624348311)) it can be quite slow to load Debugbar when there are a lot of views being loaded in.

A simple way to attempt to limit the number of views is to create a config option to allow users to exclude certain paths from being included in the ViewCollector.

```php
'options' => [
    'views' => [
        'exclude_paths' => [
            'resources/views/components/',
        ],
    ],
],
```

