### PR TITLE
Shows the real path of the views in the QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -309,7 +309,7 @@ class QueryCollector extends PDOCollector
             } elseif (strpos($file, storage_path()) !== false) {
                 $hash = pathinfo($file, PATHINFO_FILENAME);
 
-                if (! $frame->name = $this->findViewFromHash($hash)) {
+                if (! $frame->name = $this->findViewContent($file)) {
                     $frame->name = $hash;
                 }
 
@@ -397,6 +397,23 @@ class QueryCollector extends PDOCollector
                 return $name;
             }
         }
+    }
+
+    /**
+     * Find the template name inside the Blade template.
+     *
+     * @param  string $file
+     * @return null|string
+     */
+    protected function findViewContent($file)
+    {
+        preg_match('/\/\*\*PATH\s(.*)\sENDPATH/', file_get_contents($file), $matches);
+
+        if (isset($matches[1])) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     /**

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -58,4 +58,26 @@ SQL
             );
         });
     }
+
+    public function testFindingCorrectPathForView()
+    {
+        debugbar()->boot();
+
+        /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
+        $collector = debugbar()->getCollector('queries');
+
+        view('query')
+            ->with('db', $this->app['db']->connection())
+            ->with('collector', $collector)
+            ->render();
+
+        tap(Arr::first($collector->collect()['statements']), function (array $statement) {
+            $this->assertEquals(
+                "SELECT a FROM b WHERE c = '$10' AND d = '$2y$10_DUMMY_BCRYPT_HASH' AND e = '\$_$\$_$$\$_$2_$3'",
+                $statement['sql']
+            );
+
+            $this->assertEquals('query', $statement['backtrace'][1]->name);
+        });
+    }
 }

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -72,12 +72,14 @@ SQL
             ->render();
 
         tap(Arr::first($collector->collect()['statements']), function (array $statement) {
+//                        xdebug_break();
+
             $this->assertEquals(
                 "SELECT a FROM b WHERE c = '$10' AND d = '$2y$10_DUMMY_BCRYPT_HASH' AND e = '\$_$\$_$$\$_$2_$3'",
                 $statement['sql']
             );
 
-            $this->assertEquals('query', $statement['backtrace'][1]->name);
+            $this->assertEquals(realpath(__DIR__ . '/../resources/views/query.blade.php'), $statement['backtrace'][1]->name);
         });
     }
 }

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -72,8 +72,6 @@ SQL
             ->render();
 
         tap(Arr::first($collector->collect()['statements']), function (array $statement) {
-//                        xdebug_break();
-
             $this->assertEquals(
                 "SELECT a FROM b WHERE c = '$10' AND d = '$2y$10_DUMMY_BCRYPT_HASH' AND e = '\$_$\$_$$\$_$2_$3'",
                 $statement['sql']

--- a/tests/resources/views/query.blade.php
+++ b/tests/resources/views/query.blade.php
@@ -1,0 +1,12 @@
+<div>
+    <p>Basic view</p>
+
+    @php
+        $collector->addQuery(
+            "SELECT a FROM b WHERE c = ? AND d = ? AND e = ?",
+            ['$10', '$2y$10_DUMMY_BCRYPT_HASH', '$_$$_$$$_$2_$3'],
+            0,
+            $db
+        );
+    @endphp
+</div>


### PR DESCRIPTION
Hey,

really loving this package. 
Recently I tried to debug a n+1 query but it was triggered in a view. But the debugbar only showed the path of the compiled version.
It uses the PATH ENDPATH logic added to the end of the compiled view. That was added in 5.8. ( https://github.com/laravel/framework/pull/28117 ).

The regex logic is the same Nuno  used in this PR. https://github.com/laravel/framework/pull/44347