### PR TITLE
Improve assertion equals

### DIFF
--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -26,11 +26,11 @@ class QueryCollectorTest extends TestCase
         );
 
         tap($collector->collect(), function (array $collection) {
-            $this->assertEquals(1, $collection['nb_statements']);
+            $this->assertSame(1, $collection['nb_statements']);
 
             tap(Arr::first($collection['statements']), function (array $statement) {
                 $this->assertEquals([3, '{4}'], $statement['bindings']);
-                $this->assertEquals(<<<SQL
+                $this->assertSame(<<<SQL
 SELECT ('[1, 2, 3]'::jsonb ? 3) as a, ('[4, 5, 6]'::jsonb ?| '{4}') as b, 'hello world ? example ??' as c
 SQL
                     , $statement['sql']);
@@ -52,7 +52,7 @@ SQL
         );
 
         tap(Arr::first($collector->collect()['statements']), function (array $statement) {
-            $this->assertEquals(
+            $this->assertSame(
                 "SELECT a FROM b WHERE c = '$10' AND d = '$2y$10_DUMMY_BCRYPT_HASH' AND e = '\$_$\$_$$\$_$2_$3'",
                 $statement['sql']
             );

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -28,7 +28,7 @@ class ViewCollectorTest extends TestCase
         );
 
         tap(Arr::first($collector->collect()['templates']), function (array $template) {
-            $this->assertEquals(
+            $this->assertSame(
                 'vscode://file/' . realpath(__DIR__ . '/../resources/views/dashboard.blade.php') . ':1',
                 $template['xdebug_link']['url']
             );

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -34,7 +34,7 @@ class DebugbarTest extends TestCase
         $crawler = $this->call('GET', 'web/plain');
 
         $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
     }
 
     public function testItInjectsOnHtml()
@@ -42,7 +42,7 @@ class DebugbarTest extends TestCase
         $crawler = $this->call('GET', 'web/html');
 
         $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
     }
 
     public function testItDoesntInjectOnJson()
@@ -50,6 +50,6 @@ class DebugbarTest extends TestCase
         $crawler = $this->call('GET', 'api/ping');
 
         $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
-        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertSame(200, $crawler->getStatusCode());
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals strict.