### PR TITLE
Ensures a simple `composer` is registered so view events get fired

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -157,7 +157,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     }
 
     /**
-     * Register the Debugbar Middleware
+     * Ensures view "composing" events get fired.
      */
     protected function ensureViewComposingEvents()
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -106,6 +106,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
 
+        $this->ensureViewComposingEvents();
+
         $this->registerMiddleware(InjectDebugbar::class);
 
         if ($this->app->runningInConsole()) {
@@ -152,5 +154,15 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $kernel = $this->app[Kernel::class];
         $kernel->pushMiddleware($middleware);
+    }
+
+    /**
+     * Register the Debugbar Middleware
+     */
+    protected function ensureViewComposingEvents()
+    {
+        $this->app['view']->composer('*', function () {
+            // ..
+        });
     }
 }


### PR DESCRIPTION
This pull request starts to fix https://github.com/barryvdh/laravel-debugbar/issues/1354, by registering a simple `composer` so view events get fired when using Debugbar.

@browner12 Can you try this, and let me know how it goes?