### PR TITLE
Support for Read-Only PDO in QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -133,7 +133,7 @@ class QueryCollector extends PDOCollector
 
         $pdo = null;
         try {
-            $pdo = $connection->getPdo();
+            $pdo = preg_match('/^\s*(SELECT) /i', $query) ? $connection->getReadPdo() : $connection->getPdo();
         } catch (\Exception $e) {
             // ignore error for non-pdo laravel drivers
         }


### PR DESCRIPTION
Hello,

We've run into a few problems using Debugbar on our project as it is configured read-only.

To ensure there are no development mistakes, the read connection is configured with a live DB instance and the write connection is configured with invalid details, so it'll throw an error if anyone tries to write to the DB.

Debugbar appears to be trying to use the write connection rather than read, with read being Laravel's default for SELECT statements (and it would also be fine for EXPLAIN SELECT).

Would you consider replicating Laravel's default behaviour with this change to use the read PDO when nothing other than SELECTs are being used?

Regards,
iamacarpet