### PR TITLE
QueryCollector: Exception -> Throwable

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -134,7 +134,7 @@ class QueryCollector extends PDOCollector
         $pdo = null;
         try {
             $pdo = $connection->getPdo();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // ignore error for non-pdo laravel drivers
         }
         $bindings = $connection->prepareBindings($bindings);


### PR DESCRIPTION
Hello,

For some reason, on PHP 8.1, PDOException isn't being caught as an `\Exception`.

Swapping to `\Throwable` properly catches the error so it is silent.

`Throwable` is supported in PHP 7, so it shouldn't cause a conflict with your minimum version requirement.

Regards,
iamacarpet
