### PR TITLE
fix: deprecated dynamic property on PHP 8.2

### DIFF
--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -4,6 +4,7 @@ namespace Barryvdh\Debugbar\DataFormatter;
 
 use DebugBar\DataFormatter\DataFormatter;
 
+#[AllowDynamicProperties]
 class QueryFormatter extends DataFormatter
 {
     /**

--- a/src/DataFormatter/QueryFormatter.php
+++ b/src/DataFormatter/QueryFormatter.php
@@ -4,7 +4,7 @@ namespace Barryvdh\Debugbar\DataFormatter;
 
 use DebugBar\DataFormatter\DataFormatter;
 
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class QueryFormatter extends DataFormatter
 {
     /**

--- a/src/DataFormatter/SimpleFormatter.php
+++ b/src/DataFormatter/SimpleFormatter.php
@@ -9,7 +9,7 @@ use DebugBar\DataFormatter\DataFormatter;
  *
  * @see https://github.com/symfony/symfony/blob/v3.4.4/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class SimpleFormatter extends DataFormatter
 {
     /**

--- a/src/DataFormatter/SimpleFormatter.php
+++ b/src/DataFormatter/SimpleFormatter.php
@@ -9,6 +9,7 @@ use DebugBar\DataFormatter\DataFormatter;
  *
  * @see https://github.com/symfony/symfony/blob/v3.4.4/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
  */
+#[AllowDynamicProperties]
 class SimpleFormatter extends DataFormatter
 {
     /**


### PR DESCRIPTION
Fixing deprecated on PHP 8.2 :
- Creation of dynamic property Barryvdh\Debugbar\DataFormatter\QueryFormatter::$cloner is deprecated
- Creation of dynamic property Barryvdh\Debugbar\DataFormatter\QueryFormatter::$dumper is deprecated
- Creation of dynamic property Barryvdh\Debugbar\DataFormatter\SimpleFormatter::$cloner is deprecated
- Creation of dynamic property Barryvdh\Debugbar\DataFormatter\SimpleFormatter::$dumper is deprecated

Reference : 
https://php.watch/versions/8.2/dynamic-properties-deprecated