### PR TITLE
feat: json_encode context with JSON_PRETTY_PRINT flag

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -260,7 +260,7 @@ class LaravelDebugbar extends DebugBar
                             try {
                                 $logMessage = (string) $message;
                                 if (mb_check_encoding($logMessage, 'UTF-8')) {
-                                    $logMessage .= (!empty($context) ? ' ' . json_encode($context) : '');
+                                    $logMessage .= (!empty($context) ? ' ' . json_encode($context, JSON_PRETTY_PRINT) : '');
                                 } else {
                                     $logMessage = "[INVALID UTF-8 DATA]";
                                 }


### PR DESCRIPTION
This commit is intended for the improvement in the readability of messages if they have long context data. 

For example, without pretty print
![image](https://user-images.githubusercontent.com/8613679/210812175-68e3bb4c-f208-4079-a7cc-c44f8826c06c.png)

With pretty print
![image](https://user-images.githubusercontent.com/8613679/210816684-07c6a988-f5e6-4cb7-8c88-982987f4a0df.png)

