### PR TITLE
Add db.slow_threshold to default config

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -198,7 +198,8 @@ return [
                 'types' => ['SELECT'],     // Deprecated setting, is always only SELECT
             ],
             'hints'             => false,    // Show hints for common mistakes
-            'show_copy'         => false,    // Show copy button next to the query
+            'show_copy'         => false,    // Show copy button next to the query,
+            'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
         ],
         'mail' => [
             'full_log' => false,


### PR DESCRIPTION
I didn't find this feature in documentation so at least it can be in default config