### PR TITLE
Laravel 10.x Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
-        laravel: [^9, ^8, ^7]
+        laravel: [^10, ^9, ^8, ^7]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - laravel: ^7*
+          - laravel: ^7
             php: 8.1
           - laravel: ^7
             php: 8.2
@@ -35,8 +35,14 @@ jobs:
             php: 7.3
           - laravel: ^9
             php: 7.4
-          - laravel: ^7
-            php: 8.1
+          - laravel: ^10
+            php: 7.2
+          - laravel: ^10
+            php: 7.3
+          - laravel: ^10
+            php: 7.4
+          - laravel: ^10
+            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     "require": {
         "php": ">=7.2.5",
         "maximebf/debugbar": "^1.17.2",
-        "illuminate/routing": "^7|^8.67|^9",
-        "illuminate/session": "^7|^8.67|^9",
-        "illuminate/support": "^7|^8.67|^9",
+        "illuminate/routing": "^7|^8.67|^9|^10",
+        "illuminate/session": "^7|^8.67|^9|^10",
+        "illuminate/support": "^7|^8.67|^9|^10",
         "symfony/finder": "^5|^6"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench-dusk": "^5|^6|^7",
+        "orchestra/testbench-dusk": "^5|^6|^7|^8",
         "phpunit/phpunit": "^8.5.30|^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },


### PR DESCRIPTION
```batch
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.1
Configuration: /laravel-debugbar/laravel-debugbar/phpunit.xml.dist
Warning:       No code coverage driver available
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...S........                                                      12 / 12

Time: 00:06.208, Memory: 30.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 12, Assertions: 22, Skipped: 1.
```
