### PR TITLE
set `font-size: initial;` on `div.phpdebugbar *`

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -13,6 +13,7 @@ div.phpdebugbar {
 
 div.phpdebugbar * {
     direction: ltr;
+    font-size: initial;
     text-align: left;
 }
 


### PR DESCRIPTION
This will reset the font size to the browser initial value and ignore any css that is setting font size on things like `li` or `ul` in the apps css file. 

Since this is at the top of the package's css file, you can override it farther down too and it will be whatever is set there.