### PR TITLE
[Fix] Version detection in Lumen

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -103,6 +103,9 @@ class LaravelDebugbar extends DebugBar
         $this->app = $app;
         $this->version = $app->version();
         $this->is_lumen = Str::contains($this->version, 'Lumen');
+        if ($this->is_lumen) {
+            $this->version = Str::betweenFirst($app->version(), '(', ')');
+        }
     }
 
     /**


### PR DESCRIPTION
Lumen does return version as string like "Lumen (9.1.5) (Laravel Components ^9.21)".  
This PR will extract the correct version from the returned string,
this will in turn fix the `checkVersion` method,
this will in turn fix the fix for Illuminate 9 from https://github.com/barryvdh/laravel-debugbar/commit/b96f9820aaf1ff9afe945207883149e1c7afb298 to disable the Mailer in Illuminate 9