### PR TITLE
Update Debugbar to include autoshow setting

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -894,9 +894,12 @@ class LaravelDebugbar extends DebugBar
      */
     public function injectDebugbar(Response $response)
     {
+        $config = $this->app['config'];
         $content = $response->getContent();
 
         $renderer = $this->getJavascriptRenderer();
+        $autoShow = $config->get('debugbar.ajax_handler_auto_show', true);
+        $renderer->setAjaxHandlerAutoShow($autoShow);
         if ($this->getStorage()) {
             $openHandlerUrl = route('debugbar.openhandler');
             $renderer->setOpenHandlerUrl($openHandlerUrl);


### PR DESCRIPTION
I think that's a valid point to include, due to the fact that in a lot of software with the autoshow set to true it's impossible to use the debugbar. I'm in Laravel Nova right now, every time a notification ajax gets sent, the request I'm debugging gets removed by that setting. I've tried to add a middleware to enable that setting, but it breaks other things in beetween. Right now this it's the most polished solution.
Let me know if it's ok!
Thanks!