### PR TITLE
Show only duplicated queries

### DIFF
--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -259,6 +259,24 @@
                 if (duplicate) {
                     t.append(", " + duplicate + " of which were duplicated");
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
+
+                    // add toggler for displaying only duplicated queries
+                    var duplicatedText = "Show only duplicated";
+                    var allText = "Show All";
+                    var id = "phpdebugbar-show-duplicates";
+                    t.append(". <a id='" + id + "'>" + duplicatedText + "</a>");
+
+                    $(".phpdebugbar #" + id).click(function () {
+                        var $this = $(this);
+                        $this.toggleClass("shown_duplicated");
+                        $this.text($this.hasClass("shown_duplicated") ? allText : duplicatedText);
+                        $(".phpdebugbar-widgets-sqlqueries .phpdebugbar-widgets-list-item")
+                            .not(".phpdebugbar-widgets-sql-duplicate")
+                            .toggle();
+
+                        return false;
+                    });
+
                 }
                 if (data.accumulated_duration_str) {
                     this.$status.append($('<span title="Accumulated duration" />').addClass(csscls('duration')).text(data.accumulated_duration_str));


### PR DESCRIPTION
This is resubmission of https://github.com/barryvdh/laravel-debugbar/pull/681 to quickly find only duplicated DB queries.
It seems difficult to me to find only duplicated queries every time. As we learned some other developers find this useful too.

I didn't change color of the duplicated query line this time because it maybe not desirable for others. Color will not matter if we have this button. It's visible only if there are duplicated queries.

If text requires too many space you or me can replace it with some font icon I guess.

**Off**
![Screenshot_1](https://user-images.githubusercontent.com/1434668/219940935-80fba287-805c-4d4f-8462-c9f247f1a81a.jpg)
**On**
![Screenshot_3](https://user-images.githubusercontent.com/1434668/219940963-87d4ea10-1fd3-49b1-a12d-2ff0dcf2f943.jpg)



