### PR TITLE
Fix openhandler close icon position

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -235,6 +235,7 @@ div.phpdebugbar-openhandler .phpdebugbar-openhandler-header {
 }
 
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-header a {
+    display: flex;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have fixed the openhandler close icon position

## Before
![image](https://user-images.githubusercontent.com/60013703/220697939-2f7beedd-d4f0-4fed-83cc-b0513220fb00.png)


## After
![image](https://user-images.githubusercontent.com/60013703/220698005-e0935bbe-cd94-435a-8c6e-c2816f2cb380.png)
