### PR TITLE
Fixed debug output if exception or php fatal error is thrown.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /build
 /vendor
 composer.phar

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -174,7 +174,7 @@ div.phpdebugbar-minimized {
 }
 
 div.phpdebugbar code, div.phpdebugbar pre, div.phpdebugbar samp {
-    background: none;
+    background: none !important;
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
     font-size: 1em;
     border: 0;
@@ -649,7 +649,7 @@ div.phpdebugbar-widgets-messages .phpdebugbar-widgets-value.phpdebugbar-widgets-
 }
 
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item pre.sf-dump {
-    display: inline-block;
+    display: inline-block !important;
     position: relative;
     top: -1px;
 }
@@ -804,4 +804,14 @@ div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before {
     height: 100%;
     opacity: 0.2;
     background: red;
+}
+
+@media (prefers-color-scheme: dark) {
+    div.phpdebugbar .phpdebugbar-indicator span.phpdebugbar-tooltip,
+    div.phpdebugbar div.phpdebugbar-mini-design a.phpdebugbar-tab:hover span.phpdebugbar-text,
+    div.phpdebugbar pre.sf-dump,
+    div.phpdebugbar .hljs,
+    div.phpdebugbar code.phpdebugbar-widgets-sql span.hljs-operator {
+        color: var(--color-gray-100) !important;
+    }
 }


### PR DESCRIPTION
This will fix the problem that debug output is hidden if an error or exception is thrown.
Fixes #1379 and #1369