### PR TITLE
use short array syntax

### DIFF
--- a/src/DataFormatter/SimpleFormatter.php
+++ b/src/DataFormatter/SimpleFormatter.php
@@ -52,7 +52,7 @@ class SimpleFormatter extends DataFormatter
 
             $indent = str_repeat('  ', $depth);
 
-            $a = array();
+            $a = [];
             foreach ($value as $k => $v) {
                 if (is_array($v)) {
                     $deep = true;

--- a/src/Storage/SocketStorage.php
+++ b/src/Storage/SocketStorage.php
@@ -84,7 +84,7 @@ class SocketStorage implements StorageInterface
     /**
      * @inheritDoc
      */
-    function find(array $filters = array(), $max = 20, $offset = 0)
+    function find(array $filters = [], $max = 20, $offset = 0)
     {
         //
     }


### PR DESCRIPTION
the short array syntax is standard throughout the rest of the project, looks like these 2 just got left behind.