### PR TITLE
spelling and grammar updates

### DIFF
--- a/src/DataCollector/FilesCollector.php
+++ b/src/DataCollector/FilesCollector.php
@@ -50,7 +50,7 @@ class FilesCollector extends DataCollector implements Renderable
             } else {
                 $alreadyCompiled[] = [
                     'message' => "* '" . $this->stripBasePath($file) . "',",
-                    // Mark with *, so know they are compiled anyways.
+                    // Mark with *, so know they are compiled anyway.
                     'is_string' => true,
                 ];
             }

--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -27,7 +27,7 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
             /** @var \Livewire\Component $component */
             $component = $view->getData()['_instance'];
 
-            // Create an unique name for each compoent
+            // Create a unique name for each component
             $key = $component->getName() . ' #' . $component->id;
 
             $data = [

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -499,7 +499,7 @@ class QueryCollector extends PDOCollector
                 'connection' => $query['connection'],
             ];
 
-            // Add the results from the explain as new rows
+            // Add the results from the EXPLAIN as new rows
             if ($query['driver'] === 'pgsql') {
                 $explainer = trim(implode("\n", array_map(function ($explain) {
                     return $explain->{'QUERY PLAN'};

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -79,7 +79,7 @@ class LaravelDebugbar extends DebugBar
     protected $booted = false;
 
     /**
-     * True when enabled, false disabled an null for still unknown
+     * True when enabled, false disabled on null for still unknown
      *
      * @var bool
      */
@@ -937,7 +937,7 @@ class LaravelDebugbar extends DebugBar
         $response->setContent($content);
         $response->headers->remove('Content-Length');
 
-        // Restore original response (eg. the View or Ajax data)
+        // Restore original response (e.g. the View or Ajax data)
         if ($original) {
             $response->original = $original;
         }

--- a/src/Storage/FilesystemStorage.php
+++ b/src/Storage/FilesystemStorage.php
@@ -63,7 +63,7 @@ class FilesystemStorage implements StorageInterface
     }
 
     /**
-     * Delete files older then a certain age (gc_lifetime)
+     * Delete files older than a certain age (gc_lifetime)
      */
     protected function garbageCollect()
     {


### PR DESCRIPTION
- "a" should be before words that start with a consonant *sound*, not necessarily letter.
- I capitalized "EXPLAIN" to make it more clear we are talking about a query