### PR TITLE
Fixed the command debugbar:clear not being triggered via the Artisan::call

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -108,9 +108,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->registerMiddleware(InjectDebugbar::class);
 
-        if ($this->app->runningInConsole()) {
-            $this->commands(['command.debugbar.clear']);
-        }
+        $this->commands(['command.debugbar.clear']);
     }
 
     /**


### PR DESCRIPTION
PR raised with reference to: https://github.com/barryvdh/laravel-debugbar/issues/1409