### PR TITLE
Add support for PHPStorm via IDE Remote Control plugin

### DIFF
--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -36,6 +36,7 @@ class RouteCollector extends DataCollector implements Renderable
         'emacs' => 'emacs://open?url=file://%file&line=%line',
         'macvim' => 'mvim://open/?url=file://%file&line=%line',
         'phpstorm' => 'phpstorm://open?file=%file&line=%line',
+        'phpstorm-remote' => 'http://localhost:63342/api/file/%file:%line',
         'idea' => 'idea://open?file=%file&line=%line',
         'vscode' => 'vscode://file/%file:%line',
         'vscode-insiders' => 'vscode-insiders://file/%file:%line',


### PR DESCRIPTION
Jetbrains official plugin for linking code to IDE from a webpage:

https://plugins.jetbrains.com/plugin/19991-ide-remote-control

Since the `phpstorm://` protocol does not work for a large number of people (me included:)