### PR TITLE
Improved visibility of #phpdebugbar-show-duplicates anchor tag in widget.js

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -805,3 +805,8 @@ div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before {
     opacity: 0.2;
     background: red;
 }
+
+div.phpdebugbar #phpdebugbar-show-duplicates {
+    font-weight: bold;
+    text-shadow: 1px 1px #FFF;
+}

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -808,5 +808,4 @@ div.phpdebugbar-widgets-templates span.phpdebugbar-widgets-param-count:before {
 
 div.phpdebugbar #phpdebugbar-show-duplicates {
     font-weight: bold;
-    text-shadow: 1px 1px #FFF;
 }

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -261,8 +261,8 @@
                     t.append(", " + (data.nb_statements - duplicate) + " unique");
 
                     // add toggler for displaying only duplicated queries
-                    var duplicatedText = "Show only duplicated";
-                    var allText = "Show All";
+                    var duplicatedText = "Show only duplicated queries.";
+                    var allText = "Show all queries.";
                     var id = "phpdebugbar-show-duplicates";
                     t.append(". <a id='" + id + "'>" + duplicatedText + "</a>");
 


### PR DESCRIPTION
In the widget.js file, I made the #phpdebugbar-show-duplicates anchor tag more visible by adding bold styles to it, indicating that it is clickable. I also updated the wording of the anchor tag to say "Show only duplicated queries" and "Show all queries" for clarity.

Please see the attached screenshot for reference:

![image](https://github.com/barryvdh/laravel-debugbar/assets/3579831/36986d2c-1f0b-4b3e-80f2-5c398f4bdb5a)

Thank you for considering my contribution.

