### PR TITLE
Uppercase SQL keywords

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -561,6 +561,10 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
     max-width: 100%;
 }
 
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-keyword {
+    text-transform: uppercase;
+}
+
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration {
     margin-left: auto;
     margin-right: 5px;

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -561,8 +561,20 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
     max-width: 100%;
 }
 
-ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-keyword {
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator {
     text-transform: uppercase;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > * {
+  text-transform: lowercase;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > .hljs-keyword {
+  text-transform: uppercase;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > div {
+    text-transform: lowercase;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -561,20 +561,14 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
     max-width: 100%;
 }
 
-ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator {
-    text-transform: uppercase;
-}
-
-ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > * {
-  text-transform: lowercase;
-}
-
-ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > .hljs-keyword {
+ul.phpdebugbar-widgets-list li .phpdebugbar-widgets-sql .hljs-operator,
+ul.phpdebugbar-widgets-list li .phpdebugbar-widgets-sql .hljs-operator > .hljs-keyword,
+ul.phpdebugbar-widgets-list li .phpdebugbar-widgets-sql .hljs-operator > .hljs-aggregate {
   text-transform: uppercase;
 }
 
-ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql .hljs-operator > div {
-    text-transform: lowercase;
+ul.phpdebugbar-widgets-list li .phpdebugbar-widgets-sql .hljs-operator > *:not(.hljs-keyword):not(.hljs-aggregate) {
+  text-transform: lowercase;
 }
 
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration {


### PR DESCRIPTION
Neat SQL Syntax, more readable.

![image](https://github.com/barryvdh/laravel-debugbar/assets/37969970/62eb7ffb-c47d-4a18-8b5c-1d296f0974fe)
