### PR TITLE
Support editor link on QueryCollector/ExceptionsCollector

### DIFF
--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Config;
-use InvalidArgumentException;
 
 /**
  * Based on Illuminate\Foundation\Console\RoutesCommand for Taylor Otwell
@@ -24,30 +23,6 @@ class RouteCollector extends DataCollector implements Renderable
      * @var \Illuminate\Routing\Router
      */
     protected $router;
-
-    /**
-     * A list of known editor strings.
-     *
-     * @var array
-     */
-    protected $editors = [
-        'sublime' => 'subl://open?url=file://%file&line=%line',
-        'textmate' => 'txmt://open?url=file://%file&line=%line',
-        'emacs' => 'emacs://open?url=file://%file&line=%line',
-        'macvim' => 'mvim://open/?url=file://%file&line=%line',
-        'phpstorm' => 'phpstorm://open?file=%file&line=%line',
-        'idea' => 'idea://open?file=%file&line=%line',
-        'vscode' => 'vscode://file/%file:%line',
-        'vscode-insiders' => 'vscode-insiders://file/%file:%line',
-        'vscode-remote' => 'vscode://vscode-remote/%file:%line',
-        'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/%file:%line',
-        'vscodium' => 'vscodium://file/%file:%line',
-        'nova' => 'nova://core/open/file?filename=%file&line=%line',
-        'xdebug' => 'xdebug://%file@%line',
-        'atom' => 'atom://core/open/file?filename=%file&line=%line',
-        'espresso' => 'x-espresso://open?filepath=%file&lines=%line',
-        'netbeans' => 'netbeans://open/?f=%file:%line',
-    ];
 
     public function __construct(Router $router)
     {
@@ -100,10 +75,17 @@ class RouteCollector extends DataCollector implements Renderable
         }
 
         if (isset($reflector)) {
-            $filename = ltrim(str_replace(base_path(), '', $reflector->getFileName()), '/');
+            $filename = $this->normalizeFilePath($reflector->getFileName());
 
-            if ($href = $this->getEditorHref($reflector->getFileName(), $reflector->getStartLine())) {
-                $result['file'] = sprintf('<a href="%s">%s:%s-%s</a>', $href, $filename, $reflector->getStartLine(), $reflector->getEndLine());
+            if ($link = $this->getXdebugLink($reflector->getFileName(), $reflector->getStartLine())) {
+                $result['file'] = sprintf(
+                    '<a href="%s" onclick="%s">%s:%s-%s</a>',
+                    $link['url'],
+                    $link['ajax'] ? 'event.preventDefault();$.ajax(this.href);' : '',
+                    $filename,
+                    $reflector->getStartLine(),
+                    $reflector->getEndLine()
+                );
             } else {
                 $result['file'] = sprintf('%s:%s-%s', $filename, $reflector->getStartLine(), $reflector->getEndLine());
             }
@@ -174,47 +156,5 @@ class RouteCollector extends DataCollector implements Renderable
         $this->table->setHeaders($this->headers)->setRows($routes);
 
         $this->table->render($this->getOutput());
-    }
-
-    /**
-     * Get the editor href for a given file and line, if available.
-     *
-     * @param string $filePath
-     * @param int    $line
-     *
-     * @throws InvalidArgumentException If editor resolver does not return a string
-     *
-     * @return null|string
-     */
-    protected function getEditorHref($filePath, $line)
-    {
-        if (empty(config('debugbar.editor'))) {
-            return null;
-        }
-
-        if (empty($this->editors[config('debugbar.editor')])) {
-            throw new InvalidArgumentException(
-                'Unknown editor identifier: ' . config('debugbar.editor') . '. Known editors:' .
-                implode(', ', array_keys($this->editors))
-            );
-        }
-
-        $filePath = $this->replaceSitesPath($filePath);
-
-        $url = str_replace(['%file', '%line'], [$filePath, $line], $this->editors[config('debugbar.editor')]);
-
-        return $url;
-    }
-
-    /**
-     * Replace remote path
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function replaceSitesPath($filePath)
-    {
-        return str_replace(config('debugbar.remote_sites_path'), config('debugbar.local_sites_path'), $filePath);
     }
 }

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -5,7 +5,6 @@ namespace Barryvdh\Debugbar\DataCollector;
 use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
 use DebugBar\Bridge\Twig\TwigCollector;
 use Illuminate\View\View;
-use InvalidArgumentException;
 
 class ViewCollector extends TwigCollector
 {
@@ -15,33 +14,9 @@ class ViewCollector extends TwigCollector
     protected $exclude_paths;
 
     /**
-     * A list of known editor strings.
-     *
-     * @var array
-     */
-    protected $editors = [
-        'sublime' => 'subl://open?url=file://%file&line=%line',
-        'textmate' => 'txmt://open?url=file://%file&line=%line',
-        'emacs' => 'emacs://open?url=file://%file&line=%line',
-        'macvim' => 'mvim://open/?url=file://%file&line=%line',
-        'phpstorm' => 'phpstorm://open?file=%file&line=%line',
-        'idea' => 'idea://open?file=%file&line=%line',
-        'vscode' => 'vscode://file/%file:%line',
-        'vscode-insiders' => 'vscode-insiders://file/%file:%line',
-        'vscode-remote' => 'vscode://vscode-remote/%file:%line',
-        'vscode-insiders-remote' => 'vscode-insiders://vscode-remote/%file:%line',
-        'vscodium' => 'vscodium://file/%file:%line',
-        'nova' => 'nova://core/open/file?filename=%file&line=%line',
-        'xdebug' => 'xdebug://%file@%line',
-        'atom' => 'atom://core/open/file?filename=%file&line=%line',
-        'espresso' => 'x-espresso://open?filepath=%file&lines=%line',
-        'netbeans' => 'netbeans://open/?f=%file:%line',
-    ];
-
-    /**
      * Create a ViewCollector
      *
-     * @param bool $collectData Collects view data when tru
+     * @param bool $collectData Collects view data when true
      * @param string[] $excludePaths Paths to exclude from collection
      */
     public function __construct($collectData = true, $excludePaths = [])
@@ -74,36 +49,6 @@ class ViewCollector extends TwigCollector
     }
 
     /**
-     * Get the editor href for a given file and line, if available.
-     *
-     * @param string $filePath
-     * @param int    $line
-     *
-     * @throws InvalidArgumentException If editor resolver does not return a string
-     *
-     * @return null|string
-     */
-    protected function getEditorHref($filePath, $line)
-    {
-        if (empty(config('debugbar.editor'))) {
-            return null;
-        }
-
-        if (empty($this->editors[config('debugbar.editor')])) {
-            throw new InvalidArgumentException(
-                'Unknown editor identifier: ' . config('debugbar.editor') . '. Known editors:' .
-                implode(', ', array_keys($this->editors))
-            );
-        }
-
-        $filePath = $this->replaceSitesPath($filePath);
-
-        $url = str_replace(['%file', '%line'], [$filePath, $line], $this->editors[config('debugbar.editor')]);
-
-        return $url;
-    }
-
-    /**
      * Add a View instance to the Collector
      *
      * @param \Illuminate\View\View $view
@@ -115,7 +60,7 @@ class ViewCollector extends TwigCollector
         $type = '';
 
         if ($path && is_string($path)) {
-            $path = ltrim(str_replace(base_path(), '', realpath($path)), '/');
+            $path = $this->normalizeFilePath($path);
 
             if (substr($path, -10) == '.blade.php') {
                 $type = 'blade';
@@ -128,7 +73,7 @@ class ViewCollector extends TwigCollector
         }
 
         foreach ($this->exclude_paths as $excludePath) {
-            if (strpos($path, $excludePath) !== false) {
+            if (str_starts_with($path, $excludePath)) {
                 return;
             }
         }
@@ -147,11 +92,10 @@ class ViewCollector extends TwigCollector
             'name' => $path ? sprintf('%s (%s)', $name, $path) : $name,
             'param_count' => count($params),
             'params' => $params,
-            'type' => $type,
-            'editorLink' => $this->getEditorHref($view->getPath(), 0),
+            'type' => $type,            
         ];
 
-        if ($this->getXdebugLink($path)) {
+        if ($this->getXdebugLinkTemplate()) {
             $template['xdebug_link'] = $this->getXdebugLink(realpath($view->getPath()));
         }
 
@@ -166,17 +110,5 @@ class ViewCollector extends TwigCollector
             'nb_templates' => count($templates),
             'templates' => $templates,
         ];
-    }
-
-    /**
-     * Replace remote path
-     *
-     * @param string $filePath
-     *
-     * @return string
-     */
-    protected function replaceSitesPath($filePath)
-    {
-        return str_replace(config('debugbar.remote_sites_path'), config('debugbar.local_sites_path'), $filePath);
     }
 }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -96,6 +96,8 @@ class LaravelDebugbar extends DebugBar
      */
     protected $is_lumen = false;
 
+    protected array $editorTemplateArgs = [];
+
     /**
      * @param Application $app
      */
@@ -138,6 +140,8 @@ class LaravelDebugbar extends DebugBar
 
         /** @var Application $app */
         $app = $this->app;
+
+        $this->editorTemplateArgs = [$this->app['config']->get('debugbar.editor'), $this->getRemoteServerReplacements()];
 
         // Set custom error handler
         if ($app['config']->get('debugbar.error_handler', false)) {
@@ -584,6 +588,10 @@ class LaravelDebugbar extends DebugBar
 
         if (method_exists($collector, 'useHtmlVarDumper')) {
             $collector->useHtmlVarDumper();
+        }
+        if (method_exists($collector, 'setEditorLinkTemplate')) {
+            $collector->setEditorLinkTemplate($this->editorTemplateArgs[0]);
+            $collector->addXdebugReplacements($this->editorTemplateArgs[1]);
         }
 
         return $this;
@@ -1165,6 +1173,17 @@ class LaravelDebugbar extends DebugBar
 
             $response->headers->set('Server-Timing', $headers, false);
         }
+    }
+
+    /**
+     * @return array
+     */
+    private function getRemoteServerReplacements()
+    {
+        $localPath = $this->app['config']->get('debugbar.local_sites_path', '');
+        $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path', ''))) ?: [base_path()];
+
+        return array_fill_keys($remotePaths, $localPath);
     }
 
     /**

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -578,6 +578,14 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
     margin-right: 5px;
 }
 
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-stmt-id a {
+    color: #888;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-stmt-id a:hover {
+    color: #aaa;
+}
+
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item table.phpdebugbar-widgets-params {
     background-color: #fdfdfd;
     margin: 10px 0px;

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -83,7 +83,17 @@
                     $('<span title="Row count" />').addClass(csscls('row-count')).text(stmt.row_count).appendTo(li);
                 }
                 if (typeof(stmt.stmt_id) != 'undefined' && stmt.stmt_id) {
-                    $('<span title="Prepared statement ID" />').addClass(csscls('stmt-id')).text(stmt.stmt_id).appendTo(li);
+                    $('<span title="Prepared statement ID" />').addClass(csscls('stmt-id'))
+                        .append(! stmt.xdebug_link ? $('<i/>').text(stmt.stmt_id).html() : $('<a />')
+                            .attr('href', stmt.xdebug_link.url).text(stmt.stmt_id)
+                            .on('click', function (event) {
+                                event.stopPropagation();
+                                if (stmt.xdebug_link.ajax) {
+                                    event.preventDefault();
+                                    $.ajax(stmt.xdebug_link.url);
+                                }
+                            })
+                        ).appendTo(li);
                 }
                 if (stmt.connection) {
                     $('<span title="Connection" />').addClass(csscls('database')).text(stmt.connection).appendTo(li);


### PR DESCRIPTION
This PR allow us to easy open files on editor from queries widget

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/cad328f5-e3d0-4b69-97de-f0548a3bcc62)

I also avoid duplicating the same code again, now it uses build-in methods
https://github.com/barryvdh/laravel-debugbar/blob/23f6174bff720bc4ecce767c07fe0a79a175eca8/src/DataCollector/RouteCollector.php#L33-L50
https://github.com/barryvdh/laravel-debugbar/blob/23f6174bff720bc4ecce767c07fe0a79a175eca8/src/DataCollector/ViewCollector.php#L22-L39

Also `getEditorHref` was removed, now it uses build-in methods

Related https://github.com/barryvdh/laravel-debugbar/pull/1258, https://github.com/barryvdh/laravel-debugbar/pull/1359, 