### PR TITLE
[bug] Fix normalizeFilename when multiple matches

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -433,7 +433,14 @@ class QueryCollector extends PDOCollector
         if (file_exists($path)) {
             $path = realpath($path);
         }
-        return str_replace(base_path(), '', $path);
+
+        $basepath = base_path();
+
+        if (! str_starts_with($path, $basepath)) {
+            return $path;
+        }
+
+        return substr($path, strlen($basepath));
     }
 
     /**


### PR DESCRIPTION
**Test:** [PHP Demo](https://onlinephp.io?s=TY1BCoMwEEX3gdwhCyEJWHIAFY8iow5EsHHIRHv9jgqtu8fnPX7bUySttKoISjSdseGAHIAoHJjmLQcGPqcFUnnxZylTtI3oIzA-k3PUSmCY9zc5LnnISCtM6H5ubaytzfXkffO091ECV92S4Irpn3mRvw%2C%2C&v=8.2.8)

With `str_replace` all the matches are replaced, if the base_path is a single folder with a short name it could match other segments of the path