### PR TITLE
Fix, only exclude path when it is a prefix

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -128,7 +128,7 @@ class ViewCollector extends TwigCollector
         }
 
         foreach ($this->exclude_paths as $excludePath) {
-            if (strpos($path, $excludePath) !== false) {
+            if (strpos($path, $excludePath) === 0) {
                 return;
             }
         }


### PR DESCRIPTION
[Demo](https://onlinephp.io?s=s7EvyCjg5eLlUilILMlQsFVQL0ktLlFISSsuzsouVgBzioG8lDR1a6Ci1IrknNKU1AAktSBxXq6yxKL4lNLcAo3ikqKC_GINsHE6CsgaNG1tbQ00rYlTq2hrm5aYU5yqaY3iOIVB7TpSHKdAD9cBAA%2C%2C&v=7.1.0)

