### PR TITLE
feat: update LivewireCollector to support Livewire v3

### DIFF
--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use Livewire\Component;
 
 /**
  * Collector for Models.
@@ -43,6 +44,26 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
             $data['view'] = $view->name();
             $data['component'] = get_class($component);
             $data['id'] = $component->id;
+
+            $this->data[$key] = $this->formatVar($data);
+        });
+
+        Livewire::listen('render', function (Component $component) use ($request) {
+            // Create an unique name for each compoent
+            $key = $component->getName() . ' #' . $component->getId();
+
+            $data = [
+                'data' => $component->all(),
+            ];
+
+            if ($request->request->get('id') == $component->getId()) {
+                $data['oldData'] = $request->request->get('data');
+                $data['actionQueue'] = $request->request->get('actionQueue');
+            }
+
+            $data['name'] = $component->getName();
+            $data['component'] = get_class($component);
+            $data['id'] = $component->getId();
 
             $this->data[$key] = $this->formatVar($data);
         });

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -838,7 +838,7 @@ class LaravelDebugbar extends DebugBar
     protected function isJsonRequest(Request $request)
     {
         // If XmlHttpRequest or Live, return true
-        if ($request->isXmlHttpRequest() || $request->headers->get('X-Livewire')) {
+        if ($request->isXmlHttpRequest() || $request->headers->has('X-Livewire')) {
             return true;
         }
 


### PR DESCRIPTION
Based on my explanation here #1435. This is to support Livewire v3 release.

To keep it backward compatible with the previous version of Livewire, I keep the old listener. 

Here I created a new listener based on the old listener: 
I removed the $data['view'] due to in the Livewire 3 is now we don't really need to have a view.
Then, `$component->getPublicPropertiesDefinedBySubClass()` is now moved to the `Livewire\Concerns\InteractsWithProperties::all`. So, `$component->all()`

I updated the `Barryvdh\Debugbar\LaravelDebugbar::isJsonRequest` to only check the header key instead of its value. Because the Livewire v3 `x-livewire` header is an empty string `""`, as you know it could be a falsy value