### PR TITLE
Livewire V3 Support

### DIFF
--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -51,8 +51,8 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
 
         Livewire::listen('render', function (Component $component) use ($request) {
             // Create an unique name for each compoent
-            $key = $component->getName() . ' #' . $component->getId();
             $component_id = !property_exists($component, 'id') ? $component->getId() : $component->id;
+            $key = $component->getName() . ' #' . $component_id;
 
             $data = [
                 'data' => $component->all(),

--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -27,15 +27,16 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
         Livewire::listen('view:render', function (View $view) use ($request) {
             /** @var \Livewire\Component $component */
             $component = $view->getData()['_instance'];
+            $component_id = !property_exists($component, 'id') ? $component->getId() : $component->id;
 
             // Create an unique name for each compoent
-            $key = $component->getName() . ' #' . $component->id;
+            $key = $component->getName() . ' #' . $component_id;
 
             $data = [
                 'data' => $component->getPublicPropertiesDefinedBySubClass(),
             ];
 
-            if ($request->request->get('id') == $component->id) {
+            if ($request->request->get('id') == $component_id) {
                 $data['oldData'] = $request->request->get('data');
                 $data['actionQueue'] = $request->request->get('actionQueue');
             }
@@ -43,7 +44,7 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
             $data['name'] = $component->getName();
             $data['view'] = $view->name();
             $data['component'] = get_class($component);
-            $data['id'] = $component->id;
+            $data['id'] = $component_id;
 
             $this->data[$key] = $this->formatVar($data);
         });
@@ -51,19 +52,20 @@ class LivewireCollector extends DataCollector implements DataCollectorInterface,
         Livewire::listen('render', function (Component $component) use ($request) {
             // Create an unique name for each compoent
             $key = $component->getName() . ' #' . $component->getId();
+            $component_id = !property_exists($component, 'id') ? $component->getId() : $component->id;
 
             $data = [
                 'data' => $component->all(),
             ];
 
-            if ($request->request->get('id') == $component->getId()) {
+            if ($request->request->get('id') == $component_id) {
                 $data['oldData'] = $request->request->get('data');
                 $data['actionQueue'] = $request->request->get('actionQueue');
             }
 
             $data['name'] = $component->getName();
             $data['component'] = get_class($component);
-            $data['id'] = $component->getId();
+            $data['id'] = $component_id;
 
             $this->data[$key] = $this->formatVar($data);
         });


### PR DESCRIPTION
Due to the removal of the $component->id function, which is replaced with $component->getId(), the current version of Debugbar returns a blank Livewire slot.

This PR matches against the "id" property if it exists, otherwise it uses the getId() to provide some backwards compatibility.

No tests created.