### PR TITLE
fix when forget button is unclickable if the cache name is too long

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -334,6 +334,9 @@ ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
     top: 0px;
     color: #000;
     font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 90%;
 }
 
 ul.phpdebugbar-widgets-timeline li .phpdebugbar-widgets-value span.phpdebugbar-widgets-label {


### PR DESCRIPTION
Fix issue #1363[](https://github.com/barryvdh/laravel-debugbar/issues/1363)

Before:
<img width="1241" alt="Before" src="https://github.com/barryvdh/laravel-debugbar/assets/42939853/5647b713-10e2-4f41-8ab4-d74502abf183">

After:
![After](https://github.com/barryvdh/laravel-debugbar/assets/42939853/ed870690-a45a-49ec-83b9-70c6e2c0b64e)
