### PR TITLE
Feat protect storage

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -31,9 +31,13 @@ return [
      | By default, file storage (in the storage folder) is used. Redis and PDO
      | can also be used. For PDO, run the package migrations first.
      |
+     | Warning: Enabling storage.open will allow everyone to access previous request, 
+     | do not enable open storage in publicly available environments!  
+     | Specify a callback if you want to limit based on IP or authentication.
      */
     'storage' => [
         'enabled'    => true,
+        'open'       => env('DEBUGBAR_OPEN_STORAGE', false), // Can be bool or callback. 
         'driver'     => 'file', // redis, file, pdo, socket, custom
         'path'       => storage_path('debugbar'), // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Read [the documentation](http://phpdebugbar.com/docs/) for more configuration op
 ![Debugbar 3.3 Screenshot](https://user-images.githubusercontent.com/973269/79428890-196cc680-7fc7-11ea-8229-189f5eac9009.png)
 
 
-> Note: Use the DebugBar only in development. Do not use Debugbar on public websites, as it will leak information from stored requests (by design). It can also slow the application down (because it has to gather data). So when experiencing slowness, try disabling some of the collectors.
+### Note: Use the DebugBar only in development. Do not use Debugbar on publicly accessible websites, as it will leak information from stored requests (by design). It can also slow the application down (because it has to gather data). So when experiencing slowness, try disabling some of the collectors.
 
 This package includes some custom collectors:
  - QueryCollector: Show all queries, including binding + timing
@@ -183,6 +183,12 @@ You can enable or disable the debugbar during run time.
 
 NB. Once enabled, the collectors are added (and could produce extra overhead), so if you want to use the debugbar in production, disable in the config and only enable when needed.
 
+## Storage
+
+Debugbar remembers previous requests, which you can view using the Browse button on the right. This will only work if you enable `debugbar.storage.open` in the config. 
+Make sure you only do this on local development, because otherwise other people will be able to view previous requests.
+In general, Debugbar should only be used locally or at least restricted by IP.
+It's possible to pass a callback, which will receive the Request object, so you can determine access to the OpenHandler storage.
 
 ## Twig Integration
 


### PR DESCRIPTION
Force users to enable open storage. Shows an error message to enable it, to avoid confusion.

![image](https://github.com/barryvdh/laravel-debugbar/assets/973269/9d7c6fa9-2e7e-4289-abf3-dd7c526133a0)
