### PR TITLE
Adding of messages can be chained

### DIFF
--- a/src/Facades/Debugbar.php
+++ b/src/Facades/Debugbar.php
@@ -7,17 +7,17 @@ use DebugBar\DataCollector\DataCollectorInterface;
 /**
  * @method static LaravelDebugbar addCollector(DataCollectorInterface $collector)
  * @method static void addMessage(mixed $message, string $label = 'info')
- * @method static void alert(mixed $message)
- * @method static void critical(mixed $message)
- * @method static void debug(mixed $message)
- * @method static void emergency(mixed $message)
- * @method static void error(mixed $message)
+ * @method static LaravelDebugbar alert(mixed $message)
+ * @method static LaravelDebugbar critical(mixed $message)
+ * @method static LaravelDebugbar debug(mixed $message)
+ * @method static LaravelDebugbar emergency(mixed $message)
+ * @method static LaravelDebugbar error(mixed $message)
  * @method static LaravelDebugbar getCollector(string $name)
  * @method static bool hasCollector(string $name)
- * @method static void info(mixed $message)
- * @method static void log(mixed $message)
- * @method static void notice(mixed $message)
- * @method static void warning(mixed $message)
+ * @method static LaravelDebugbar info(mixed $message)
+ * @method static LaravelDebugbar log(mixed $message)
+ * @method static LaravelDebugbar notice(mixed $message)
+ * @method static LaravelDebugbar warning(mixed $message)
  *
  * @see \Barryvdh\Debugbar\LaravelDebugbar
  */

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -45,15 +45,15 @@ use Symfony\Component\HttpFoundation\Response;
  * Debug bar subclass which adds all without Request and with LaravelCollector.
  * Rest is added in Service Provider
  *
- * @method void emergency(...$message)
- * @method void alert(...$message)
- * @method void critical(...$message)
- * @method void error(...$message)
- * @method void warning(...$message)
- * @method void notice(...$message)
- * @method void info(...$message)
- * @method void debug(...$message)
- * @method void log(...$message)
+ * @method LaravelDebugbar emergency(...$message)
+ * @method LaravelDebugbar alert(...$message)
+ * @method LaravelDebugbar critical(...$message)
+ * @method LaravelDebugbar error(...$message)
+ * @method LaravelDebugbar warning(...$message)
+ * @method LaravelDebugbar notice(...$message)
+ * @method LaravelDebugbar info(...$message)
+ * @method LaravelDebugbar debug(...$message)
+ * @method LaravelDebugbar log(...$message)
  */
 class LaravelDebugbar extends DebugBar
 {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1034,7 +1034,7 @@ class LaravelDebugbar extends DebugBar
      *
      * @param string $method
      * @param array $args
-     * @return mixed|void
+     * @return $this
      */
     public function __call($method, $args)
     {
@@ -1044,6 +1044,8 @@ class LaravelDebugbar extends DebugBar
                 $this->addMessage($arg, $method);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
fixes #1376[](https://github.com/barryvdh/laravel-debugbar/issues/1376)

Allow to call `debugbar()->emergency('message #1')->alert('message #2')->critical('message #3')`.