### PR TITLE
Hide sensitive information by config

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -216,6 +216,12 @@ return [
         'route' => [
             'label' => true,  // show complete route on bar
         ],
+        'session' => [
+            'hiddens' => [], // hides sensitive values using array paths
+        ],
+        'symfony_request' => [
+            'hiddens' => [], // hides sensitive values using array paths, example: request_request.password
+        ],
         'logs' => [
             'file' => null,
         ],

--- a/src/DataCollector/SessionCollector.php
+++ b/src/DataCollector/SessionCollector.php
@@ -5,20 +5,25 @@ namespace Barryvdh\Debugbar\DataCollector;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\Renderable;
+use Illuminate\Support\Arr;
 
 class SessionCollector extends DataCollector implements DataCollectorInterface, Renderable
 {
     /** @var  \Symfony\Component\HttpFoundation\Session\SessionInterface|\Illuminate\Contracts\Session\Session $session */
     protected $session;
+    /** @var array */
+    protected $hiddens;
 
     /**
      * Create a new SessionCollector
      *
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface|\Illuminate\Contracts\Session\Session $session
+     * @param array $hiddens
      */
-    public function __construct($session)
+    public function __construct($session, $hiddens = [])
     {
         $this->session = $session;
+        $this->hiddens = $hiddens;
     }
 
     /**
@@ -26,10 +31,18 @@ class SessionCollector extends DataCollector implements DataCollectorInterface, 
      */
     public function collect()
     {
-        $data = [];
-        foreach ($this->session->all() as $key => $value) {
+        $data = $this->session->all();
+
+        foreach ($this->hiddens as $key) {
+            if (Arr::has($data, $key)) {
+                Arr::set($data, $key, '******');
+            }
+        }
+
+        foreach ($data as $key => $value) {
             $data[$key] = is_string($value) ? $value : $this->formatVar($value);
         }
+
         return $data;
     }
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -701,6 +701,7 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
+        $sessionHiddens = $app['config']->get('debugbar.options.session.hiddens', []);
         if ($this->app->bound(SessionManager::class)) {
 
             /** @var \Illuminate\Session\SessionManager $sessionManager */
@@ -710,7 +711,7 @@ class LaravelDebugbar extends DebugBar
 
             if ($this->shouldCollect('session') && ! $this->hasCollector('session')) {
                 try {
-                    $this->addCollector(new SessionCollector($sessionManager));
+                    $this->addCollector(new SessionCollector($sessionManager, $sessionHiddens));
                 } catch (\Exception $e) {
                     $this->addThrowable(
                         new Exception(
@@ -725,10 +726,14 @@ class LaravelDebugbar extends DebugBar
             $sessionManager = null;
         }
 
+        $requestHiddens = array_merge(
+            $app['config']->get('debugbar.options.symfony_request.hiddens', []),
+            array_map(fn ($key) => 'session_attributes.' . $key, $sessionHiddens)
+        );
         if ($this->shouldCollect('symfony_request', true) && !$this->hasCollector('request')) {
             try {
                 $reqId = $this->getCurrentRequestId();
-                $this->addCollector(new RequestCollector($request, $response, $sessionManager, $reqId));
+                $this->addCollector(new RequestCollector($request, $response, $sessionManager, $reqId, $requestHiddens));
             } catch (\Exception $e) {
                 $this->addThrowable(
                     new Exception(
@@ -742,7 +747,7 @@ class LaravelDebugbar extends DebugBar
 
         if ($app['config']->get('debugbar.clockwork') && ! $this->hasCollector('clockwork')) {
             try {
-                $this->addCollector(new ClockworkCollector($request, $response, $sessionManager));
+                $this->addCollector(new ClockworkCollector($request, $response, $sessionManager, $requestHiddens));
             } catch (\Exception $e) {
                 $this->addThrowable(
                     new Exception(

--- a/src/Support/Clockwork/ClockworkCollector.php
+++ b/src/Support/Clockwork/ClockworkCollector.php
@@ -5,6 +5,7 @@ namespace Barryvdh\Debugbar\Support\Clockwork;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\Renderable;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -20,6 +21,8 @@ class ClockworkCollector extends DataCollector implements DataCollectorInterface
     protected $response;
     /** @var  \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
     protected $session;
+    /** @var array */
+    protected $hiddens;
 
     /**
      * Create a new SymfonyRequestCollector
@@ -27,12 +30,19 @@ class ClockworkCollector extends DataCollector implements DataCollectorInterface
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param \Symfony\Component\HttpFoundation\Request $response
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
+     * @param array $hiddens
      */
-    public function __construct($request, $response, $session = null)
+    public function __construct($request, $response, $session = null, $hiddens = [])
     {
         $this->request = $request;
         $this->response = $response;
         $this->session = $session;
+        $this->hiddens = array_merge($hiddens, [
+            'request_request.password',
+            'request_request.PHP_AUTH_PW',
+            'request_request.php-auth-pw',
+            'request_headers.php-auth-pw.0',
+        ]);
     }
 
     /**
@@ -70,19 +80,27 @@ class ClockworkCollector extends DataCollector implements DataCollectorInterface
         ];
 
         if ($this->session) {
-            $sessionAttributes = [];
-            foreach ($this->session->all() as $key => $value) {
-                $sessionAttributes[$key] = $value;
+            $data['sessionData'] = $this->session->all();
+        }
+
+        if (isset($data['headers']['authorization'][0])) {
+            $data['headers']['authorization'][0] = substr($data['headers']['authorization'][0], 0, 12) . '******';
+        }
+
+        $keyAlias = [
+            'request_query' => 'getData',
+            'request_request' => 'postData',
+            'request_headers' => 'headers',
+            'request_cookies' => 'cookies',
+            'session_attributes' => 'sessionData',
+        ];
+        foreach ($this->hiddens as $key) {
+            $key = explode('.', $key);
+            $key[0] = $keyAlias[$key[0]] ?? $key[0];
+            $key = implode('.', $key);
+            if (Arr::has($data, $key)) {
+                Arr::set($data, $key, '******');
             }
-            $data['sessionData'] = $sessionAttributes;
-        }
-
-        if (isset($data['postData']['php-auth-pw'])) {
-            $data['postData']['php-auth-pw'] = '******';
-        }
-
-        if (isset($data['postData']['PHP_AUTH_PW'])) {
-            $data['postData']['PHP_AUTH_PW'] = '******';
         }
 
         return $data;


### PR DESCRIPTION
#1452 shows a security problem on debugbar files, this PR offer posibility of hide data by config, sometimes can be used not default keys like `pass`, `token`, or others
Only `request_request.password` is hidden from `request_request`
https://github.com/barryvdh/laravel-debugbar/blob/27b088aaad2adba74a7a73a47cb8d11277b551e3/src/DataCollector/RequestCollector.php#L128-L130

**CC:** @barryvdh 

**UPDATE:** Now it hide keys on clockwork too, also it hide `authorization` token(security fix)