### PR TITLE
Fix readability on `Str::is`

### DIFF
--- a/src/DataCollector/RequestCollector.php
+++ b/src/DataCollector/RequestCollector.php
@@ -116,11 +116,7 @@ class RequestCollector extends DataCollector implements DataCollectorInterface, 
         }
 
         foreach ($data['request_server'] as $key => $value) {
-            if (
-                Str::is('*_KEY', $key) || Str::is('*_PASSWORD', $key)
-                    || Str::is('*_SECRET', $key) || Str::is('*_PW', $key)
-                    || Str::is('*_TOKEN', $key) || Str::is('*_PASS', $key)
-            ) {
+            if (Str::is(['*_KEY', '*_PASSWORD', '*_SECRET', '*_PW', '*_TOKEN', '*_PASS'], $key)) {
                 $data['request_server'][$key] = '******';
             }
         }
@@ -140,7 +136,6 @@ class RequestCollector extends DataCollector implements DataCollectorInterface, 
         if (isset($data['request_server']['PHP_AUTH_PW'])) {
             $data['request_server']['PHP_AUTH_PW'] = '******';
         }
-        ;
 
         foreach ($data as $key => $var) {
             if (!is_string($data[$key])) {


### PR DESCRIPTION
`Str::is` supports patterns array
[Illuminate/Support/Str.php#L354-L367](https://github.com/laravel/framework/blob/e3350e87a52346af9cc655a3012d2175d2d05ad7/src/Illuminate/Support/Str.php#L354-L367)