### PR TITLE
SymfonyMailCollector support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "maximebf/debugbar": "^1.18.2",
+        "maximebf/debugbar": "^1.19",
         "illuminate/routing": "^9|^10",
         "illuminate/session": "^9|^10",
         "illuminate/support": "^9|^10",

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -206,6 +206,7 @@ return [
             'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
         ],
         'mail' => [
+            'timeline' => false,  // Add mails to the timeline
             'full_log' => false,
         ],
         'views' => [

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ This package includes some custom collectors:
 
 Bootstraps the following collectors for Laravel:
  - LogCollector: Show all Log messages
- - SwiftMailCollector and SwiftLogCollector for Mail
+ - SymfonyMailCollector for Mail
 
 And the default collectors:
  - PhpInfoCollector

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -18,8 +18,7 @@ use Barryvdh\Debugbar\DataCollector\ViewCollector;
 use Barryvdh\Debugbar\Storage\SocketStorage;
 use Barryvdh\Debugbar\Storage\FilesystemStorage;
 use DebugBar\Bridge\MonologCollector;
-use DebugBar\Bridge\SwiftMailer\SwiftLogCollector;
-use DebugBar\Bridge\SwiftMailer\SwiftMailCollector;
+use DebugBar\Bridge\Symfony\SymfonyMailCollector;
 use DebugBar\DataCollector\ConfigCollector;
 use DebugBar\DataCollector\DataCollectorInterface;
 use DebugBar\DataCollector\ExceptionsCollector;
@@ -36,10 +35,15 @@ use DebugBar\Storage\RedisStorage;
 use Exception;
 use Throwable;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Session\SessionManager;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\RawMessage;
 
 /**
  * Debug bar subclass which adds all without Request and with LaravelCollector.
@@ -455,16 +459,42 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
-        if ($this->shouldCollect('mail', true) && class_exists('Illuminate\Mail\MailServiceProvider') && $this->checkVersion('9.0', '<')) {
+        if ($this->shouldCollect('mail', true) && class_exists('Illuminate\Mail\MailServiceProvider') && isset($this->app['events'])) {
             try {
-                $mailer = $this->app['mailer']->getSwiftMailer();
-                $this->addCollector(new SwiftMailCollector($mailer));
-                if (
-                    $this->app['config']->get('debugbar.options.mail.full_log') && $this->hasCollector(
-                        'messages'
-                    )
-                ) {
-                    $this['messages']->aggregate(new SwiftLogCollector($mailer));
+                $mailCollector = new SymfonyMailCollector();
+                $this->addCollector($mailCollector);
+                $this->app['events']->listen(function (MessageSent $event) use ($mailCollector) {
+                    $mailCollector->addSymfonyMessage($event->sent->getSymfonySentMessage());
+                });
+
+                if ($this->app['config']->get('debugbar.options.mail.full_log')) {
+                    $mailCollector->showMessageDetail();
+                }
+
+                if ($debugbar->hasCollector('time') && $this->app['config']->get('debugbar.options.mail.timeline')) {
+                    $transport = $this->app['mailer']->getSymfonyTransport();
+                    $this->app['mailer']->setSymfonyTransport(new class($transport, $this) extends AbstractTransport{
+                        private $originalTransport;
+                        private $laravelDebugbar;
+
+                        public function __construct($transport, $laravelDebugbar)
+                        {
+                            $this->originalTransport = $transport;
+                            $this->laravelDebugbar = $laravelDebugbar;
+                        }
+                        public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+                        {
+                            return $this->laravelDebugbar['time']->measure(
+                                'mail: '. Str::limit($message->getSubject(), 100),
+                                function () use ($message, $envelope) {
+                                    return $this->originalTransport->send($message, $envelope);
+                                },
+                                'mail'
+                            );
+                        }
+                        protected function doSend(SentMessage $message): void {}
+                        public function __toString(): string{ $this->originalTransport->__toString(); }
+                    });
                 }
             } catch (\Exception $e) {
                 $this->addThrowable(

--- a/src/Support/Clockwork/Converter.php
+++ b/src/Support/Clockwork/Converter.php
@@ -122,11 +122,11 @@ class Converter
             }
         }
 
-        if (isset($data['swiftmailer_mails'])) {
-            foreach ($data['swiftmailer_mails']['mails'] as $mail) {
+        if (isset($data['symfonymailer_mails'])) {
+            foreach ($data['symfonymailer_mails']['mails'] as $mail) {
                 $output['emailsData'][] = [
                     'data' => [
-                        'to' => $mail['to'],
+                        'to' => implode(', ', $mail['to']),
                         'subject' => $mail['subject'],
                         'headers' => isset($mail['headers']) ? explode("\n", $mail['headers']) : null,
                     ],


### PR DESCRIPTION
Closes #1331
Depends on https://github.com/maximebf/php-debugbar/pull/554 release (_1.18.3?_)
Change `SwiftMailCollector` to `SymfonyMailCollector`