### PR TITLE
Support class resolver for open storage

### DIFF
--- a/src/Controllers/OpenHandlerController.php
+++ b/src/Controllers/OpenHandlerController.php
@@ -24,6 +24,10 @@ class OpenHandlerController extends BaseController
             return call_user_func($open, [$request]);
         }
 
+        if (is_string($open) && class_exists($open) && method_exists($open, 'resolve')) {
+            return $open::resolve($request);
+        }
+
         return $open;
     }
 

--- a/src/Controllers/OpenHandlerController.php
+++ b/src/Controllers/OpenHandlerController.php
@@ -24,8 +24,8 @@ class OpenHandlerController extends BaseController
             return call_user_func($open, [$request]);
         }
 
-        if (is_string($open) && class_exists($open) && method_exists($open, 'resolve')) {
-            return $open::resolve($request);
+        if (is_string($open) && class_exists($open)) {
+            return method_exists($open, 'resolve') ? $open::resolve($request) : false;
         }
 
         return $open;

--- a/src/Controllers/OpenHandlerController.php
+++ b/src/Controllers/OpenHandlerController.php
@@ -28,7 +28,7 @@ class OpenHandlerController extends BaseController
             return method_exists($open, 'resolve') ? $open::resolve($request) : false;
         }
 
-        return $open;
+        return is_bool($open) ? $open : false;
     }
 
     public function handle(Request $request)


### PR DESCRIPTION
For config cache, 
Wouldn't it be better to be able to use a resolver by class name instead of a callback method?
So, on `storage.open` we can set a string class name, where is a `resolve` method
Or in `DEBUGBAR_OPEN_STORAGE ` we just can set the fqn of the class