### PR TITLE
Show queries memory usage

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -204,6 +204,7 @@ return [
             'hints'             => false,    // Show hints for common mistakes
             'show_copy'         => false,    // Show copy button next to the query,
             'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
+            'memory_usage'      => false,   // Show queries memory usage
         ],
         'mail' => [
             'full_log' => false,

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -424,6 +424,18 @@ class LaravelDebugbar extends DebugBar
                         $queryCollector->collectTransactionEvent('Rollback Transaction', $params[0]);
                     }
                 );
+
+                $db->getEventDispatcher()->listen(
+                    function (\Illuminate\Database\Events\ConnectionEstablished $event) use ($queryCollector) {
+                        $queryCollector->collectTransactionEvent('Connection Established', $event->connection);
+
+                        if (app('config')->get('debugbar.options.db.memory_usage')) {
+                            $event->connection->beforeExecuting(function () use ($queryCollector){
+                                $queryCollector->startMemoryUsage();
+                            });
+                        }
+                    }
+                );
             } catch (\Exception $e) {
                 $this->addThrowable(
                     new Exception(


### PR DESCRIPTION
Adds memory usage  on queries tab
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/cc4dbbf6-a47f-4b88-bed1-85959ab29887)

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/4b92226a-c623-40e0-a87d-38a78b651d02)

the js widget already supports this