### PR TITLE
show collector name on timeline items

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -196,7 +196,7 @@ class QueryCollector extends PDOCollector
         ];
 
         if ($this->timeCollector !== null) {
-            $this->timeCollector->addMeasure(Str::limit($query, 100), $startTime, $endTime);
+            $this->timeCollector->addMeasure(Str::limit($query, 100), $startTime, $endTime, [], 'db');
         }
     }
 

--- a/src/DebugbarViewEngine.php
+++ b/src/DebugbarViewEngine.php
@@ -39,7 +39,7 @@ class DebugbarViewEngine implements Engine
 
         return $this->laravelDebugbar->measure($shortPath, function () use ($path, $data) {
             return $this->engine->get($path, $data);
-        });
+        }, 'views');
     }
 
     /**

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -157,12 +157,12 @@ class LaravelDebugbar extends DebugBar
             if (! $this->isLumen() && $startTime) {
                 $this->app->booted(
                     function () use ($debugbar, $startTime) {
-                        $debugbar['time']->addMeasure('Booting', $startTime, microtime(true));
+                        $debugbar->addMeasure('Booting', $startTime, microtime(true), [], 'time');
                     }
                 );
             }
 
-            $debugbar->startMeasure('application', 'Application');
+            $debugbar->startMeasure('application', 'Application', 'time');
         }
 
         if ($this->shouldCollect('memory', true)) {
@@ -583,13 +583,14 @@ class LaravelDebugbar extends DebugBar
      *
      * @param string $name Internal name, used to stop the measure
      * @param string $label Public name
+     * @param string|null $collector
      */
-    public function startMeasure($name, $label = null)
+    public function startMeasure($name, $label = null, $collector = null)
     {
         if ($this->hasCollector('time')) {
-            /** @var \DebugBar\DataCollector\TimeDataCollector $collector */
-            $collector = $this->getCollector('time');
-            $collector->startMeasure($name, $label);
+            /** @var \DebugBar\DataCollector\TimeDataCollector */
+            $time = $this->getCollector('time');
+            $time->startMeasure($name, $label, $collector);
         }
     }
 
@@ -942,13 +943,15 @@ class LaravelDebugbar extends DebugBar
      * @param string $label
      * @param float $start
      * @param float $end
+     * @param array|null $params
+     * @param string|null $collector
      */
-    public function addMeasure($label, $start, $end)
+    public function addMeasure($label, $start, $end, $params = [], $collector = null)
     {
         if ($this->hasCollector('time')) {
-            /** @var \DebugBar\DataCollector\TimeDataCollector $collector */
-            $collector = $this->getCollector('time');
-            $collector->addMeasure($label, $start, $end);
+            /** @var \DebugBar\DataCollector\TimeDataCollector */
+            $time = $this->getCollector('time');
+            $time->addMeasure($label, $start, $end, $params, $collector);
         }
     }
 
@@ -957,14 +960,15 @@ class LaravelDebugbar extends DebugBar
      *
      * @param string $label
      * @param \Closure $closure
+     * @param string|null $collector
      * @return mixed
      */
-    public function measure($label, \Closure $closure)
+    public function measure($label, \Closure $closure, $collector = null)
     {
         if ($this->hasCollector('time')) {
-            /** @var \DebugBar\DataCollector\TimeDataCollector $collector */
-            $collector = $this->getCollector('time');
-            $result = $collector->measure($label, $closure);
+            /** @var \DebugBar\DataCollector\TimeDataCollector  */
+            $time = $this->getCollector('time');
+            $result = $time->measure($label, $closure, $collector);
         } else {
             $result = $closure();
         }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -336,7 +336,7 @@ ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-collector {
     font-size: 11px;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 90%;
+    max-width: 90%;
 }
 
 ul.phpdebugbar-widgets-timeline li .phpdebugbar-widgets-value span.phpdebugbar-widgets-label {


### PR DESCRIPTION
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/a6ddff0b-1b8f-4c4f-95aa-0e66b0b0bed4)

the js widget already supports this

This fix a css bug, added on #1440
```diff
-width: 90%;
+max-width: 90%;
```