### PR TITLE
Add nonce to <script> elements

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -63,14 +63,20 @@ class JavascriptRenderer extends BaseJavascriptRenderer
         $cssRoute = preg_replace('/\Ahttps?:/', '', $cssRoute);
         $jsRoute  = preg_replace('/\Ahttps?:/', '', $jsRoute);
 
+        $nonce = $this->getNonceAttribute();
+
         $html  = "<link rel='stylesheet' type='text/css' property='stylesheet' href='{$cssRoute}' data-turbolinks-eval='false' data-turbo-eval='false'>";
-        $html .= "<script src='{$jsRoute}' data-turbolinks-eval='false' data-turbo-eval='false'></script>";
+        $html .= "<script{$nonce} src='{$jsRoute}' data-turbolinks-eval='false' data-turbo-eval='false'></script>";
 
         if ($this->isJqueryNoConflictEnabled()) {
-            $html .= '<script data-turbo-eval="false">jQuery.noConflict(true);</script>' . "\n";
+            $html .= "<script{$nonce} data-turbo-eval='false'>jQuery.noConflict(true);</script>" . "\n";
         }
 
-        $html .= $this->getInlineHtml();
+        $inlineHtml = $this->getInlineHtml();
+        if ($nonce != '') {
+            $inlineHtml = preg_replace("/<script>/", "<script{$nonce}>", $inlineHtml);
+        }
+        $html .= $inlineHtml;
 
 
         return $html;


### PR DESCRIPTION
This PR adds the configured nonce to <script> elements (or nothing, it no nonce is set, since `getNonceAttribute` will then return an empty string).

This does not fix all of the csp issues (embedded fonts, third party assets), but it atleast makes laravel-debugbar usable with a configured content security policy.

To set the nonce, you can use `Debugbar::getJavascriptRenderer()->setCspNonce($yourNonce);`
