### PR TITLE
Add nonce to <style> element created by HtmlDumper

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -74,7 +74,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
 
         $inlineHtml = $this->getInlineHtml();
         if ($nonce != '') {
-            $inlineHtml = preg_replace("/<script>/", "<script{$nonce}>", $inlineHtml);
+            $inlineHtml = preg_replace("/<(script|style)>/", "<$1{$nonce}>", $inlineHtml);
         }
         $html .= $inlineHtml;
 


### PR DESCRIPTION
This PR, in combination with another PR to maximebf/php-debugbar (yet to come, I haven't figured out a good solution yet), will fix the `style-src` csp errors.