### PR TITLE
fix css dark mode

### DIFF
--- a/src/Resources/laravel-debugbar-dark-mode.css
+++ b/src/Resources/laravel-debugbar-dark-mode.css
@@ -233,6 +233,14 @@ div.phpdebugbar a.phpdebugbar-close-btn {
     background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABUElEQVQ4T52SMUsDMRTH3xUPChHCxeko3YrUqeFGEexym3boJ9DBufhJpLODfoIbTrcuFcSxxMki3Uq5yZRAAweRVp70HdfWQZolb3i/l/x/iQd7Lm9PDjbA2Wz24HmerFarbSGEwaFaa57n+XC1WqlarXZNBxUgQsaYK+ccCCHeGWPn2GStfdFat3zfB875I8EFOBqNPpbLZRObsQnh9YktHIarUqmMoyg6wboApZTtfr9/zxhrEIw7QdbaSa/Xu1FKDTdAADiQUp6VYcpTgl4B4HsbhCRJjsIwfPN9/7hs2zn3mWXZabfb/dqRg/ZIBF2PmigzCiPbRcbpdKrQXjkTguXMKKxer8uNqw4Gg6cgCC7WT/ArAuty5vl8/hzH8eV2xmaapnec88baHooAEmaMmXQ6nVsAGO/IAQB8x0MAUGQPbSMPAAuC/gL//XV/ALsvnQ+MsaHgAAAAAElFTkSuQmCC) no-repeat 9px 6px;
 }
 
+div.phpdebugbar code.language-php,
+div.phpdebugbar pre.language-php {
+    color: #FFF;
+}
+
+pre.phpdebugbar-widgets-code-block ul {
+    background: none;
+}
 
 /* Dracula Theme v1.2.5
  *


### PR DESCRIPTION
- after https://github.com/maximebf/php-debugbar/pull/547, dark mode needs updates for readability, default color  for not reserved words is `#FFF`
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/8cd4a3fb-c1c7-45db-8eef-6ee5e242130e)
