### PR TITLE
Introduce JobsCollector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -176,6 +176,7 @@ return [
         'cache'           => false, // Display cache events
         'models'          => true,  // Display models
         'livewire'        => true,  // Display Livewire (when available)
+        'jobs'            => false, // Display enqueued jobs
     ],
 
     /*

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -176,7 +176,7 @@ return [
         'cache'           => false, // Display cache events
         'models'          => true,  // Display models
         'livewire'        => true,  // Display Livewire (when available)
-        'jobs'            => false, // Display enqueued jobs
+        'jobs'            => false, // Display dispatched jobs
     ],
 
     /*

--- a/src/DataCollector/JobsCollector.php
+++ b/src/DataCollector/JobsCollector.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\DataCollectorInterface;
+use DebugBar\DataCollector\Renderable;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class JobsCollector extends DataCollector implements DataCollectorInterface, Renderable
+{
+    public $jobs = [];
+    public $count = 0;
+
+    /**
+     * @param Dispatcher $events
+     */
+    public function __construct(Dispatcher $events)
+    {
+        $events->listen(\Illuminate\Queue\Events\JobQueued::class, function ($event) {
+                $class = get_class($event->job);
+                $this->jobs[$class] = ($this->jobs[$class] ?? 0) + 1;
+                $this->count++;
+        });
+    }
+
+    public function collect()
+    {
+        ksort($this->jobs, SORT_NUMERIC);
+
+        return ['data' => array_reverse($this->jobs), 'count' => $this->count];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'jobs';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        return [
+            "jobs" => [
+                "icon" => "briefcase",
+                "widget" => "PhpDebugBar.Widgets.HtmlVariableListWidget",
+                "map" => "jobs.data",
+                "default" => "{}"
+            ],
+            'jobs:badge' => [
+                'map' => 'jobs.count',
+                'default' => 0
+            ]
+        ];
+    }
+}

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -348,7 +348,7 @@ class LaravelDebugbar extends DebugBar
                         if (!app(static::class)->shouldCollect('db', true)) {
                             return; // Issue 776 : We've turned off collecting after the listener was attached
                         }
-                        
+
                         $bindings = $query->bindings;
                         $time = $query->time;
                         $connection = $query->connection;
@@ -554,6 +554,15 @@ class LaravelDebugbar extends DebugBar
                         $e
                     )
                 );
+            }
+        }
+
+        if ($this->shouldCollect('jobs', false)) {
+            try {
+                $jobsCollector = $this->app->make('Barryvdh\Debugbar\DataCollector\JobsCollector');
+                $this->addCollector($jobsCollector);
+            } catch (\Exception $e) {
+                // No Jobs collector
             }
         }
 

--- a/tests/DataCollector/JobsCollectorTest.php
+++ b/tests/DataCollector/JobsCollectorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\Tests\Jobs\OrderShipped;
+use Barryvdh\Debugbar\Tests\Jobs\SendNotification;
+use Barryvdh\Debugbar\Tests\TestCase;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+class JobsCollectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('debugbar.collectors.jobs', true);
+        // The `sync` and `null` driver don't dispatch events
+        // `database` or `redis` driver work great
+        $app['config']->set('queue.default', 'database');
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    public function testItCollectsDispatchedJobs()
+    {
+        $this->loadLaravelMigrations();
+        $this->createJobsTable();
+
+        debugbar()->boot();
+
+        /** @var \Barryvdh\Debugbar\DataCollector\ModelsCollector $collector */
+        $collector = debugbar()->getCollector('jobs');
+
+        $this->assertEquals(
+            ['data' => [], 'count' => 0],
+            $collector->collect()
+        );
+
+        OrderShipped::dispatch(1);
+
+        $this->assertEquals(
+            ['data' => [OrderShipped::class => 1], 'count' => 1],
+            $collector->collect()
+        );
+
+        dispatch(new SendNotification());
+        dispatch(new SendNotification());
+        dispatch(new SendNotification());
+
+        $this->assertEquals(
+            ['data' => [OrderShipped::class => 1, SendNotification::class => 3], 'count' => 4],
+            $collector->collect()
+        );
+    }
+
+    protected function createJobsTable()
+    {
+        (new class extends Migration
+        {
+            public function up()
+            {
+                Schema::create('jobs', function (Blueprint $table) {
+                    $table->bigIncrements('id');
+                    $table->string('queue')->index();
+                    $table->longText('payload');
+                    $table->unsignedTinyInteger('attempts');
+                    $table->unsignedInteger('reserved_at')->nullable();
+                    $table->unsignedInteger('available_at');
+                    $table->unsignedInteger('created_at');
+                });
+            }
+        })->up();
+    }
+}

--- a/tests/Jobs/OrderShipped.php
+++ b/tests/Jobs/OrderShipped.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class OrderShipped implements ShouldQueue
+{
+    use Dispatchable;
+
+    private $orderId;
+
+    public function __construct($orderId)
+    {
+        $this->orderId = $orderId;
+    }
+
+    public function handle()
+    {
+        // Do Nothing
+    }
+}

--- a/tests/Jobs/SendNotification.php
+++ b/tests/Jobs/SendNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SendNotification implements ShouldQueue
+{
+    use Dispatchable;
+
+    public function handle()
+    {
+        // Do Nothing
+    }
+}


### PR DESCRIPTION
This PR adds a JobsCollector, so you can track in the Debugbar what background jobs have been dispatched.

The JobsCollector is very similar to ModelsCollector but listens to the `JobQueued` events.

Note that this event is dispatched by all "production-ready" drivers but not `null` and `sync` drivers.

For testing, I only use the `database` driver for my tests, I didn't want to change the entire setup.

### Screenshots

<img width="872" alt="CleanShot 2023-09-21 at 06 31 45@2x" src="https://github.com/barryvdh/laravel-debugbar/assets/1525636/9991af00-9453-4f1f-927d-d805cc8fa9ce">
<img width="1271" alt="CleanShot 2023-09-21 at 06 32 09@2x" src="https://github.com/barryvdh/laravel-debugbar/assets/1525636/763e1c9b-0531-42a6-8f7d-cc8c51b2ad32">
<img width="1161" alt="CleanShot 2023-09-21 at 06 37 43@2x" src="https://github.com/barryvdh/laravel-debugbar/assets/1525636/c67ca9f0-3ffe-43b6-9ffb-e25787ec4070">
