### PR TITLE
(fix) Exclude laravel collection query calls

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -26,6 +26,7 @@ class QueryCollector extends PDOCollector
         '/vendor/laravel/framework/src/Illuminate/Support',
         '/vendor/laravel/framework/src/Illuminate/Database',
         '/vendor/laravel/framework/src/Illuminate/Events',
+        '/vendor/laravel/framework/src/Illuminate/Collections',
         '/vendor/october/rain',
         '/vendor/barryvdh/laravel-debugbar',
     ];


### PR DESCRIPTION
This PR excludes `/Illuminate/Collections` from backtrace, this happens on "lazy" queries like `cursor()`
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/0d4b3339-3b83-4024-a23b-2387844407f9)
After this, it shows the right file