### PR TITLE
GitHub workflow improvements

### DIFF
--- a/.github/workflows/fix-cs.yml
+++ b/.github/workflows/fix-cs.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.2
         coverage: none
         tools: composer:v2
 

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
             COMPOSER_NO_INTERACTION: 1
         strategy:
             matrix:
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 lumen: [9.*]
                 exclude:
                   - lumen: 10.*
@@ -65,7 +65,7 @@ jobs:
             COMPOSER_NO_INTERACTION: 1
         strategy:
             matrix:
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 laravel: [10.*, 9.*]
                 exclude:
                   - laravel: 10.*

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             matrix:
                 php: [8.3, 8.2, 8.1, 8.0]
-                lumen: [9.*]
+                lumen: [10.*, 9.*]
                 exclude:
                   - lumen: 10.*
                     php: 8.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.1, 8.0]
+        php: [8.3, 8.2, 8.1, 8.0]
         laravel: [^10, ^9]
         dependency-version: [prefer-stable]
         exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:>=2.62.1" --no-interaction --no-update
+        composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
 
     - name: Update Dusk Chromedriver

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -348,7 +348,7 @@ class LaravelDebugbar extends DebugBar
                         if (!app(static::class)->shouldCollect('db', true)) {
                             return; // Issue 776 : We've turned off collecting after the listener was attached
                         }
-                        
+
                         $bindings = $query->bindings;
                         $time = $query->time;
                         $connection = $query->connection;
@@ -458,7 +458,7 @@ class LaravelDebugbar extends DebugBar
 
                 if ($debugbar->hasCollector('time') && $this->app['config']->get('debugbar.options.mail.timeline')) {
                     $transport = $this->app['mailer']->getSymfonyTransport();
-                    $this->app['mailer']->setSymfonyTransport(new class($transport, $this) extends AbstractTransport{
+                    $this->app['mailer']->setSymfonyTransport(new class ($transport, $this) extends AbstractTransport{
                         private $originalTransport;
                         private $laravelDebugbar;
 
@@ -470,15 +470,20 @@ class LaravelDebugbar extends DebugBar
                         public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
                         {
                             return $this->laravelDebugbar['time']->measure(
-                                'mail: '. Str::limit($message->getSubject(), 100),
+                                'mail: ' . Str::limit($message->getSubject(), 100),
                                 function () use ($message, $envelope) {
                                     return $this->originalTransport->send($message, $envelope);
                                 },
                                 'mail'
                             );
                         }
-                        protected function doSend(SentMessage $message): void {}
-                        public function __toString(): string{ $this->originalTransport->__toString(); }
+                        protected function doSend(SentMessage $message): void
+                        {
+                        }
+                        public function __toString(): string
+                        {
+                            $this->originalTransport->__toString();
+                        }
                     });
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
(This is a follow-up to #1474, as I was doing this myself, then found out there already was a PHP 8.3 PR, so please merge that first; this is based on the branch to prevent merge conflicts).

When updating the workflow, I noticed a few things that could be slightly improved:
- use the latest stable PHP version for the `fix-cs` workflow
- remove the explicit `nesbon/carbon` version requirement in `run-tests` as it is no longer needed
- Add Lumen 10 to `run-integrations-test`, which was probably already meant to be there