### PR TITLE
Only load 5 most relevant traces on QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -177,7 +177,7 @@ class QueryCollector extends PDOCollector
 
         if ($this->findSource) {
             try {
-                $source = array_slice($this->findSource(), 0, 5);
+                $source = $this->findSource();
             } catch (\Exception $e) {
             }
         }
@@ -272,7 +272,7 @@ class QueryCollector extends PDOCollector
             $sources[] = $this->parseTrace($index, $trace);
         }
 
-        return array_filter($sources);
+        return array_slice(array_filter($sources), 0, 5);
     }
 
     /**


### PR DESCRIPTION
@barryvdh you forgot `collectTransactionEvent` on https://github.com/barryvdh/laravel-debugbar/commit/a41ea1343fe95a57543f4b24861acbd1bd71bcb6, it would be better to revert it and make it global

On transaction events, debugbar show larger trace

https://github.com/barryvdh/laravel-debugbar/blob/b7362410434d7f1155e0729e3a75c83384d3b699/src/DataCollector/QueryCollector.php#L458