### PR TITLE
fix query widget, the query collector maybe is empty

### DIFF
--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -221,6 +221,10 @@
             this.$list.$el.appendTo(this.$el);
 
             this.bindAttr('data', function (data) {
+                // the collector maybe is empty
+                if (data.length <= 0 || !data.statements) {
+                    return false;
+                }
                 this.$list.set('data', data.statements);
                 this.$status.empty();
                 var stmt;


### PR DESCRIPTION
https://github.com/maximebf/php-debugbar/pull/349 fix
Closes #559

if the query collector is empty, the script will throw js error
```
Uncaught TypeError: Cannot read property 'length' of undefined
On 1906: for (var sql = {}, duplicate = 0, i = 0; i < data.statements.length; i++) {
```