### PR TITLE
#1490 adds ajax_handler_auto_show to debugbar.php

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -116,10 +116,14 @@ return [
      |
      | Note for your request to be identified as ajax requests they must either send the header
      | X-Requested-With with the value XMLHttpRequest (most JS libraries send this), or have application/json as a Accept header.
+     | 
+     | By defauult `ajax_handler_auto_show` is set to true be default, changing this to false will disable the auto show once a 
+     | new ajax request is detected.
      */
 
     'capture_ajax' => true,
     'add_ajax_timing' => false,
+    'ajax_handler_auto_show' => true,
 
     /*
      |--------------------------------------------------------------------------

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -117,8 +117,8 @@ return [
      | Note for your request to be identified as ajax requests they must either send the header
      | X-Requested-With with the value XMLHttpRequest (most JS libraries send this), or have application/json as a Accept header.
      | 
-     | By default `ajax_handler_auto_show` is set to true be default, changing `ajax_handler_auto_show` to false will disable 
-     | the auto show when a new ajax request is detected.
+     | By default `ajax_handler_auto_show` is set to true allowing ajax requests to be shown automatically in the Debugbar.
+     | Changing `ajax_handler_auto_show` to false will prevent the Debugbar from reloading.
      */
 
     'capture_ajax' => true,

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -117,7 +117,7 @@ return [
      | Note for your request to be identified as ajax requests they must either send the header
      | X-Requested-With with the value XMLHttpRequest (most JS libraries send this), or have application/json as a Accept header.
      | 
-     | By defauult `ajax_handler_auto_show` is set to true be default, changing this to false will disable the auto show once a 
+     | By default `ajax_handler_auto_show` is set to true be default, changing this to false will disable the auto show once a 
      | new ajax request is detected.
      */
 

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -117,8 +117,8 @@ return [
      | Note for your request to be identified as ajax requests they must either send the header
      | X-Requested-With with the value XMLHttpRequest (most JS libraries send this), or have application/json as a Accept header.
      | 
-     | By default `ajax_handler_auto_show` is set to true be default, changing this to false will disable the auto show once a 
-     | new ajax request is detected.
+     | By default `ajax_handler_auto_show` is set to true be default, changing `ajax_handler_auto_show` to false will disable 
+     | the auto show when a new ajax request is detected.
      */
 
     'capture_ajax' => true,


### PR DESCRIPTION
There were a few issues that mentioned the same problem. while [1413](https://github.com/barryvdh/laravel-debugbar/issues/1413#issuecomment-1560484959) shows a solution. 

I thought it would be worth while to add the config with its default value to the `debugbar.php` config file so that others might find it more easily.

#1413 $1458 #1490