### PR TITLE
Adds config option to disable the display of parameters in views.

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -213,6 +213,7 @@ return [
         'views' => [
             'timeline' => false,  // Add the views to the timeline (Experimental)
             'data' => false,    //Note: Can slow down the application, because the data can be quite large..
+            'exclude_params' => false, // Enable to reduce browser lag for views with many blade components
             'exclude_paths' => [], // Add the paths which you don't want to appear in the views
         ],
         'route' => [

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -213,7 +213,7 @@ return [
         'views' => [
             'timeline' => false,  // Add the views to the timeline (Experimental)
             'data' => false,    //Note: Can slow down the application, because the data can be quite large..
-            'exclude_params' => false, // Enable to reduce browser lag for views with many blade components
+            'with_params' => true, // Disable to reduce browser lag for views with many blade components
             'exclude_paths' => [], // Add the paths which you don't want to appear in the views
         ],
         'route' => [

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -40,8 +40,8 @@ class ViewCollector extends TwigCollector
     ];
 
     /**
-     * @param bool $collectData Collects view data when tru
-     * @param bool $withParams Exclude list of parameters from views
+     * @param bool $collectData Collects view data when true
+     * @param bool $withParams Include view parameters when true
      * @param string[] $excludePaths Paths to exclude from collection
      */
     public function __construct($collectData = true, $withParams = true, $excludePaths = [])

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -12,7 +12,7 @@ class ViewCollector extends TwigCollector
     protected $name;
     protected $templates = [];
     protected $collect_data;
-    protected $exclude_params;
+    protected $with_params;
     protected $exclude_paths;
 
     /**
@@ -41,14 +41,14 @@ class ViewCollector extends TwigCollector
 
     /**
      * @param bool $collectData Collects view data when tru
-     * @param bool $excludeParams Exclude list of parameters from views
+     * @param bool $withParams Exclude list of parameters from views
      * @param string[] $excludePaths Paths to exclude from collection
      */
-    public function __construct($collectData = true, $excludeParams = false, $excludePaths = [])
+    public function __construct($collectData = true, $withParams = true, $excludePaths = [])
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
-        $this->exclude_params = $excludeParams;
+        $this->with_params = $withParams;
         $this->exclude_paths = $excludePaths;
         $this->templates = [];
     }
@@ -134,7 +134,7 @@ class ViewCollector extends TwigCollector
             }
         }
 
-        if ($this->exclude_params) {
+        if (!$this->with_params) {
             $params = [];
         } elseif (!$this->collect_data) {
             $params = array_keys($view->getData());

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -12,6 +12,7 @@ class ViewCollector extends TwigCollector
     protected $name;
     protected $templates = [];
     protected $collect_data;
+    protected $exclude_params;
     protected $exclude_paths;
 
     /**
@@ -39,17 +40,17 @@ class ViewCollector extends TwigCollector
     ];
 
     /**
-     * Create a ViewCollector
-     *
      * @param bool $collectData Collects view data when tru
+     * @param bool $excludeParams Exclude list of parameters from views
      * @param string[] $excludePaths Paths to exclude from collection
      */
-    public function __construct($collectData = true, $excludePaths = [])
+    public function __construct($collectData = true, $excludeParams = false, $excludePaths = [])
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
-        $this->templates = [];
+        $this->exclude_params = $excludeParams;
         $this->exclude_paths = $excludePaths;
+        $this->templates = [];
     }
 
     public function getName()
@@ -133,7 +134,9 @@ class ViewCollector extends TwigCollector
             }
         }
 
-        if (!$this->collect_data) {
+        if ($this->exclude_params) {
+            $params = [];
+        } elseif (!$this->collect_data) {
             $params = array_keys($view->getData());
         } else {
             $data = [];

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -41,15 +41,15 @@ class ViewCollector extends TwigCollector
 
     /**
      * @param bool $collectData Collects view data when true
-     * @param bool $withParams Include view parameters when true
      * @param string[] $excludePaths Paths to exclude from collection
+     * @param bool $withParams Include view parameters when true
      */
-    public function __construct($collectData = true, $withParams = true, $excludePaths = [])
+    public function __construct($collectData = true, $excludePaths = [], $withParams = true)
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
-        $this->with_params = $withParams;
         $this->exclude_paths = $excludePaths;
+        $this->with_params = $withParams;
         $this->templates = [];
     }
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -213,7 +213,8 @@ class LaravelDebugbar extends DebugBar
             try {
                 $collectData = $this->app['config']->get('debugbar.options.views.data', true);
                 $excludePaths = $this->app['config']->get('debugbar.options.views.exclude_paths', []);
-                $this->addCollector(new ViewCollector($collectData, $excludePaths));
+                $excludeParams = $this->app['config']->get('debugbar.options.views.exclude_params', false);
+                $this->addCollector(new ViewCollector($collectData, $excludeParams, $excludePaths));
                 $this->app['events']->listen(
                     'composing:*',
                     function ($view, $data = []) use ($debugbar) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -212,9 +212,9 @@ class LaravelDebugbar extends DebugBar
         if ($this->shouldCollect('views', true) && isset($this->app['events'])) {
             try {
                 $collectData = $this->app['config']->get('debugbar.options.views.data', true);
-                $withParams = $this->app['config']->get('debugbar.options.views.with_params', true);
                 $excludePaths = $this->app['config']->get('debugbar.options.views.exclude_paths', []);
-                $this->addCollector(new ViewCollector($collectData, $withParams, $excludePaths));
+                $withParams = $this->app['config']->get('debugbar.options.views.with_params', true);
+                $this->addCollector(new ViewCollector($collectData, $excludePaths, $withParams));
                 $this->app['events']->listen(
                     'composing:*',
                     function ($view, $data = []) use ($debugbar) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -212,9 +212,9 @@ class LaravelDebugbar extends DebugBar
         if ($this->shouldCollect('views', true) && isset($this->app['events'])) {
             try {
                 $collectData = $this->app['config']->get('debugbar.options.views.data', true);
+                $withParams = $this->app['config']->get('debugbar.options.views.with_params', true);
                 $excludePaths = $this->app['config']->get('debugbar.options.views.exclude_paths', []);
-                $excludeParams = $this->app['config']->get('debugbar.options.views.exclude_params', false);
-                $this->addCollector(new ViewCollector($collectData, $excludeParams, $excludePaths));
+                $this->addCollector(new ViewCollector($collectData, $withParams, $excludePaths));
                 $this->app['events']->listen(
                     'composing:*',
                     function ($view, $data = []) use ($debugbar) {


### PR DESCRIPTION
So I was playing with filamentphp last weekend and noticed some heavy browser lags for basically all list views with 100s of blade components (which is basically all xD).

After profiling I noticed a heavy lag when rendering the parameter list.
![image](https://github.com/barryvdh/laravel-debugbar/assets/5374300/af062fb5-2799-4ae6-a406-d5f413c3aa88)
`vendor/maximebf/debugbar/src/DebugBar/Resources/widgets/templates/widget.js:50`

Easy way around this would be an option to disable params from this package.

I profiled this on 2 Laptops ... with the same result.


To reproduce and ensure I'm not the only one suffering from this, just return before params are written into the dom element:
`vendor/maximebf/debugbar/src/DebugBar/Resources/widgets/templates/widget.js:50`
![image](https://github.com/barryvdh/laravel-debugbar/assets/5374300/4568bff4-3418-42ed-b988-083af77bef05)

... just figured imma rename this config to with_params, default true 🙈 one sec pls 


If I'm the only one experiencing this, please downvote this PR with a 👎 xD