### PR TITLE
Reduce View/Templates impact on performance

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -223,7 +223,7 @@ return [
             'data' => false,        //true for all data, 'keys' for only names, false for no parameters.
             'group' => true,        // Group duplicate views
             'exclude_paths' => [    // Add the paths which you don't want to appear in the views
-                //
+                'vendor/filament'   // Exclude Filament components by default
             ],
         ],
         'route' => [

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -219,9 +219,12 @@ return [
             'full_log' => false,
         ],
         'views' => [
-            'timeline' => false,  // Add the views to the timeline (Experimental)
-            'data' => false,    //Note: Can slow down the application, because the data can be quite large..
-            'exclude_paths' => [], // Add the paths which you don't want to appear in the views
+            'timeline' => false,    // Add the views to the timeline (Experimental)
+            'data' => false,        //true for all data, 'keys' for only names, false for no parameters.
+            'group' => true,        // Group duplicate views
+            'exclude_paths' => [    // Add the paths which you don't want to appear in the views
+                //
+            ],
         ],
         'route' => [
             'label' => true,  // show complete route on bar

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -13,6 +13,7 @@ class ViewCollector extends TwigCollector
     protected $templates = [];
     protected $collect_data;
     protected $exclude_paths;
+    protected $group;
 
     /**
      * A list of known editor strings.
@@ -41,15 +42,17 @@ class ViewCollector extends TwigCollector
     /**
      * Create a ViewCollector
      *
-     * @param bool $collectData Collects view data when true
+     * @param bool|string $collectData Collects view data when true
      * @param string[] $excludePaths Paths to exclude from collection
-     */
-    public function __construct($collectData = true, $excludePaths = [])
+     * @param bool $group Group the same templates together
+     * */
+    public function __construct($collectData = true, $excludePaths = [], $group = true)
     {
         $this->setDataFormatter(new SimpleFormatter());
         $this->collect_data = $collectData;
         $this->templates = [];
         $this->exclude_paths = $excludePaths;
+        $this->group = $group;
     }
 
     public function getName()
@@ -116,6 +119,14 @@ class ViewCollector extends TwigCollector
         $shortPath = '';
         $type = '';
 
+
+        // Prevent duplicates
+        $hash = $type . $path . $name . $this->collect_data ? implode(array_keys($view->getData())) : '';
+        if ($this->group && isset($this->templates[$hash])) {
+            $this->templates[$hash]['render_count']++;
+            return;
+        }
+
         if (class_exists('\Inertia\Inertia') && isset($data['page'])) {
             $data = $data['page'];
             $name = $data['component'];
@@ -153,10 +164,17 @@ class ViewCollector extends TwigCollector
             }
         }
 
-        $params = !$this->collect_data ? array_keys($data) : array_map(
-            fn ($value) => $this->getDataFormatter()->formatVar($value),
-            $data
-        );
+        if ($this->collect_data === 'keys') {
+            $params = array_keys($view->getData());
+        } elseif ($this->collect_data) {
+            $params = array_map(
+                fn ($value) => $this->getDataFormatter()->formatVar($value),
+                $data
+            );
+        } else {
+            $params = [];
+        }
+
 
         $template = [
             'name' => $shortPath ? sprintf('%s (%s)', $name, $shortPath) : $name,
@@ -164,22 +182,28 @@ class ViewCollector extends TwigCollector
             'params' => $params,
             'type' => $type,
             'editorLink' => $this->getEditorHref($path, 1),
+            'render_count' => 1,
         ];
 
         if ($this->getXdebugLinkTemplate()) {
             $template['xdebug_link'] = $this->getXdebugLink($path);
         }
 
-        $this->templates[] = $template;
+        $this->templates[$hash] = $template;
     }
 
     public function collect()
     {
         $templates = $this->templates;
+        if ($this->group) {
+            foreach ($templates as &$template) {
+                $template['name'] = $template['render_count'] . 'x ' . $template['name'];
+            }
+        }
 
         return [
             'nb_templates' => count($templates),
-            'templates' => $templates,
+            'templates' => array_values($templates),
         ];
     }
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -219,7 +219,8 @@ class LaravelDebugbar extends DebugBar
             try {
                 $collectData = $this->app['config']->get('debugbar.options.views.data', true);
                 $excludePaths = $this->app['config']->get('debugbar.options.views.exclude_paths', []);
-                $this->addCollector(new ViewCollector($collectData, $excludePaths));
+                $group = $this->app['config']->get('debugbar.options.views.group', true);
+                $this->addCollector(new ViewCollector($collectData, $excludePaths, $group));
                 $this->app['events']->listen(
                     'composing:*',
                     function ($view, $data = []) use ($debugbar) {


### PR DESCRIPTION
- By default, don't show parameters. Add new config to allow just the keys (previous default)
- By default, group the templates so you don't render 50 of the same lines
- Add filament to exclude because of the many components you probably don't need.

Before:
<img width="1498" alt="image" src="https://github.com/barryvdh/laravel-debugbar/assets/973269/28a5a65f-2d88-469d-8b67-bbbddcb1b27f">

After:
<img width="1498" alt="image" src="https://github.com/barryvdh/laravel-debugbar/assets/973269/61e0adec-505d-4d7e-af15-d7db45d9b374">
