### PR TITLE
Fix `__toString` method in `LaravelDebugbar` class

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -492,7 +492,7 @@ class LaravelDebugbar extends DebugBar
                         }
                         public function __toString(): string
                         {
-                            $this->originalTransport->__toString();
+                            return $this->originalTransport->__toString();
                         }
                     });
                 }


### PR DESCRIPTION
As discussed in https://github.com/barryvdh/laravel-debugbar/pull/1476#discussion_r1357051542, this method incorrectly has no `return` keyword.