### PR TITLE
Set default base path for xdebug replacements

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -85,8 +85,8 @@ return [
     |
     */
 
-    'remote_sites_path' => env('DEBUGBAR_REMOTE_SITES_PATH', ''),
-    'local_sites_path' => env('DEBUGBAR_LOCAL_SITES_PATH', ''),
+    'remote_sites_path' => env('DEBUGBAR_REMOTE_SITES_PATH'),
+    'local_sites_path' => env('DEBUGBAR_LOCAL_SITES_PATH'),
 
     /*
      |--------------------------------------------------------------------------

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -86,7 +86,7 @@ return [
     */
 
     'remote_sites_path' => env('DEBUGBAR_REMOTE_SITES_PATH'),
-    'local_sites_path' => env('DEBUGBAR_LOCAL_SITES_PATH'),
+    'local_sites_path' => env('DEBUGBAR_LOCAL_SITES_PATH', env('IGNITION_LOCAL_SITES_PATH')),
 
     /*
      |--------------------------------------------------------------------------

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1224,7 +1224,7 @@ class LaravelDebugbar extends DebugBar
      */
     private function getRemoteServerReplacements()
     {
-        $localPath = $this->app['config']->get('debugbar.local_sites_path', '');
+        $localPath = $this->app['config']->get('debugbar.local_sites_path') ?: base_path();
         $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path', ''))) ?: [base_path()];
 
         return array_fill_keys($remotePaths, $localPath);


### PR DESCRIPTION
I'm still not really sure if this is correct. It seems so be copied from Ignition in #1258 by @VictoRD11 ?
But should both default to the base_path?
Eg. in Laravel Herd this works fine by default, with `getRemoteServerReplacements()` looking like this:
<img width="575" alt="image" src="https://github.com/barryvdh/laravel-debugbar/assets/973269/a88ea27a-92ba-4ddb-b0f7-101d0261272f">

But not sure if this is intended like this. And should we default to the Ignition .env?
/cc @ erikn69