### PR TITLE
Soft/hard limit for query collector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -221,6 +221,8 @@ return [
             'show_copy'         => false,    // Show copy button next to the query,
             'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
             'memory_usage'      => false,   // Show queries memory usage
+            'soft_limit'       => 100,      // After the soft limit, no parameters/backtrace are captured
+            'hard_limit'       => 500,      // After the hard limit, queries are ignored
         ],
         'mail' => [
             'timeline' => false,  // Add mails to the timeline

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -618,17 +618,25 @@ class QueryCollector extends PDOCollector
 
         if ($this->softLimit && $this->hardLimit && ($this->queryCount > $this->softLimit && $this->queryCount > $this->hardLimit)) {
             array_unshift($statements, [
-                'sql' => '# Query soft and hard limit for Debugbar are reached. Only the first ' . $this->softLimit . ' queries show details. Queries after the first ' . $this->hardLimit.  ' are ignored. Limits can be raised in the config.',
+                'sql' => '# Query soft and hard limit for Debugbar are reached. Only the first ' . $this->softLimit . ' queries show details. Queries after the first ' . $this->hardLimit.  ' are ignored. Limits can be raised in the config (debugbar.options.db.soft/hard_limit).',
                 'type' => 'info',
             ]);
+            $statements[] = [
+                'sql' => '... ' . ($this->queryCount - $this->hardLimit) . ' additional queries are executed but now shown because of Debugbar query limits. Limits can be raised in the config (debugbar.options.db.soft/hard_limit)',
+                'type' => 'info',
+            ];
         } else if ($this->hardLimit && $this->queryCount > $this->hardLimit) {
             array_unshift($statements, [
-                'sql' => '# Query hard limit for Debugbar is reached after ' . $this->hardLimit . ' queries, additional ' . ($this->queryCount - $this->hardLimit) . ' queries are not shown..',
+                'sql' => '# Query hard limit for Debugbar is reached after ' . $this->hardLimit . ' queries, additional ' . ($this->queryCount - $this->hardLimit) . ' queries are not shown.. Limits can be raised in the config (debugbar.options.db.hard_limit)',
                 'type' => 'info',
             ]);
+            $statements[] = [
+                'sql' => '... ' . ($this->queryCount - $this->hardLimit) . ' additional queries are executed but now shown because of Debugbar query limits. Limits can be raised in the config (debugbar.options.db.hard_limit)',
+                'type' => 'info',
+            ];
         } elseif ($this->softLimit && $this->queryCount > $this->softLimit) {
             array_unshift($statements, [
-                'sql' => '# Query soft limit for Debugbar is reached after ' . $this->softLimit . ' queries, additional ' . ($this->queryCount - $this->softLimit) . ' queries only show the query. Limit can be raised in the config.',
+                'sql' => '# Query soft limit for Debugbar is reached after ' . $this->softLimit . ' queries, additional ' . ($this->queryCount - $this->softLimit) . ' queries only show the query. Limit can be raised in the config. Limits can be raised in the config (debugbar.options.db.soft_limit)',
                 'type' => 'info',
             ]);
         }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -334,7 +334,7 @@ class LaravelDebugbar extends DebugBar
             $queryCollector = new QueryCollector($timeCollector);
 
             $queryCollector->setDataFormatter(new QueryFormatter());
-
+            $queryCollector->setLimits($this->app['config']->get('debugbar.options.db.soft_limit'), $this->app['config']->get('debugbar.options.db.hard_limit'));
             if ($this->app['config']->get('debugbar.options.db.with_params')) {
                 $queryCollector->setRenderSqlWithParams(true);
             }

--- a/src/Resources/sqlqueries/widget.js
+++ b/src/Resources/sqlqueries/widget.js
@@ -130,7 +130,21 @@
                         .appendTo(li);
                 }
 
-                var table = $('<table><tr><th colspan="2">Metadata</th></tr></table>').addClass(csscls('params')).appendTo(li);
+                if ((stmt.bindings && stmt.bindings.length)
+                    || (stmt.hints && stmt.hints.length)
+                    || (stmt.backtrace && stmt.backtrace.length)
+                    || (stmt.params && stmt.params.length)
+                ) {
+                    var table = $('<table><tr><th colspan="2">Metadata</th></tr></table>').addClass(csscls('params')).appendTo(li);
+                    li.css('cursor', 'pointer').click(function () {
+                        if (table.is(':visible')) {
+                            table.hide();
+                        } else {
+                            table.show();
+                        }
+                    });
+                }
+
 
                 if (stmt.bindings && stmt.bindings.length) {
                     table.append(function () {
@@ -221,14 +235,6 @@
                         }
                     }
                 }
-
-                li.css('cursor', 'pointer').click(function () {
-                    if (table.is(':visible')) {
-                        table.hide();
-                    } else {
-                        table.show();
-                    }
-                });
             }});
             this.$list.$el.appendTo(this.$el);
 


### PR DESCRIPTION
Set a soft and hard limit for queries. Maybe need to tweak the defaults a bit but:
 - After soft limit, stop adding all the parameters / source etc to the meta data
 - After hard limit, stop collecting the queries entirely
 - Show message in both cases. Setting to null can disable it.