### PR TITLE
Allow Debugbar to work with runtime connection

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -299,7 +299,11 @@ class LaravelDebugbar extends DebugBar
         }
 
         if ($this->shouldCollect('db', true) && isset($this->app['db'])) {
+            /** @var \Illuminate\Database\DatabaseManager $db */
             $db = $this->app['db'];
+            /** @var \Illuminate\Events\Dispatcher $events */
+            $events = $this->app['events'];
+
             if (
                 $debugbar->hasCollector('time') && $this->app['config']->get(
                     'debugbar.options.db.timeline',
@@ -346,7 +350,7 @@ class LaravelDebugbar extends DebugBar
             $this->addCollector($queryCollector);
 
             try {
-                $db->listen(
+                $events->listen(
                     function (\Illuminate\Database\Events\QueryExecuted $query) {
                         if (!app(static::class)->shouldCollect('db', true)) {
                             return; // Issue 776 : We've turned off collecting after the listener was attached
@@ -364,49 +368,49 @@ class LaravelDebugbar extends DebugBar
             }
 
             try {
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     \Illuminate\Database\Events\TransactionBeginning::class,
                     function ($transaction) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Begin Transaction', $transaction->connection);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     \Illuminate\Database\Events\TransactionCommitted::class,
                     function ($transaction) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Commit Transaction', $transaction->connection);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     \Illuminate\Database\Events\TransactionRolledBack::class,
                     function ($transaction) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Rollback Transaction', $transaction->connection);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     'connection.*.beganTransaction',
                     function ($event, $params) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Begin Transaction', $params[0]);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     'connection.*.committed',
                     function ($event, $params) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Commit Transaction', $params[0]);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     'connection.*.rollingBack',
                     function ($event, $params) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Rollback Transaction', $params[0]);
                     }
                 );
 
-                $db->getEventDispatcher()->listen(
+                $events->listen(
                     function (\Illuminate\Database\Events\ConnectionEstablished $event) use ($queryCollector) {
                         $queryCollector->collectTransactionEvent('Connection Established', $event->connection);
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -298,9 +298,7 @@ class LaravelDebugbar extends DebugBar
             }
         }
 
-        if ($this->shouldCollect('db', true) && isset($this->app['db'])) {
-            /** @var \Illuminate\Database\DatabaseManager $db */
-            $db = $this->app['db'];
+        if ($this->shouldCollect('db', true) && isset($this->app['db']) && isset($this->app['events'])) {
             /** @var \Illuminate\Events\Dispatcher $events */
             $events = $this->app['events'];
 

--- a/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
+++ b/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
@@ -19,6 +19,10 @@ class QueryCollectorRuntimeDatabaseTest extends TestCase
 
     public function testCollectsQueriesFromRuntimeConnections()
     {
+        if (version_compare($this->app->version(), '10', '<')) {
+            $this->markTestSkipped('This test is not compatible with Laravel 9.x and below');
+        }
+
         debugbar()->boot();
 
         /** @var Connection $connection */
@@ -29,6 +33,37 @@ class QueryCollectorRuntimeDatabaseTest extends TestCase
                 'database' => ':memory:',
             ],
         );
+
+        $connection->statement('SELECT 1');
+
+        /** @var \Debugbar\DataCollector\ExceptionsCollector $collector */
+        $exceptions = debugbar()->getCollector('exceptions');
+
+        self::assertEmpty($exceptions->getExceptions());
+
+        /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
+        $collector  = debugbar()->getCollector('queries');
+
+        tap($collector->collect(), function (array $collection) {
+            $this->assertEquals(1, $collection['nb_statements']);
+
+            self::assertSame('SELECT 1', $collection['statements'][2]['sql']);
+        });
+    }
+
+    public function testCollectsQueriesFromRuntimeConnectionsWithoutConnectUsing()
+    {
+        debugbar()->boot();
+
+        $this->app['config']->set('database.connections.dynamic-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $this->app['config']->set('database.default', 'dynamic-connection');
+
+        /** @var Connection $connection */
+        $connection = $this->app['db']->connection('dynamic-connection');
 
         $connection->statement('SELECT 1');
 

--- a/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
+++ b/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\Tests\TestCase;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+
+class QueryCollectorRuntimeDatabaseTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', null);
+
+        $app['config']->set('database.connections', []);
+    }
+
+    public function testItReplacesQuestionMarksBindingsCorrectly()
+    {
+        debugbar()->boot();
+
+        /** @var Connection $connection */
+        $connection = $this->app['db']->connectUsing(
+            'runtime-connection',
+            [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+            ],
+        );
+
+        $connection->statement('SELECT 1');
+
+        /** @var \Debugbar\DataCollector\ExceptionsCollector $collector */
+        $exceptions = debugbar()->getCollector('exceptions');
+
+        self::assertEmpty($exceptions->getExceptions());
+
+        /** @var \Barryvdh\Debugbar\DataCollector\QueryCollector $collector */
+        $collector  = debugbar()->getCollector('queries');
+
+        tap($collector->collect(), function (array $collection) {
+            $this->assertEquals(1, $collection['nb_statements']);
+
+            self::assertSame('SELECT 1', $collection['statements'][2]['sql']);
+        });
+    }
+}

--- a/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
+++ b/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
@@ -17,7 +17,7 @@ class QueryCollectorRuntimeDatabaseTest extends TestCase
         $app['config']->set('database.connections', []);
     }
 
-    public function testItReplacesQuestionMarksBindingsCorrectly()
+    public function testCollectsQueriesFromRuntimeConnections()
     {
         debugbar()->boot();
 


### PR DESCRIPTION
### Issue

In a clean Laravel application, if you erase the `database.default` and the `database.connections` block, Laravel Debugbar will not be able to collect database information.

### Root Cause

Laravel Debugbar automatically injects the `InjectDebugbar` as a Global Middleware and adds Database Event Listeners through the `DatabaseManager $db` class which goes through `__call()` and tries to resolve the default connection, leading to an error.

The fact Debugbar goes through `__call()` makes it trigger a connection. 

### Proposal

Use the event listener directly to listen to relevant events without causing a connection to be established. If the database is never used, it will never connect and events will not be dispatched.