### PR TITLE
Support Inertia ajax calls

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -92,16 +92,14 @@ class ViewCollector extends TwigCollector
             if (isset($data['props'], $data['component'])) {
                 $name = $data['component'];
                 $data = $data['props'];
-                $oldPath = $path;
 
-                if (!@file_exists($path = resource_path('js/Pages/' . $name . '.js'))) {
-                    if (!@file_exists($path = resource_path('js/Pages/' . $name . '.vue'))) {
-                        if (!@file_exists($path = resource_path('js/Pages/' . $name . '.svelte'))) {
-                            $path = $oldPath;
-                        }
+                if ($files = glob(resource_path('js/Pages/' . $name . '.*'))) {
+                    $path = $files[0];
+                    $type = pathinfo($path, PATHINFO_EXTENSION);
+
+                    if (in_array($type, ['js', 'jsx'])) {
+                        $type = 'react';
                     }
-                } else {
-                    $type = 'react';
                 }
             }
         }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -766,7 +766,7 @@ class LaravelDebugbar extends DebugBar
             $app['config']->get('debugbar.capture_ajax', true)
         ) {
             try {
-                if ($this->hasCollector('views') && class_exists('\Inertia\Inertia')) {
+                if ($this->hasCollector('views') && $response->headers->has('X-Inertia')) {
                     $content = $response->getContent();
 
                     if (is_string($content)) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -766,6 +766,20 @@ class LaravelDebugbar extends DebugBar
             $app['config']->get('debugbar.capture_ajax', true)
         ) {
             try {
+                if ($this->hasCollector('views') && class_exists('\Inertia\Inertia')) {
+                    $content = $response->getContent();
+
+                    if (is_string($content)) {
+                        $content = json_decode($content, true);
+                    }
+                    
+                    if (is_array($content)) {
+                        $this['views']->addInertiaAjaxView($content);
+                    }
+                }
+            } catch (Exception $e) {
+            }
+            try {
                 $this->sendDataInHeaders(true);
 
                 if ($app['config']->get('debugbar.add_ajax_timing', false)) {


### PR DESCRIPTION
After https://github.com/barryvdh/laravel-debugbar/pull/1525#issuecomment-1943878274, I realized that only first load uses a blade view, from that point all views are loaded through ajax, now ajax calls shows the inertia view
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/ca820430-341f-4190-b3ee-ed303aebf1bc)
I have removed junk code that does nothing, I also fixed some merging errors, thanks to that, the editor link opens the inertia file instead of the blade layout (_this layout is the same for all inertia views_)

I see some features in this collector, I did try to keep everything in order, but check it
