### PR TITLE
Make opt-in events data collecting

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -245,6 +245,9 @@ return [
         'symfony_request' => [
             'hiddens' => [], // hides sensitive values using array paths, example: request_request.password
         ],
+        'events' => [
+            'data' => false, // collect events data, listeners
+        ],
         'logs' => [
             'file' => null,
         ],

--- a/src/DataCollector/EventCollector.php
+++ b/src/DataCollector/EventCollector.php
@@ -16,17 +16,29 @@ class EventCollector extends TimeDataCollector
     /** @var integer */
     protected $previousTime;
 
-    public function __construct($requestStartTime = null)
+    /** @var bool */
+    protected $collectValues;
+
+    public function __construct($requestStartTime = null, $collectValues = false)
     {
         parent::__construct($requestStartTime);
         $this->previousTime = microtime(true);
+        $this->collectValues = $collectValues;
         $this->setDataFormatter(new SimpleFormatter());
     }
 
     public function onWildcardEvent($name = null, $data = [])
     {
-        $params = $this->prepareParams($data);
         $currentTime = microtime(true);
+
+        if (! $this->collectValues) {
+            $this->addMeasure($name, $this->previousTime, $currentTime);
+            $this->previousTime = $currentTime;
+
+            return;
+        }
+
+        $params = $this->prepareParams($data);
 
         // Find all listeners for the current event
         foreach ($this->events->getListeners($name) as $i => $listener) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -221,8 +221,9 @@ class LaravelDebugbar extends DebugBar
 
         if ($this->shouldCollect('events', false) && isset($this->app['events'])) {
             try {
-                $startTime = $this->app['request']->server('REQUEST_TIME_FLOAT');
-                $this->addCollector(new EventCollector($startTime));
+                $startTime = $app['request']->server('REQUEST_TIME_FLOAT');
+                $collectData = $app['config']->get('debugbar.options.events.data', false);
+                $this->addCollector(new EventCollector($startTime, $collectData));
                 $this->app['events']->subscribe($debugbar['event']);
             } catch (Exception $e) {
                 $this->addCollectorException('Cannot add EventCollector', $e);


### PR DESCRIPTION
There are pages that can have more than a thousand events, this option allows you to deactivate the capture of the parameters/listeners of each event if it is not necessary

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/c3874a85-c407-4751-81c5-eda66909a1bf)

Same as cacheCollector 
https://github.com/barryvdh/laravel-debugbar/blob/d1a48965f2b25a6cec2eea07d719b568a37c9a88/src/DataCollector/CacheCollector.php#L30
