### PR TITLE
Query backtrace results custom limit option

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -88,12 +88,12 @@ class QueryCollector extends PDOCollector
     /**
      * Enable/disable finding the source
      *
-     * @param bool $value
+     * @param bool|int $value
      * @param array $middleware
      */
     public function setFindSource($value, array $middleware)
     {
-        $this->findSource = (bool) $value;
+        $this->findSource = $value;
         $this->middleware = $middleware;
     }
 
@@ -301,7 +301,7 @@ class QueryCollector extends PDOCollector
             $sources[] = $this->parseTrace($index, $trace);
         }
 
-        return array_slice(array_filter($sources), 0, 5);
+        return array_slice(array_filter($sources), 0, is_int($this->findSource) ? $this->findSource : 5);
     }
 
     /**

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -294,9 +294,8 @@ class LaravelDebugbar extends DebugBar
         }
 
         if ($this->shouldCollect('db', true) && isset($app['db']) && $events) {
-            if (
-                $debugbar->hasCollector('time') && $config->get('debugbar.options.db.timeline', false)) {
-                $timeCollector = $debugbar->getCollector('time');
+            if ($this->hasCollector('time') && $config->get('debugbar.options.db.timeline', false)) {
+                $timeCollector = $this['time'];
             } else {
                 $timeCollector = null;
             }
@@ -310,9 +309,9 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setRenderSqlWithParams(true);
             }
 
-            if ($config->get('debugbar.options.db.backtrace')) {
+            if ($dbBacktrace = $config->get('debugbar.options.db.backtrace')) {
                 $middleware = ! $this->is_lumen ? $app['router']->getMiddleware() : [];
-                $queryCollector->setFindSource(true, $middleware);
+                $queryCollector->setFindSource($dbBacktrace, $middleware);
             }
 
             if ($excludePaths = $config->get('debugbar.options.db.backtrace_exclude_paths')) {


### PR DESCRIPTION
Closes #1186

**Usage:**
```php
// `true` get 5 as default
'backtrace'         => 2,      // Use a backtrace to find the origin of the query in your files.
```


https://github.com/barryvdh/laravel-debugbar/blob/950695096cba9e3dfa91cd719b90ab223dc931e5/config/debugbar.php#L212
https://github.com/barryvdh/laravel-debugbar/blob/950695096cba9e3dfa91cd719b90ab223dc931e5/src/DataCollector/QueryCollector.php#L304

