### PR TITLE
Search auth identifer support UUID, ULID, GLID

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -47,7 +47,7 @@ class GateCollector extends MessagesCollector
 
         if ($user) {
             $userKey = Str::snake(class_basename($user));
-            $userId = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->id;
+            $userId = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->getKey();
         }
 
         $label = $result ? 'success' : 'error';

--- a/src/DataCollector/MultiAuthCollector.php
+++ b/src/DataCollector/MultiAuthCollector.php
@@ -113,14 +113,16 @@ class MultiAuthCollector extends DataCollector implements Renderable
         }
 
         // The default auth identifer is the ID number, which isn't all that
-        // useful. Try username and email.
-        $identifier = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->id;
-        if (is_numeric($identifier)) {
+        // useful. Try username, email and name.
+        $identifier = $user instanceof Authenticatable ? $user->getAuthIdentifier() : $user->getKey();
+        if (is_numeric($identifier) || Str::isUuid($identifier) || Str::isUlid($identifier)) {
             try {
                 if (isset($user->username)) {
                     $identifier = $user->username;
                 } elseif (isset($user->email)) {
                     $identifier = $user->email;
+                } elseif (isset($user->name)) {
+                    $identifier = Str::limit($user->name, 24);
                 }
             } catch (\Throwable $e) {
             }


### PR DESCRIPTION
**BUG FIX:** `$user->id` isn't a default, pk could by `$user->uuid`, use `getKey()` instead

[laravel/framework/src/Illuminate/Database/Eloquent/Model.php#L1955-L1963](https://github.com/laravel/framework/blob/f7c57c47f677b3fcfa1c70c6c3c51d0f90866d31/src/Illuminate/Database/Eloquent/Model.php#L1955-L1963) `getKey()`
[laravel/framework/src/Illuminate/Database/Eloquent/Model.php#L1876-L1884](https://github.com/laravel/framework/blob/f7c57c47f677b3fcfa1c70c6c3c51d0f90866d31/src/Illuminate/Database/Eloquent/Model.php#L1876-L1884) `getKeyName()`

Alternative to #1499, i think that `name` must be last fallback, not the first, `username/email` have priority