### PR TITLE
PHP8.2 explode(): Passing null to parameter #2 ($string) of type string is deprecated

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -36,14 +36,14 @@ return [
      | Specify a callback if you want to limit based on IP or authentication.
      */
     'storage' => [
-        'enabled'    => true,
-        'open'       => env('DEBUGBAR_OPEN_STORAGE', false), // bool/callback.
-        'driver'     => 'file', // redis, file, pdo, socket, custom
-        'path'       => storage_path('debugbar'), // For file driver
-        'connection' => null,   // Leave null for default connection (Redis/PDO)
-        'provider'   => '', // Instance of StorageInterface for custom driver
-        'hostname'   => '127.0.0.1', // Hostname to use with the "socket" driver
-        'port'       => 2304, // Port to use with the "socket" driver
+        'enabled' => true,
+        'open' => env('DEBUGBAR_OPEN_STORAGE', false), // bool/callback.
+        'driver' => 'file', // redis, file, pdo, socket, custom
+        'path' => storage_path('debugbar'), // For file driver
+        'connection' => null, // Leave null for default connection (Redis/PDO)
+        'provider' => '', // Instance of StorageInterface for custom driver
+        'hostname' => '127.0.0.1', // Hostname to use with the "socket" driver
+        'port' => 2304, // Port to use with the "socket" driver
     ],
 
     /*
@@ -157,30 +157,30 @@ return [
      */
 
     'collectors' => [
-        'phpinfo'         => true,  // Php version
-        'messages'        => true,  // Messages
-        'time'            => true,  // Time Datalogger
-        'memory'          => true,  // Memory usage
-        'exceptions'      => true,  // Exception displayer
-        'log'             => true,  // Logs from Monolog (merged in messages if enabled)
-        'db'              => true,  // Show database (PDO) queries and bindings
-        'views'           => true,  // Views with their data
-        'route'           => true,  // Current route information
-        'auth'            => false, // Display Laravel authentication status
-        'gate'            => true,  // Display Laravel Gate checks
-        'session'         => true,  // Display session data
-        'symfony_request' => true,  // Only one can be enabled..
-        'mail'            => true,  // Catch mail messages
-        'laravel'         => false, // Laravel version and environment
-        'events'          => false, // All events fired
+        'phpinfo' => true, // Php version
+        'messages' => true, // Messages
+        'time' => true, // Time Datalogger
+        'memory' => true, // Memory usage
+        'exceptions' => true, // Exception displayer
+        'log' => true, // Logs from Monolog (merged in messages if enabled)
+        'db' => true, // Show database (PDO) queries and bindings
+        'views' => true, // Views with their data
+        'route' => true, // Current route information
+        'auth' => false, // Display Laravel authentication status
+        'gate' => true, // Display Laravel Gate checks
+        'session' => true, // Display session data
+        'symfony_request' => true, // Only one can be enabled..
+        'mail' => true, // Catch mail messages
+        'laravel' => false, // Laravel version and environment
+        'events' => false, // All events fired
         'default_request' => false, // Regular or special Symfony request logger
-        'logs'            => false, // Add the latest log messages
-        'files'           => false, // Show the included files
-        'config'          => false, // Display config settings
-        'cache'           => false, // Display cache events
-        'models'          => true,  // Display models
-        'livewire'        => true,  // Display Livewire (when available)
-        'jobs'            => false, // Display dispatched jobs
+        'logs' => false, // Add the latest log messages
+        'files' => false, // Show the included files
+        'config' => false, // Display config settings
+        'cache' => false, // Display cache events
+        'models' => true, // Display models
+        'livewire' => true, // Display Livewire (when available)
+        'jobs' => false, // Display dispatched jobs
     ],
 
     /*
@@ -194,50 +194,50 @@ return [
 
     'options' => [
         'time' => [
-            'memory_usage' => false,  // Calculated by subtracting memory start and end, it may be inaccurate
+            'memory_usage' => false, // Calculated by subtracting memory start and end, it may be inaccurate
         ],
         'messages' => [
-            'trace' => true,   // Trace the origin of the debug message
+            'trace' => true, // Trace the origin of the debug message
         ],
         'memory' => [
-            'reset_peak' => false,     // run memory_reset_peak_usage before collecting
-            'with_baseline' => false,  // Set boot memory usage as memory peak baseline
-            'precision' => 0,          // Memory rounding precision
+            'reset_peak' => false, // run memory_reset_peak_usage before collecting
+            'with_baseline' => false, // Set boot memory usage as memory peak baseline
+            'precision' => 0, // Memory rounding precision
         ],
         'auth' => [
-            'show_name' => true,   // Also show the users name/email in the debugbar
+            'show_name' => true, // Also show the users name/email in the debugbar
         ],
         'db' => [
-            'with_params'       => true,   // Render SQL with the parameters substituted
-            'backtrace'         => true,   // Use a backtrace to find the origin of the query in your files.
-            'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
-            'timeline'          => false,  // Add the queries to the timeline
-            'duration_background'  => true,   // Show shaded background on each query relative to how long it took to execute.
-            'explain' => [                 // Show EXPLAIN output on queries
+            'with_params' => true, // Render SQL with the parameters substituted
+            'backtrace' => true, // Use a backtrace to find the origin of the query in your files.
+            'backtrace_exclude_paths' => [], // Paths to exclude from backtrace. (in addition to defaults)
+            'timeline' => false, // Add the queries to the timeline
+            'duration_background' => true, // Show shaded background on each query relative to how long it took to execute.
+            'explain' => [ // Show EXPLAIN output on queries
                 'enabled' => false,
-                'types' => ['SELECT'],     // Deprecated setting, is always only SELECT
+                'types' => ['SELECT'], // Deprecated setting, is always only SELECT
             ],
-            'hints'             => false,    // Show hints for common mistakes
-            'show_copy'         => false,    // Show copy button next to the query,
-            'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
-            'memory_usage'      => false,   // Show queries memory usage
-            'soft_limit'       => 100,      // After the soft limit, no parameters/backtrace are captured
-            'hard_limit'       => 500,      // After the hard limit, queries are ignored
+            'hints' => false, // Show hints for common mistakes
+            'show_copy' => false, // Show copy button next to the query,
+            'slow_threshold' => false, // Only track queries that last longer than this time in ms
+            'memory_usage' => false, // Show queries memory usage
+            'soft_limit' => 100, // After the soft limit, no parameters/backtrace are captured
+            'hard_limit' => 500, // After the hard limit, queries are ignored
         ],
         'mail' => [
-            'timeline' => false,  // Add mails to the timeline
+            'timeline' => false, // Add mails to the timeline
             'full_log' => false,
         ],
         'views' => [
-            'timeline' => false,    // Add the views to the timeline (Experimental)
-            'data' => false,        //true for all data, 'keys' for only names, false for no parameters.
-            'group' => 50,          // Group duplicate views. Pass value to auto-group, or true/false to force
-            'exclude_paths' => [    // Add the paths which you don't want to appear in the views
-                'vendor/filament'   // Exclude Filament components by default
+            'timeline' => false, // Add the views to the timeline (Experimental)
+            'data' => false, // true for all data, 'keys' for only names, false for no parameters.
+            'group' => 50, // Group duplicate views. Pass value to auto-group, or true/false to force
+            'exclude_paths' => [ // Add the paths which you don't want to appear in the views
+                'vendor/filament', // Exclude Filament components by default
             ],
         ],
         'route' => [
-            'label' => true,  // show complete route on bar
+            'label' => true, // show complete route on bar
         ],
         'session' => [
             'hiddens' => [], // hides sensitive values using array paths

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -14,7 +14,7 @@ return [
      |
      */
 
-    'enabled' => env('DEBUGBAR_ENABLED', null),
+    'enabled' => env('DEBUGBAR_ENABLED'),
     'except' => [
         'telescope*',
         'horizon*',

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1164,7 +1164,7 @@ class LaravelDebugbar extends DebugBar
     private function getRemoteServerReplacements()
     {
         $localPath = $this->app['config']->get('debugbar.local_sites_path') ?: base_path();
-        $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path', ''))) ?: [base_path()];
+        $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path') ?? '')) ?: [base_path()];
 
         return array_fill_keys($remotePaths, $localPath);
     }


### PR DESCRIPTION
Hi.

1. deprecated by PHP8.2
    * `local.WARNING: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /*/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php`
2. use PHP-CS-Fixer (LaravelPint) to config/debugbar.php 