### PR TITLE
Add check icon on gate collector(`success` label)

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -413,6 +413,11 @@ div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-w
     background-color: #5896e2;
 }
 
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter[rel="success"],
+div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded[rel="success"] {
+    background-color: #45ab45;
+}
+
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter[rel="error"],
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded[rel="error"] {
     background-color: var(--color-red-vivid);
@@ -626,8 +631,9 @@ div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugb
     font-family: PhpDebugbarFontAwesome;
     content: "\f005";
     color: #333;
-    font-size: 13px;
+    font-size: 15px !important;
     margin-right: 8px;
+    margin-top: -3px;
     float: left;
 }
 
@@ -636,10 +642,13 @@ div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugb
 }
 
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-info:before {
-    font-family: PhpDebugbarFontAwesome;
     content: "\f05a";
     color: #5896e2;
-    font-size: 15px;
+}
+
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-success:before {
+    content: "\f058";
+    color: #45ab45;
 }
 
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-error {
@@ -648,14 +657,9 @@ div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugb
 
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-error:before {
     color: var(--color-red-vivid);
-    font-size: 15px;
 }
 
-div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-warning:before {
-    color: #FF9800;
-    font-size: 13px;
-}
-
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-warning:before,
 div.phpdebugbar-widgets-messages .phpdebugbar-widgets-value.phpdebugbar-widgets-warning {
     color: #FF9800;
 }


### PR DESCRIPTION
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/548cfa9e-ece3-4304-9ccb-016315ead494)

Additionally, this change centers the icon vertically, and normalizes the size of the icons.
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/66dfb52d-9860-4546-90df-26fd3d14829b)

---
Should messages that have a `debug` label also be differentiated?
![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/c5821506-9a21-471f-afc9-f8f92196b3bb)


