### PR TITLE
Fix explode(): Passing null to parameter `#2` warning

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -1164,7 +1164,7 @@ class LaravelDebugbar extends DebugBar
     private function getRemoteServerReplacements()
     {
         $localPath = $this->app['config']->get('debugbar.local_sites_path') ?: base_path();
-        $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path', ''))) ?: [base_path()];
+        $remotePaths = array_filter(explode(',', $this->app['config']->get('debugbar.remote_sites_path') ?: '')) ?: [base_path()];
 
         return array_fill_keys($remotePaths, $localPath);
     }


### PR DESCRIPTION
Fix logs depecated warnings
It's a bug, my log file is growing unnecessarily.
![image](https://github.com/barryvdh/laravel-debugbar/assets/109294935/e49c0b2a-dd3d-45bb-a8ef-5da3e2abd5a9)

