### PR TITLE
Update JavascriptRenderer.php

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -59,8 +59,8 @@ class JavascriptRenderer extends BaseJavascriptRenderer
             'v' => $this->getModifiedTime('js')
         ]);
 
-        $cssRoute = preg_replace('/\Ahttps?:/', '', $cssRoute);
-        $jsRoute  = preg_replace('/\Ahttps?:/', '', $jsRoute);
+        $cssRoute = preg_replace('/\Ahttps?:\/\/[^\/]+/', '', $cssRoute);
+        $jsRoute  = preg_replace('/\Ahttps?:\/\/[^\/]+/', '', $jsRoute);
 
         $nonce = $this->getNonceAttribute();
 


### PR DESCRIPTION
Update the `preg_replace()` functions for `$cssRoute` and `$jsRoute` to remove the site domain when fetching those assets.

I had issues with the following tags.

`<link rel="stylesheet" type="text/css" property="stylesheet" href="//my-domain.com/_debugbar/assets/stylesheets?v=1709304073&amp;theme=dark" data-turbolinks-eval="false" data-turbo-eval="false">`

`<script src="//my-domain.com/_debugbar/assets/javascript?v=1709304073" data-turbolinks-eval="false" data-turbo-eval="false"></script>`

which resulted in 404 errors. Changing the `preg_replace` regex pattern fixed this for me. 

`<link rel="stylesheet" type="text/css" property="stylesheet" href="/_debugbar/assets/stylesheets?v=1709304073&amp;theme=dark" data-turbolinks-eval="false" data-turbo-eval="false">`

`<script src="/_debugbar/assets/javascript?v=1709304073" data-turbolinks-eval="false" data-turbo-eval="false"></script>`

Would highly appreciate some input whether this is a feasible fix or if it would break other functionality. 