### PR TITLE
Force string cast to remote_sites_path and local_sites_path

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -85,8 +85,8 @@ return [
     |
     */
 
-    'remote_sites_path' => env('DEBUGBAR_REMOTE_SITES_PATH'),
-    'local_sites_path' => env('DEBUGBAR_LOCAL_SITES_PATH', env('IGNITION_LOCAL_SITES_PATH')),
+    'remote_sites_path' => strval(env('DEBUGBAR_REMOTE_SITES_PATH')),
+    'local_sites_path' => strval(env('DEBUGBAR_LOCAL_SITES_PATH', env('IGNITION_LOCAL_SITES_PATH'))),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Using the default configuration without configure `DEBUGBAR_REMOTE_SITES_PATH` and `DEBUGBAR_LOCAL_SITES_PATH` on `.env` file you get the error inside the `deprecations` log:

```
[2024-03-05T16:41:37+01:00] deprecations-daily.WARNING: ErrorException: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /app/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php:1177
Stack trace:
#0 /app/vendor/laravel/framework/src/Illuminate/Support/helpers.php(432): Illuminate\Foundation\Bootstrap\HandleExceptions->Illuminate\Foundation\Bootstrap\{closure}()
#1 /app/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(102): with()
#2 /app/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(71): Illuminate\Foundation\Bootstrap\HandleExceptions->handleDeprecationError()
#3 /app/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError()
#4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->Illuminate\Foundation\Bootstrap\{closure}()
#5 /app/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php(1177): explode()
#6 /app/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php(147): Barryvdh\Debugbar\LaravelDebugbar->getRemoteServerReplacements()
#7 /app/vendor/barryvdh/laravel-debugbar/src/Middleware/InjectDebugbar.php(62): Barryvdh\Debugbar\LaravelDebugbar->boot()
#8 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Barryvdh\Debugbar\Middleware\InjectDebugbar->handle()
#16 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): App\Http\Middleware\RequestLogger->handle()
#17 /app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#18 /app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php(40): Illuminate\Foundation\Http\Middleware\TransformsRequest->handle()
#19 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Foundation\Http\Middleware\TrimStrings->handle()
#20 /app/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(121): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#21 /app/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php(64): Illuminate\Session\Middleware\StartSession->handleStatefulRequest()
#22 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Session\Middleware\StartSession->handle()
#23 /app/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php(37): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#24 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse->handle()
#25 /app/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(67): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#26 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Cookie\Middleware\EncryptCookies->handle()
#27 /app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php(99): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#28 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance->handle()
#29 /app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#30 /app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(175): Illuminate\Pipeline\Pipeline->then()
#31 /app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(144): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter()
#32 /app/public/index.php(52): Illuminate\Foundation\Http\Kernel->handle()
#33 {main}  
```

Forcing this two vars to be string solve the problem.