### PR TITLE
feat(LogsCollector): support multiple log files

### DIFF
--- a/src/DataCollector/LogsCollector.php
+++ b/src/DataCollector/LogsCollector.php
@@ -15,7 +15,10 @@ class LogsCollector extends MessagesCollector
     {
         parent::__construct($name);
 
-        $paths = Arr::wrap($path ?: storage_path('logs/laravel.log'));
+        $paths = Arr::wrap($path ?: [
+            storage_path('logs/laravel.log'),            
+            storage_path('logs/laravel-' . date('Y-m-d') . '.log'), // for daily driver
+        ]);
         
         foreach ($paths as $path) {
             $this->getStorageLogs($path);

--- a/src/DataCollector/LogsCollector.php
+++ b/src/DataCollector/LogsCollector.php
@@ -38,12 +38,14 @@ class LogsCollector extends MessagesCollector
 
         //Load the latest lines, guessing about 15x the number of log entries (for stack traces etc)
         $file = implode("", $this->tailFile($path, $this->lines));
+        $basename = basename($path);
 
         foreach ($this->getLogs($file) as $log) {
             $this->messages[] = [
                 'message' => $log['header'] . $log['stack'],
                 'label' => $log['level'],
                 'time' => substr($log['header'], 1, 19),
+                'collector' => $basename,
                 'is_string' => false,
             ];
         }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -379,6 +379,11 @@ div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugb
     color: #333;
 }
 
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-collector {
+    text-transform: none;
+    color: #888;
+}
+
 .phpdebugbar-widgets-toolbar i.phpdebugbar-fa.phpdebugbar-fa-search {
     position: relative;
     top: -1px;


### PR DESCRIPTION
Alternative of #1557
> ### Description
> This PR lets users add multiple paths to `'options.logs.file`.
> 
> Old config:
> 
> ```php
> 'logs' => [
>     'file' => null,
>     // or a single custom file path
>     'file' => storage_path('logs/laravel.log'),
> ],
> ```
> 
> This PR allows a paths array:
> 
> ```php
> 'logs' => [
>     'file' => [
>         storage_path('logs/laravel.log'),
>         // https://laravel.com/docs/10.x/logging#logging-deprecation-warnings
>         storage_path('logs/php-deprecation-warnings'),
>     ],
> ],
> ```
> 
> Note: I've modified the code to be backwards compatible: string values will still work as expected.
>       Also the logs are sorted by timestamp after they have been merged.
> 
Closes #1556




----
Removed Laravel 5.0 code fix
https://github.com/barryvdh/laravel-debugbar/blob/6fd181adc9981aebc8fa50a54ba49d31c751ef1d/src/DataCollector/LogsCollector.php#L28-L34