### PR TITLE
Fix `CSRF token mismatch.` on cache forget

### DIFF
--- a/src/Resources/cache/widget.js
+++ b/src/Resources/cache/widget.js
@@ -19,7 +19,6 @@
 
             $.ajax({
                 url: $(el).attr("data-url"),
-                type: 'DELETE',
                 success: function (result) {
                     $(el).fadeOut(200);
                 }

--- a/src/debugbar-routes.php
+++ b/src/debugbar-routes.php
@@ -35,7 +35,7 @@ app('router')->group($routeConfig, function ($router) {
         'as' => 'debugbar.assets.js',
     ]);
 
-    $router->delete('cache/{key}/{tags?}', [
+    $router->get('cache/{key}/{tags?}', [
         'uses' => 'CacheController@delete',
         'as' => 'debugbar.cache.delete',
     ]);


### PR DESCRIPTION
If you add `['web']` middleware on [`debugbar.route_middleware`](https://github.com/barryvdh/laravel-debugbar/blob/6fd181adc9981aebc8fa50a54ba49d31c751ef1d/config/debugbar.php#L289-L291), the cache forget action gets `CSRF token mismatch.` exception
Also others middleware could validate `delete` route, this route is not deleting anything itself, it just forgets the cache.

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/4382161a-10f0-4354-ab8e-d5813acbe1ec)

Other  option is adding `CSRF to header
[laravel/echo/src/connector/connector.ts#L60-L79](https://github.com/laravel/echo/blob/bb66b08ca24164fd20b1afc4dfa8ff5af6d5da6e/src/connector/connector.ts#L60-L79)
