### PR TITLE
Revert and fix #557

### DIFF
--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -53,14 +53,11 @@ class JavascriptRenderer extends BaseJavascriptRenderer
         $cssRoute = route('debugbar.assets.css', [
             'v' => $this->getModifiedTime('css'),
             'theme' => config('debugbar.theme', 'auto'),
-        ]);
+        ], false);
 
         $jsRoute = route('debugbar.assets.js', [
             'v' => $this->getModifiedTime('js')
-        ]);
-
-        $cssRoute = preg_replace('/\Ahttps?:/', '', $cssRoute);
-        $jsRoute  = preg_replace('/\Ahttps?:/', '', $jsRoute);
+        ], false);
 
         $nonce = $this->getNonceAttribute();
 


### PR DESCRIPTION
- On #557 a regex pattern was added, but `route()` 3rd arg already fix the issue, when false, it returns relative link, without protocol
- Alternative to #1555
>I had issues with the following tags.
>
>`<script src="//my-domain.com/_debugbar/assets/javascript?v=1709304073"`
>
>which resulted in 404 errors. Changing the `preg_replace` regex pattern fixed this for me.
>
>`<script src="/_debugbar/assets/javascript?v=1709304073"`