### PR TITLE
Easy-to-track silenced errors

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -576,10 +576,15 @@ class LaravelDebugbar extends DebugBar
      */
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
+        $exception = new \ErrorException($message, 0, $level, $file, $line);
         if (error_reporting() & $level) {
-            throw new \ErrorException($message, 0, $level, $file, $line);
-        } else {
-            $this->addMessage($message, 'deprecation');
+            throw $exception;
+        }
+
+        $this->addThrowable($exception);
+        if ($this->hasCollector('messages')) {
+            $file = $file ? ' on ' . $this['messages']->normalizeFilePath($file) . ":{$line}" : '';
+            $this['messages']->addMessage($message . $file, 'deprecation');
         }
     }
 

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -672,6 +672,11 @@ div.phpdebugbar-widgets-messages .phpdebugbar-widgets-value.phpdebugbar-widgets-
     color: #FF9800;
 }
 
+div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item span.phpdebugbar-widgets-value.phpdebugbar-widgets-deprecation:before {
+    content: "\f1f6";
+    color: #FF9800;
+}
+
 div.phpdebugbar-widgets-messages li.phpdebugbar-widgets-list-item pre.sf-dump {
     display: inline-block !important;
     position: relative;


### PR DESCRIPTION
Currently silenced errors do not show any indication of where they occurred, this PR adds `filename:line` on the messages if MessageCollector exists, and also adds the exception with the trace if ExceptionCollector exists

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/bdd73172-5f94-490b-824f-9f71987717dc)

![image](https://github.com/barryvdh/laravel-debugbar/assets/4933954/68a4dc9d-8d76-493f-8360-e244583ddbc5)
