### PR TITLE
Fix exclude_paths on ViewCollector

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -81,8 +81,9 @@ class ViewCollector extends TwigCollector
                 }
             }
 
+            $shortPath = $this->normalizeFilePath($path);
             foreach ($this->exclude_paths as $excludePath) {
-                if (str_starts_with($path, $excludePath)) {
+                if (str_starts_with($shortPath, $excludePath)) {
                     return;
                 }
             }


### PR DESCRIPTION
Apparently this functionality was broken in the merge