### PR TITLE
Make auth tab optional and show only user name

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -206,6 +206,7 @@ return [
         ],
         'auth' => [
             'show_name' => true,   // Also show the users name/email in the debugbar
+            'show_guards' => true, // Show the guards that are used
         ],
         'db' => [
             'with_params'       => true,   // Render SQL with the parameters substituted

--- a/src/DataCollector/MultiAuthCollector.php
+++ b/src/DataCollector/MultiAuthCollector.php
@@ -25,6 +25,9 @@ class MultiAuthCollector extends DataCollector implements Renderable
     /** @var bool */
     protected $showName = false;
 
+    /** @var bool */
+    protected $showGuardsData = true;
+
     /**
      * @param \Illuminate\Auth\AuthManager $auth
      * @param array $guards
@@ -42,6 +45,15 @@ class MultiAuthCollector extends DataCollector implements Renderable
     public function setShowName($showName)
     {
         $this->showName = (bool) $showName;
+    }
+
+    /**
+     * Set to hide the guards tab, and show only name
+     * @param bool $showGuardsData
+     */
+    public function setShowGuardsData($showGuardsData)
+    {
+        $this->showGuardsData = (bool) $showGuardsData;
     }
 
     /**
@@ -79,6 +91,9 @@ class MultiAuthCollector extends DataCollector implements Renderable
         }
 
         $data['names'] = rtrim($names, ', ');
+        if (!$this->showGuardsData) {
+            unset($data['guards']);
+        }
 
         return $data;
     }
@@ -142,14 +157,16 @@ class MultiAuthCollector extends DataCollector implements Renderable
      */
     public function getWidgets()
     {
-        $widgets = [
-            "auth" => [
+        $widgets = [];
+
+        if ($this->showGuardsData) {
+            $widgets["auth"] = [
                 "icon" => "lock",
                 "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "auth.guards",
-                "default" => "{}"
-            ]
-        ];
+                "default" => "{}",
+            ];
+        }
 
         if ($this->showName) {
             $widgets['auth.name'] = [

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -492,6 +492,9 @@ class LaravelDebugbar extends DebugBar
                 $this['auth']->setShowName(
                     $config->get('debugbar.options.auth.show_name')
                 );
+                $this['auth']->setShowGuardsData(
+                    $config->get('debugbar.options.auth.show_guards', true)
+                );
             } catch (Exception $e) {
                 $this->addCollectorException('Cannot add AuthCollector', $e);
             }


### PR DESCRIPTION
Try to save less authentication data but without losing the `guard:user` indicator
opt-out, true by default