### PR TITLE
Remove deprecated TwigCollector

### DIFF
--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -3,10 +3,12 @@
 namespace Barryvdh\Debugbar\DataCollector;
 
 use Barryvdh\Debugbar\DataFormatter\SimpleFormatter;
-use DebugBar\Bridge\Twig\TwigCollector;
+use DebugBar\DataCollector\AssetProvider;
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\Renderable;
 use Illuminate\View\View;
 
-class ViewCollector extends TwigCollector
+class ViewCollector extends DataCollector implements Renderable, AssetProvider
 {
     protected $name;
     protected $templates = [];
@@ -48,6 +50,17 @@ class ViewCollector extends TwigCollector
                 'map' => 'views.nb_templates',
                 'default' => 0
             ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getAssets()
+    {
+        return [
+            'css' => 'widgets/templates/widget.css',
+            'js' => 'widgets/templates/widget.js',
         ];
     }
 


### PR DESCRIPTION
`TwigCollector` is deprecated 
[maximebf/php-debugbar/src/DebugBar/Bridge/Twig/TwigCollector.php#L30](https://github.com/maximebf/php-debugbar/blob/6cfc9ae6834adc9ac45f3bc81f1e6048a3d08103/src/DebugBar/Bridge/Twig/TwigCollector.php#L30)

