### PR TITLE
Show dataset tab

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "maximebf/debugbar": "~1.21.0",
+        "maximebf/debugbar": "~1.22.0",
         "illuminate/routing": "^9|^10|^11",
         "illuminate/session": "^9|^10|^11",
         "illuminate/support": "^9|^10|^11",

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -124,7 +124,7 @@ return [
     'capture_ajax' => true,
     'add_ajax_timing' => false,
     'ajax_handler_auto_show' => true,
-    'ajax_handler_enable_tab' => false,
+    'ajax_handler_enable_tab' => true,
 
     /*
      |--------------------------------------------------------------------------

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -124,6 +124,7 @@ return [
     'capture_ajax' => true,
     'add_ajax_timing' => false,
     'ajax_handler_auto_show' => true,
+    'ajax_handler_enable_tab' => false,
 
     /*
      |--------------------------------------------------------------------------

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -916,6 +916,10 @@ class LaravelDebugbar extends DebugBar
         $renderer = $this->getJavascriptRenderer();
         $autoShow = $config->get('debugbar.ajax_handler_auto_show', true);
         $renderer->setAjaxHandlerAutoShow($autoShow);
+
+        $enableTab = $config->get('debugbar.ajax_handler_enable_tab', true);
+        $renderer->setAjaxHandlerEnableTab($enableTab);
+
         if ($this->getStorage()) {
             $openHandlerUrl = route('debugbar.openhandler');
             $renderer->setOpenHandlerUrl($openHandlerUrl);

--- a/src/Resources/laravel-debugbar-dark-mode.css
+++ b/src/Resources/laravel-debugbar-dark-mode.css
@@ -15,6 +15,7 @@ div.phpdebugbar-openhandler {
 }
 
 div.phpdebugbar,
+div.phpdebugbar-widgets-dataset-history .phpdebugbar-widgets-dataset-actions,
 div.phpdebugbar-openhandler {
     background: var(--color-gray-800);
 }
@@ -57,6 +58,7 @@ div.phpdebugbar div.phpdebugbar-header > div > select,
 div.phpdebugbar ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item table.phpdebugbar-widgets-params,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions > form input,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions > form select,
+div.phpdebugbar-panel .phpdebugbar-widgets-dataset-actions select,
 div.phpdebugbar input[type='text'],
 div.phpdebugbar input[type='password'] {
     background-color: var(--color-gray-800);
@@ -322,4 +324,9 @@ div.phpdebugbar .hljs-strong {
 div.phpdebugbar .hljs-literal,
 div.phpdebugbar .hljs-number {
     color: #bd93f9;
+}
+
+.phpdebugbar-widgets-dataset-history table tr.phpdebugbar-widgets-active {
+    background-color: var(--color-gray-700);
+    color: white;
 }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -786,6 +786,10 @@ div.phpdebugbar-panel {
     padding: 10px;
 }
 
+div.phpdebugbar-panel[data-collector="__datasets"] {
+    padding: 0 10px;
+}
+
 div.phpdebugbar-panel table {
     margin: 10px 0px!important;
     width: 100%!important;

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -767,7 +767,6 @@ div.phpdebugbar-mini-design a.phpdebugbar-tab {
 
 div.phpdebugbar-header-right > a {
     height: 20px;
-    width: 20px;
     background-position: center;
 }
 


### PR DESCRIPTION
Replaces the dropdown with a tab. Optional and currently disabled by default, but can be marked as default in the future.

Most important benefits:
 - More details then the dropdown
 - Toggle autoshow from front-end (much requested)
 - Filter/search history
 - See highlights (eg. number of queries)
 
![image](https://github.com/barryvdh/laravel-debugbar/assets/973269/6c11b091-08be-498e-9540-d92c3c6add27)

See https://github.com/maximebf/php-debugbar/pull/627
(Needs a new release upstream though)
