### PR TITLE
Set line default as 1 on QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -318,7 +318,7 @@ class QueryCollector extends PDOCollector
             'namespace' => null,
             'name' => null,
             'file' => null,
-            'line' => isset($trace['line']) ? $trace['line'] : '?',
+            'line' => $trace['line'] ?? '1',
         ];
 
         if (isset($trace['function']) && $trace['function'] == 'substituteBindings') {


### PR DESCRIPTION
Some editor throw error on finding `?` sign, line `1` must be as default