### PR TITLE
Revert "Use dark theme by default"

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -308,7 +308,7 @@ return [
      | Switches between light and dark theme. If set to auto it will respect system preferences
      | Possible values: auto, light, dark
      */
-    'theme' => env('DEBUGBAR_THEME', 'dark'),
+    'theme' => env('DEBUGBAR_THEME', 'auto'),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Reverts barryvdh/laravel-debugbar#1546

It seems not so popular, so I'll consider reverting it back the 'auto'.

What do you prefer? Thumbs up for auto, down for dark.