### PR TITLE
Allow localhost for openhandler

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -34,10 +34,11 @@ return [
      | Warning: Enabling storage.open will allow everyone to access previous
      | request, do not enable open storage in publicly available environments!
      | Specify a callback if you want to limit based on IP or authentication.
+     | Leaving it to null will allow localhost only.
      */
     'storage' => [
         'enabled'    => true,
-        'open'       => env('DEBUGBAR_OPEN_STORAGE', false), // bool/callback.
+        'open'       => env('DEBUGBAR_OPEN_STORAGE'), // bool/callback.
         'driver'     => 'file', // redis, file, pdo, socket, custom
         'path'       => storage_path('debugbar'), // For file driver
         'connection' => null,   // Leave null for default connection (Redis/PDO)

--- a/src/Controllers/OpenHandlerController.php
+++ b/src/Controllers/OpenHandlerController.php
@@ -28,7 +28,16 @@ class OpenHandlerController extends BaseController
             return method_exists($open, 'resolve') ? $open::resolve($request) : false;
         }
 
-        return is_bool($open) ? $open : false;
+        if (is_bool($open)) {
+            return $open;
+        }
+
+        // Allow localhost request when not explicitly allowed/disallowed
+        if (in_array($request->ip(), ['127.0.0.1', '::1'], true)) {
+            return true;
+        }
+
+        return false;
     }
 
     public function handle(Request $request)


### PR DESCRIPTION
Using it locally should be safe, so easier to use.