### PR TITLE
Reduce text shadow use

### DIFF
--- a/src/Resources/laravel-debugbar-dark-mode.css
+++ b/src/Resources/laravel-debugbar-dark-mode.css
@@ -31,10 +31,11 @@ div.phpdebugbar code.phpdebugbar-widgets-sql span.hljs-keyword,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-header,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-header a {
     color: var(--color-gray-200);
-    text-shadow: 1px 1px #000;
 }
 
-
+div.phpdebugbar ul.phpdebugbar-widgets-timeline li span.phpdebugbar-widgets-label {
+    text-shadow: 1px 1px #000;
+}
 
 div.phpdebugbar-openhandler,
 div.phpdebugbar div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar,


### PR DESCRIPTION
This PR removes text shadow on many elements that has been added in my ui refinement PR. I only added it to make the text on the timeline waterfall better readable. So it make sense to only target just that label instead of all the other elements. Maybe this is also related to it https://github.com/barryvdh/laravel-debugbar/pull/1601#issuecomment-2035145321