### PR TITLE
Toolbar refinements

### DIFF
--- a/src/Resources/laravel-debugbar-dark-mode.css
+++ b/src/Resources/laravel-debugbar-dark-mode.css
@@ -50,7 +50,6 @@ div.phpdebugbar-panel .phpdebugbar-widgets-dataset-actions select {
     border-color: var(--color-gray-600);
 }
 
-div.phpdebugbar div.phpdebugbar-header,
 div.phpdebugbar div.phpdebugbar-panel div.phpdebugbar-widgets-status > span:first-child:before,
 div.phpdebugbar-openhandler table th,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions > a,
@@ -58,6 +57,14 @@ div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions button,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions > form input,
 div.phpdebugbar-openhandler .phpdebugbar-openhandler-actions > form select {
     text-shadow: 1px 1px var(--color-gray-700);
+}
+
+div.phpdebugbar div.phpdebugbar-header {
+    text-shadow: none;
+}
+
+div.phpdebugbar-header-right > * {
+    border-right-color: var(--color-gray-800);
 }
 
 div.phpdebugbar div.phpdebugbar-header > div > select,
@@ -100,6 +107,10 @@ div.phpdebugbar-openhandler table th,
 div.phpdebugbar-openhandler table tr:nth-child(2n),
 div.phpdebugbar div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar {
     background-color: var(--color-gray-700);
+}
+
+div.phpdebugbar a.phpdebugbar-tab.phpdebugbar-active:hover {
+    background-color: var(--color-red-vivid);
 }
 
 div.phpdebugbar .phpdebugbar-indicator span.phpdebugbar-tooltip,
@@ -179,7 +190,7 @@ div.phpdebugbar-openhandler {
 }
 
 div.phpdebugbar div.phpdebugbar-header .phpdebugbar-tab {
-    border-left-color: var(--color-gray-800);
+    border-color: var(--color-gray-800);
 }
 
 div.phpdebugbar div.phpdebugbar-body {
@@ -188,12 +199,6 @@ div.phpdebugbar div.phpdebugbar-body {
 
 div.phpdebugbar a.phpdebugbar-restore-btn {
     border-right-color: var(--color-gray-800) !important;
-}
-
-div.phpdebugbar span.phpdebugbar-indicator,
-div.phpdebugbar a.phpdebugbar-indicator,
-div.phpdebugbar a.phpdebugbar-close-btn {
-    border-right-color: var(--color-gray-800);
 }
 
 div.phpdebugbar div.phpdebugbar-panel div.phpdebugbar-widgets-status {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -316,6 +316,10 @@ dl.phpdebugbar-widgets-kvlist dd.phpdebugbar-widgets-value.phpdebugbar-widgets-p
     background: transparent;
 }
 
+dl.phpdebugbar-widgets-kvlist dt {
+    width: calc(25% - 10px);
+}
+
 dl.phpdebugbar-widgets-kvlist dd {
     margin-left: 25%;
 }

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -795,7 +795,11 @@ div.phpdebugbar-header-right > * {
 }
 
 div.phpdebugbar-header-right > *:first-child {
-    border-right: none;
+    border-right: 0;
+}
+
+div.phpdebugbar-header-right a.phpdebugbar-tab.phpdebugbar-tab-history  {
+    border-left: 0;
 }
 
 div.phpdebugbar-panel[data-collector="__datasets"] {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -227,8 +227,13 @@ div.phpdebugbar-header {
     text-shadow: 1px 1px #FFF;
 }
 
-div.phpdebugbar-header  span.phpdebugbar-text, div.phpdebugbar-header > div > span > span {
+div.phpdebugbar-header  span.phpdebugbar-text, div.phpdebugbar-header > div > span > span,  div.phpdebugbar-header > div > span > i{
+    display: inline-block;
     transform: translateY(-0.5px) !important;
+}
+
+div.phpdebugbar-header > div > span > i.phpdebugbar-fa-code{
+    transform: translateY(-1px) !important;
 }
 
 a.phpdebugbar-restore-btn {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -785,7 +785,7 @@ div.phpdebugbar-header-right {
 }
 
 div.phpdebugbar-header-right > * {
-    border-right: 1px solid;
+    border-right: 1px solid #ddd;
 }
 
 div.phpdebugbar-header-right > *:first-child {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -228,7 +228,7 @@ div.phpdebugbar-header {
 }
 
 div.phpdebugbar-header  span.phpdebugbar-text, div.phpdebugbar-header > div > span > span {
-    transform: translateY(-1px) !important;
+    transform: translateY(-0.5px) !important;
 }
 
 a.phpdebugbar-restore-btn {
@@ -266,22 +266,24 @@ a.phpdebugbar-restore-btn {
 }
 
 div.phpdebugbar-header > div > * {
+    padding: 5px 8px;
     font-size: 13px;
-    padding: 5px;
+    height: 20px;
 }
 
 div.phpdebugbar-header .phpdebugbar-tab {
-    padding: 5px 8px;
     border-left: 1px solid #ddd;
     display: flex;
     align-items: center;
+    justify-content: center;
+    min-width: 16px;
 }
 
 a.phpdebugbar-tab.phpdebugbar-tab-history {
-    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    border-left: 0;
 }
 
 div.phpdebugbar-header .phpdebugbar-header-left {
@@ -477,9 +479,9 @@ a.phpdebugbar-open-btn:hover {
     /* transition: background-color .25s linear 0s, color .25s linear 0s; */
 }
 
-a.phpdebugbar-minimize-btn,
-a.phpdebugbar-maximize-btn {
-    width: 28px!important;
+a.phpdebugbar-close-btn, a.phpdebugbar-open-btn, a.phpdebugbar-minimize-btn , a.phpdebugbar-maximize-btn, a.phpdebugbar-tab.phpdebugbar-tab-history {
+  width: 14px;
+  height: 20px;
 }
 
 a.phpdebugbar-tab.phpdebugbar-active {
@@ -767,11 +769,7 @@ ul.phpdebugbar-widgets-cache a.phpdebugbar-widgets-forget {
     line-height: 1.5rem;
 }
 
-a.phpdebugbar-tab i {
-    line-height: 20px;
-}
-
-div.phpdebugbar-mini-design a.phpdebugbar-tab {
+div.phpdebugbar-mini-design div.phpdebugbar-header-left a.phpdebugbar-tab {
     border-right: none;
 }
 
@@ -782,14 +780,12 @@ div.phpdebugbar-header-right {
     flex-wrap: wrap;
 }
 
-div.phpdebugbar-header-right > a {
-    height: 20px;
-    background-position: center;
+div.phpdebugbar-header-right > * {
+    border-right: 1px solid;
 }
 
-div.phpdebugbar-header-right .phpdebugbar-indicator > i.phpdebugbar-fa {
-    vertical-align: baseline;
-    margin-top: 2px;
+div.phpdebugbar-header-right > *:first-child {
+    border-right: none;
 }
 
 div.phpdebugbar-panel[data-collector="__datasets"] {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -288,7 +288,6 @@ a.phpdebugbar-tab.phpdebugbar-tab-history {
     display: flex;
     justify-content: center;
     align-items: center;
-    border-left: 0;
 }
 
 div.phpdebugbar-header .phpdebugbar-header-left {
@@ -301,7 +300,7 @@ div.phpdebugbar-header .phpdebugbar-header-left {
 }
 
 div.phpdebugbar .phpdebugbar-header select {
-    margin: 0;
+    margin: 0 4px;
     padding: 2px 3px 3px 3px;
     border-radius: 3px;
     width: auto;
@@ -491,7 +490,7 @@ a.phpdebugbar-open-btn:hover {
 }
 
 a.phpdebugbar-close-btn, a.phpdebugbar-open-btn, a.phpdebugbar-minimize-btn , a.phpdebugbar-maximize-btn, a.phpdebugbar-tab.phpdebugbar-tab-history {
-  width: 14px;
+  min-width: 14px;
   height: 20px;
 }
 


### PR DESCRIPTION
Was taking another look at the toolbar and found some more things that could be improved
- Different paddings were being used for left and right side, this is now consistent
- Weird hover state on active tab/element
- Text appears bit fuzzy because of text shadow, I think its more clear to show it without a text shadow
- Icons on the right side seem to have different paddings, made those consistent as well
- applied better vertical alignment for the icons used on the right side

Visual side by side:
![visual-changes](https://github.com/barryvdh/laravel-debugbar/assets/18613261/83ff1cb6-1658-4d49-8ce5-131df696ca97)

Also noticed that the rows of the request data is not nicely aligned anymore:
<img width="807" alt="Screenshot 2024-04-04 at 21 39 23" src="https://github.com/barryvdh/laravel-debugbar/assets/18613261/5aa03848-f05f-450a-b82b-3b8e8904be56">
I saw this remark: https://github.com/barryvdh/laravel-debugbar/pull/1605#discussion_r1551759026 and also the PR that is causing the misalignment: https://github.com/barryvdh/laravel-debugbar/pull/1608

This CSS fixes the alignment, while making sure there is enough space for the key to be fully displayed and not being cut off. 
```
dl.phpdebugbar-widgets-kvlist dt {
    width: 25%;
    width: calc(25% - 10px);
}
```
Note that this is now properly calculating the width instead of `width: calc(25%-10px);` which I included and then removed in some commits ago as it was invalid due to missing spaces.

<img width="751" alt="Screenshot 2024-04-05 at 00 06 13" src="https://github.com/barryvdh/laravel-debugbar/assets/18613261/e8e34334-c64b-41e1-9bf8-88d969141c3a">
