### PR TITLE
Line height only on sqls

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -554,6 +554,9 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item {
     border: none;
     font-family: inherit;
     overflow: visible;
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-sql {
     line-height: 20px;
 }
 


### PR DESCRIPTION
On last version, this change was supposed to only affect the readability of the sqls, but it is affecting all items lists

Fix #1605