### PR TITLE
Fix forget cache button position on cache collector

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -773,7 +773,7 @@ ul.phpdebugbar-widgets-cache a.phpdebugbar-widgets-forget {
     border-radius: 4px;
     color: #fff;
     text-decoration: none;
-    line-height: 1.5rem;
+    line-height: 1.25rem;
 }
 
 a.phpdebugbar-tab i {

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -907,6 +907,7 @@ ul.phpdebugbar-widgets-table-list li:last-child {
 
 
 pre.phpdebugbar-widgets-code-block ul.phpdebugbar-widgets-numbered-code li {
+    padding-top: 0;
     line-height: 20px;
 }
 


### PR DESCRIPTION
Buttons are not aligned correctly after CSS changes

Now they are aligned 
![image](https://github.com/barryvdh/laravel-debugbar/assets/109294935/47233ec2-fa25-48e4-a40b-e0344af9df75)
