### PR TITLE
Fix route path in phar

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -104,7 +104,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__ . '/../config/debugbar.php';
         $this->publishes([$configPath => $this->getConfigPath()], 'config');
 
-        $this->loadRoutesFrom(realpath(__DIR__ . '/debugbar-routes.php'));
+        $this->loadRoutesFrom(__DIR__ . '/debugbar-routes.php');
 
         $this->registerMiddleware(InjectDebugbar::class);
 


### PR DESCRIPTION
Don't call realpath() on route file path, it breaks routes inside phars.
It doesn't match the $configPath above it.  I can't figure out why realpath() would be called here.

Don't ask why I'm using in a phar ;)