### PR TITLE
Use `substituteBindingsIntoRawSql` when is available on QueryCollector

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -173,8 +173,11 @@ class QueryCollector extends PDOCollector
             $explainResults = $statement->fetchAll(\PDO::FETCH_CLASS);
         }
 
+        $grammar = $query->connection->getQueryGrammar();
         $bindings = $this->getDataFormatter()->checkBindings($bindings);
-        if (!empty($bindings) && $this->renderSqlWithParams) {
+        if (!empty($bindings) && $this->renderSqlWithParams && method_exists($grammar, 'substituteBindingsIntoRawSql')) {
+            $sql = $grammar->substituteBindingsIntoRawSql($sql, $bindings);
+        } else if (!empty($bindings) && $this->renderSqlWithParams) {
             foreach ($bindings as $key => $binding) {
                 // This regex matches placeholders only, not the question marks,
                 // nested in quotes, while we iterate through the bindings


### PR DESCRIPTION
Since Laravel 10.15(https://github.com/laravel/framework/pull/47507), this task can be performed natively
[Illuminate/Database/Query/Grammars/Grammar.php#L1388-L1424](https://github.com/laravel/framework/blob/f7ea4e912ce9bacfdb327de4648d07b4c7ee3cb7/src/Illuminate/Database/Query/Grammars/Grammar.php#L1388-L1424)


When 9.x is removed in the future, can the entire foreach be removed?