### PR TITLE
HTMX support

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -852,8 +852,10 @@ class LaravelDebugbar extends DebugBar
      */
     protected function isJsonRequest(Request $request)
     {
-        // If XmlHttpRequest or Live, return true
-        if ($request->isXmlHttpRequest() || $request->headers->has('X-Livewire')) {
+        // If XmlHttpRequest, Live or HTMX, return true
+        if ($request->isXmlHttpRequest() ||
+            $request->headers->has('X-Livewire') ||
+            ($request->headers->has('Hx-Request') && $request->headers->has('Hx-Target'))) {
             return true;
         }
 

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -52,4 +52,25 @@ class DebugbarTest extends TestCase
         $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
     }
+
+    public function testItDoesntInjectsOnHxRequestWithHxTarget()
+    {
+        $crawler = $this->get('web/html', [
+            'Hx-Request' => 'true',
+            'Hx-Target' => 'main',
+        ]);
+
+        $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+    }
+
+    public function testItInjectsOnHxRequestWithoutHxTarget()
+    {
+        $crawler = $this->get('web/html', [
+            'Hx-Request' => 'true',
+        ]);
+
+        $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+    }
 }


### PR DESCRIPTION
These changes prevent duplicate debugbar instances on HTMX requests. It excludes requests that do not have a target since they replace the whole `body` by default.