### PR TITLE
Add (initial) support for PHP 8.4

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
             COMPOSER_NO_INTERACTION: 1
         strategy:
             matrix:
-                php: [8.3, 8.2, 8.1, 8.0]
+                php: [8.4, 8.3, 8.2, 8.1, 8.0]
                 lumen: [10.*, 9.*]
                 exclude:
                   - lumen: 10.*
@@ -66,7 +66,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.3, 8.2, 8.1, 8.0]
+                php: [8.4, 8.3, 8.2, 8.1, 8.0]
                 laravel: [11.*, 10.*, 9.*]
                 exclude:
                   - laravel: 10.*

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -54,10 +54,11 @@ jobs:
             - name: Execute clear run
               run: |
                   cd sample
+                  mkdir -p "storage/debugbar/" && touch "storage/debugbar/foo.json"
                   php artisan debugbar:clear
             - name: Check file count in logs
               run: |
-                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ];then exit 1;fi
+                if [ `ls -1q "sample/storage/debugbar/" | wc -l` -gt 0 ];then exit 1;fi
     php-laravel-integration-tests:
         runs-on: ubuntu-latest
         timeout-minutes: 15
@@ -103,7 +104,8 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
+                  mkdir -p "storage/debugbar/" && touch "storage/debugbar/foo.json"
                   php artisan debugbar:clear
             - name: Check file count in logs
               run: |
-                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ];then exit 1;fi
+                if [ `ls -1q "sample/storage/debugbar/" | wc -l` -gt 0 ];then exit 1;fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2, 8.1, 8.0]
+        php: [8.4, 8.3, 8.2, 8.1, 8.0]
         laravel: [^11, ^10, ^9]
         dependency-version: [prefer-stable]
         exclude:


### PR DESCRIPTION
This MR:
- Runs the testsuite against PHP 8.4 (uses the currently still unstable beta version); to allow this the `--ignore-platform-req=php+` is added to `composer` calls in integration tests, to ignore checking package bounds on upper PHP versions
- ~~Replaces deprecated implicit nullable types in parameter declarations (see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)~~ see #1632

To make (integration) tests pass, the following changes are introduced:
- As Laravel cannot install yet by default with PHP 8.4, per https://github.com/nette/schema/issues/68, the suggestion there is applied to ignore PHP version in platform req checks for composer. Although opting to wait for a fix of the mentioned issue is also viable, I think not checking PHP version (through composer) for integration tests is a reasonable change, as any impactful change should already be breaking the tests anyways, and still end-users will be warned when installing with composer.
- The integration test is somewhat altered, as previously it checked for an empty `logs` directory. Due to deprecations in previous Laravel/Lumen versions being triggered on PHP 8.4, a log file is created by Laravel to log these messages. This MR changes the integration test to solely test functionality of the clear command, by adding a test file to the directory that should be cleared and subequently testing emptiness of that directory.