### PR TITLE
Replace implicit nullable types in parameter declarations

### DIFF
--- a/src/DataCollector/FilesCollector.php
+++ b/src/DataCollector/FilesCollector.php
@@ -15,7 +15,7 @@ class FilesCollector extends DataCollector implements Renderable
     /**
      * @param \Illuminate\Container\Container $app
      */
-    public function __construct(Container $app = null)
+    public function __construct(?Container $app = null)
     {
         $this->app = $app;
         $this->basePath = base_path();

--- a/src/DataCollector/LaravelCollector.php
+++ b/src/DataCollector/LaravelCollector.php
@@ -14,7 +14,7 @@ class LaravelCollector extends DataCollector implements Renderable
     /**
      * @param Application $app
      */
-    public function __construct(Application $app = null)
+    public function __construct(?Application $app = null)
     {
         $this->app = $app;
     }

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -38,7 +38,7 @@ class QueryCollector extends PDOCollector
     /**
      * @param TimeDataCollector $timeCollector
      */
-    public function __construct(TimeDataCollector $timeCollector = null)
+    public function __construct(?TimeDataCollector $timeCollector = null)
     {
         $this->timeCollector = $timeCollector;
     }

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -448,7 +448,7 @@ class LaravelDebugbar extends DebugBar
                             $this->originalTransport = $transport;
                             $this->laravelDebugbar = $laravelDebugbar;
                         }
-                        public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+                        public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
                         {
                             return $this->laravelDebugbar['time']->measure(
                                 'mail: ' . Str::limit($message->getSubject(), 100),


### PR DESCRIPTION
See also https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This was created as part of #1631, but due to test failures I'll open this individually so it can already be applied without having to wait for succeeding tests on PHP 8.4.