### PR TITLE
Migrate PHPCS configuration to file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,8 +52,8 @@
         }
     },
     "scripts": {
-        "check-style": "phpcs -p --standard=PSR12 config/ src/ tests/  --ignore=src/Resources/* ",
-        "fix-style": "phpcbf -p --standard=PSR12 config/ src/ tests/  --ignore=src/Resources*",
+        "check-style": "phpcs",
+        "fix-style": "phpcbf",
         "test": "phpunit"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <file>config</file>
+    <file>src</file>
+    <file>tests</file>
+
+    <exclude-pattern>src/Resources/*</exclude-pattern>
+    <exclude-pattern>*.blade.php</exclude-pattern>
+
+    <arg value="p"/>
+
+    <rule ref="PSR12" />
+</ruleset>

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -853,9 +853,11 @@ class LaravelDebugbar extends DebugBar
     protected function isJsonRequest(Request $request)
     {
         // If XmlHttpRequest, Live or HTMX, return true
-        if ($request->isXmlHttpRequest() ||
+        if (
+            $request->isXmlHttpRequest() ||
             $request->headers->has('X-Livewire') ||
-            ($request->headers->has('Hx-Request') && $request->headers->has('Hx-Target'))) {
+            ($request->headers->has('Hx-Request') && $request->headers->has('Hx-Target'))
+        ) {
             return true;
         }
 

--- a/src/Storage/SocketStorage.php
+++ b/src/Storage/SocketStorage.php
@@ -23,7 +23,7 @@ class SocketStorage implements StorageInterface
     /**
      * @inheritDoc
      */
-    function save($id, $data)
+    public function save($id, $data)
     {
         $socketIsFresh = !$this->socket;
 
@@ -76,7 +76,7 @@ class SocketStorage implements StorageInterface
     /**
      * @inheritDoc
      */
-    function get($id)
+    public function get($id)
     {
         //
     }
@@ -84,7 +84,7 @@ class SocketStorage implements StorageInterface
     /**
      * @inheritDoc
      */
-    function find(array $filters = [], $max = 20, $offset = 0)
+    public function find(array $filters = [], $max = 20, $offset = 0)
     {
         //
     }
@@ -92,7 +92,7 @@ class SocketStorage implements StorageInterface
     /**
      * @inheritDoc
      */
-    function clear()
+    public function clear()
     {
         //
     }


### PR DESCRIPTION
This PR migrates the PHPCS cli configuration to a xml file, to allow for easier usage and ensure consistency across phpcs/phpcbf calls. It also fixes some (auto-)fixable codestyle errors that the CI job currently fails to correct on the `master` branch.

Finally it adds `blade.php` files to excluded patterns, as they should not be linted as PHP code.