### PR TITLE
Avoid calling urlencode() on null

### DIFF
--- a/src/DataCollector/RequestCollector.php
+++ b/src/DataCollector/RequestCollector.php
@@ -152,7 +152,7 @@ class RequestCollector extends DataCollector implements DataCollectorInterface, 
 
     private function getCookieHeader($name, $value, $expires, $path, $domain, $secure, $httponly)
     {
-        $cookie = sprintf('%s=%s', $name, urlencode($value));
+        $cookie = sprintf('%s=%s', $name, urlencode($value ?? ''));
 
         if (0 !== $expires) {
             if (is_numeric($expires)) {


### PR DESCRIPTION
Hi,

The PR fixes this deprecation warning:
```
urlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/barryvdh/laravel-debugbar/src/DataCollector/RequestCollector.php:168
```

This can happen because [the value of a cookie is a nullable string](https://github.com/symfony/http-foundation/blob/d272906/Cookie.php#L315).