### PR TITLE
Add collectors unit tests for route and session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 composer.phar
 composer.lock
 .DS_Store
-.phpunit.result.cache
+.phpunit*
 /tests/Browser

--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -5,8 +5,6 @@ namespace Barryvdh\Debugbar\DataCollector;
 use Closure;
 use DebugBar\DataCollector\DataCollector;
 use DebugBar\DataCollector\Renderable;
-use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Config;
 

--- a/tests/DataCollector/RouteCollectorTest.php
+++ b/tests/DataCollector/RouteCollectorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\Tests\TestCase;
+use DebugBar\DataCollector\DataCollector;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class RouteCollectorTest extends TestCase
+{
+    /** @var \Barryvdh\Debugbar\DataCollector\RouteCollector $collector */
+    private DataCollector $routeCollector;
+    protected function setUp(): void
+    {
+        parent::setUp();
+        debugbar()->boot();
+
+        $this->routeCollector = debugbar()->getCollector('route');
+    }
+
+    public function testItCollectsRouteUri()
+    {
+        $this->get('web/html');
+        $this->assertSame('GET web/html', $this->routeCollector->collect()['uri']);
+
+        $this->call('POST', 'web/mw');
+        $this->assertSame('POST web/mw', $this->routeCollector->collect()['uri']);
+    }
+
+    #[DataProvider('controllerData')]
+    public function testItCollectsWithControllerHandler($controller, $file)
+    {
+        $this->get('web/show');
+
+        $collected = $this->routeCollector->collect();
+
+        $this->assertNotEmpty($collected);
+        $this->assertArrayHasKey('file', $collected);
+        $this->assertArrayHasKey('controller', $collected);
+        $this->assertStringContainsString($file, $collected['file']);
+        $this->assertStringContainsString($controller, $collected['controller']);
+    }
+
+    #[DataProvider('viewComponentData')]
+    public function testItCollectsWithViewComponentHandler($controller, $file)
+    {
+        $this->get('web/view');
+
+        $collected = $this->routeCollector->collect();
+
+        $this->assertStringContainsString($file, $collected['file']);
+        $this->assertStringContainsString($controller, $collected['controller']);
+    }
+
+    #[DataProvider('closureData')]
+    public function testItCollectsWithClosureHandler($file)
+    {
+        $this->get('web/html');
+
+        $collected = $this->routeCollector->collect();
+
+        $this->assertNotEmpty($collected);
+        $this->assertArrayHasKey('uses', $collected);
+        $this->assertArrayHasKey('file', $collected);
+        $this->assertStringContainsString($file, $collected['uses']);
+        $this->assertStringContainsString($file, $collected['file']);
+    }
+
+    public function testItCollectsMiddleware()
+    {
+        $this->call('POST', 'web/mw');
+
+        $collected = $this->routeCollector->collect();
+
+        $this->assertNotEmpty($collected);
+        $this->assertArrayHasKey('middleware', $collected);
+        $this->assertStringContainsString('MockMiddleware', $collected['middleware']);
+    }
+
+    public static function controllerData()
+    {
+        $filePath = urlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockController.php')));
+        return [['MockController@show',
+                 sprintf('phpstorm://open?file=%s', $filePath)
+        ]];
+    }
+
+    public static function viewComponentData()
+    {
+        $filePath = urlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockViewComponent.php')));
+        return [['MockViewComponent@render',
+                 sprintf('phpstorm://open?file=%s', $filePath)
+        ]];
+    }
+
+    public static function closureData()
+    {
+        return [['TestCase.php']];
+    }
+}

--- a/tests/DataCollector/RouteCollectorTest.php
+++ b/tests/DataCollector/RouteCollectorTest.php
@@ -4,7 +4,6 @@ namespace Barryvdh\Debugbar\Tests\DataCollector;
 
 use Barryvdh\Debugbar\Tests\TestCase;
 use DebugBar\DataCollector\DataCollector;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouteCollectorTest extends TestCase
 {
@@ -27,7 +26,9 @@ class RouteCollectorTest extends TestCase
         $this->assertSame('POST web/mw', $this->routeCollector->collect()['uri']);
     }
 
-    #[DataProvider('controllerData')]
+    /**
+     * @dataProvider controllerData
+     */
     public function testItCollectsWithControllerHandler($controller, $file)
     {
         $this->get('web/show');
@@ -41,7 +42,9 @@ class RouteCollectorTest extends TestCase
         $this->assertStringContainsString($controller, $collected['controller']);
     }
 
-    #[DataProvider('viewComponentData')]
+    /**
+     * @dataProvider viewComponentData
+     */
     public function testItCollectsWithViewComponentHandler($controller, $file)
     {
         $this->get('web/view');
@@ -52,7 +55,9 @@ class RouteCollectorTest extends TestCase
         $this->assertStringContainsString($controller, $collected['controller']);
     }
 
-    #[DataProvider('closureData')]
+    /**
+     * @dataProvider closureData
+     */
     public function testItCollectsWithClosureHandler($file)
     {
         $this->get('web/html');

--- a/tests/DataCollector/SessionCollectorTest.php
+++ b/tests/DataCollector/SessionCollectorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\DataCollector;
+
+use Barryvdh\Debugbar\Tests\TestCase;
+use Barryvdh\Debugbar\DataCollector\SessionCollector;
+use Illuminate\Session\SessionManager;
+
+class SessionCollectorTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('debugbar.options.session.hiddens', ['secret']);
+        parent::getEnvironmentSetUp($app);
+    }
+
+    public function testItCollectsSessionVariables()
+    {
+        /** @var \Barryvdh\Debugbar\DataCollector\SessionCollector $collector */
+        $collector = new SessionCollector(
+            $this->app->make(SessionManager::class),
+            $this->app['config']->get('debugbar.options.session.hiddens', [])
+        );
+
+        $this->assertEmpty($collector->collect());
+
+        $this->withSession(['testVariable' => 1, 'secret' => 'testSecret'])->get('/');
+
+        $collected = $collector->collect();
+
+        $this->assertNotEmpty($collected);
+        $this->assertArrayHasKey('secret', $collected);
+        $this->assertArrayHasKey('testVariable', $collected);
+        $this->assertEquals($collected['secret'], '******');
+        $this->assertEquals($collected['testVariable'], 1);
+
+        $this->flushSession();
+        $this->assertCount(0, $collector->collect());
+    }
+}

--- a/tests/Mocks/MockController.php
+++ b/tests/Mocks/MockController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\Mocks;
+
+use Illuminate\Routing\Controller;
+
+class MockController extends Controller
+{
+    public function show()
+    {
+        return view('dashboard');
+    }
+}

--- a/tests/Mocks/MockMiddleware.php
+++ b/tests/Mocks/MockMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\Mocks;
+
+use Closure;
+
+class MockMiddleware
+{
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+}

--- a/tests/Mocks/MockViewComponent.php
+++ b/tests/Mocks/MockViewComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests\Mocks;
+
+use Illuminate\View\InvokableComponentVariable;
+
+class MockViewComponent extends InvokableComponentVariable
+{
+    public function render()
+    {
+        return view('dashboard');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,9 @@ use Barryvdh\Debugbar\Facades\Debugbar;
 use Barryvdh\Debugbar\ServiceProvider;
 use Illuminate\Routing\Router;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Barryvdh\Debugbar\Tests\Mocks\MockController;
+use Barryvdh\Debugbar\Tests\Mocks\MockViewComponent;
+use Barryvdh\Debugbar\Tests\Mocks\MockMiddleware;
 
 class TestCase extends Orchestra
 {
@@ -55,17 +58,19 @@ class TestCase extends Orchestra
      */
     protected function addWebRoutes(Router $router)
     {
-        $router->get('web/plain', [
-            'uses' => function () {
-                return 'PONG';
-            }
-        ]);
+        $router->get('web/plain', function () {
+            return 'PONG';
+        });
 
-        $router->get('web/html', [
-            'uses' => function () {
-                return '<html><head></head><body>Pong</body></html>';
-            }
-        ]);
+        $router->get('web/html', function () {
+            return '<html><head></head><body>Pong</body></html>';
+        });
+
+        $router->get('web/show', [ MockController::class, 'show' ]);
+
+        $router->get('web/view', MockViewComponent::class);
+
+        $router->post('web/mw')->middleware(MockMiddleware::class);
     }
 
     /**


### PR DESCRIPTION
* Adds new unit tests for collectors. 
`tests/DataCollector/RouteCollectorTest.php`
`tests/DataCollector/SessionCollectorTest.php`

* Adds test mock classes to make tests less complex.
`tests/Mocks/MockController.php`
`tests/Mocks/MockMiddleware.php`
`tests/Mocks/MockViewComponent.php`

* Adds 3 routes for route testing:
`$router->get('web/show', [MockController::class, 'show']);`
`$router->post('web/mw')->middleware(MockMiddleware::class);`
`$router->get('web/view', MockViewComponent::class);`