### PR TITLE
Fix: Query hints rendering `<code>`

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -344,7 +344,11 @@
                 if (showLineNumbers) {
                     $ul.append($li.clone().append([$muted.clone().text(`${i}:`), '&nbsp;', $('<span/>').text(values[i])]));
                 } else {
-                    $ul.append($li.clone().text(values[i]));
+                    if (caption === 'Hints') {
+                        $ul.append($li.clone().append(values[i]));
+                    } else {
+                        $ul.append($li.clone().text(values[i]));
+                    }
                 }
             }
 


### PR DESCRIPTION
See: https://github.com/barryvdh/laravel-debugbar/pull/1648#discussion_r1748019494