### PR TITLE
Laravel Pennant Collector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -183,6 +183,7 @@ return [
         'models'          => true,  // Display models
         'livewire'        => true,  // Display Livewire (when available)
         'jobs'            => false, // Display dispatched jobs
+        'pennant'         => false, // Display Pennant feature flags
     ],
 
     /*

--- a/src/DataCollector/PennantCollector.php
+++ b/src/DataCollector/PennantCollector.php
@@ -48,7 +48,7 @@ class PennantCollector extends DataCollector implements DataCollectorInterface, 
         return [
             "pennant" => [
                 "icon" => "flag",
-                "widget" => "PhpDebugBar.Widgets.HtmlVariableListWidget",
+                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
                 "map" => "pennant",
                 "default" => "{}"
             ]

--- a/src/DataCollector/PennantCollector.php
+++ b/src/DataCollector/PennantCollector.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Barryvdh\Debugbar\DataCollector;
+
+use DebugBar\DataCollector\DataCollector;
+use DebugBar\DataCollector\DataCollectorInterface;
+use DebugBar\DataCollector\Renderable;
+use Illuminate\Support\Facades\Config;
+
+class PennantCollector extends DataCollector implements DataCollectorInterface, Renderable
+{
+    /** @var  \Laravel\Pennant\FeatureManager */
+    protected $manager;
+
+    /**
+     * Create a new SessionCollector
+     *
+     * @param \Laravel\Pennant\FeatureManager $manager
+     */
+    public function __construct($manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect()
+    {
+        $store = $this->manager->store(Config::get('pennant.default'));
+
+        return $store->values($store->stored());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'pennant';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getWidgets()
+    {
+        return [
+            "pennant" => [
+                "icon" => "flag",
+                "widget" => "PhpDebugBar.Widgets.HtmlVariableListWidget",
+                "map" => "pennant",
+                "default" => "{}"
+            ]
+        ];
+    }
+}

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -10,6 +10,7 @@ use Barryvdh\Debugbar\DataCollector\LaravelCollector;
 use Barryvdh\Debugbar\DataCollector\LivewireCollector;
 use Barryvdh\Debugbar\DataCollector\LogsCollector;
 use Barryvdh\Debugbar\DataCollector\MultiAuthCollector;
+use Barryvdh\Debugbar\DataCollector\PennantCollector;
 use Barryvdh\Debugbar\DataCollector\QueryCollector;
 use Barryvdh\Debugbar\DataCollector\SessionCollector;
 use Barryvdh\Debugbar\DataCollector\RequestCollector;
@@ -527,6 +528,17 @@ class LaravelDebugbar extends DebugBar
                 });
             } catch (Exception $e) {
                 $this->addCollectorException('Cannot add Jobs Collector', $e);
+            }
+        }
+
+        if ($this->shouldCollect('pennant', false)) {
+            if (class_exists('Laravel\Pennant\FeatureManager') && $app->bound(\Laravel\Pennant\FeatureManager::class)) {
+                $featureManager = $app->make(\Laravel\Pennant\FeatureManager::class);
+                try {
+                    $this->addCollector(new PennantCollector($featureManager));
+                } catch (Exception $e) {
+                    $this->addCollectorException('Cannot add PennantCollector', $e);
+                }
             }
         }
 


### PR DESCRIPTION
I was using Laravel Pennant recently and wanted to know in the context of the page if a feature flag was enabled or not and had to result to outputting the state via Ray/dd outputs.

So I thought it would be quite handy to have a collector that is disabled by default that lists out the flags in a table format similar to models etc...

The pull request takes into account Laravel Pennant not being installed, or the specific case it is installed but not bound to the container.

I was hoping to write some tests but felt it would be difficult due to the external dependencies, similar to the Livewire collector.

I have done some manual testing with both array and database drivers and verified the output correctly renders. 

![image](https://github.com/user-attachments/assets/56a1f740-9e7d-4bfe-a14d-db4f490824e9)

![image](https://github.com/user-attachments/assets/20b4c514-73aa-46b9-8dfb-7edcc3ec8226)

Hopefully this could be of use to others? Happy to change anything, attempt further to add tests if required.