### PR TITLE
Fix redirect session

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,8 @@
     <php>
         <env name="DEBUGBAR_ENABLED" value="true"/>
         <env name="DB_CONNECTION" value="testing"/>
+        <env name="DB_CONNECTION" value="testing"/>
+        <env name="SESSION_DRIVER" value="file"/>
         <ini name="xdebug.file_link_format" value="vscode://file/%f:%l"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,7 +29,6 @@
         <env name="DEBUGBAR_ENABLED" value="true"/>
         <env name="DB_CONNECTION" value="testing"/>
         <env name="DB_CONNECTION" value="testing"/>
-        <env name="SESSION_DRIVER" value="database"/>
         <ini name="xdebug.file_link_format" value="vscode://file/%f:%l"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,7 +29,7 @@
         <env name="DEBUGBAR_ENABLED" value="true"/>
         <env name="DB_CONNECTION" value="testing"/>
         <env name="DB_CONNECTION" value="testing"/>
-        <env name="SESSION_DRIVER" value="file"/>
+        <env name="SESSION_DRIVER" value="database"/>
         <ini name="xdebug.file_link_format" value="vscode://file/%f:%l"/>
     </php>
 </phpunit>

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -100,8 +100,8 @@ class LaravelDebugbar extends DebugBar
 
     protected ?string $editorTemplateLink = null;
     protected array $remoteServerReplacements = [];
-
-
+    protected bool $responseIsModified = false;
+    protected array $stackedData = [];
     /**
      * @param Application $app
      */
@@ -706,9 +706,12 @@ class LaravelDebugbar extends DebugBar
     {
         /** @var Application $app */
         $app = $this->app;
-        if (!$this->isEnabled() || $this->isDebugbarRequest()) {
+        if (!$this->isEnabled() || $this->isDebugbarRequest() || $this->responseIsModified) {
             return $response;
         }
+
+        // Prevent duplicate modification
+        $this->responseIsModified = true;
 
         // Show the Http Response Exception in the Debugbar, when available
         if (isset($response->exception)) {
@@ -977,6 +980,29 @@ class LaravelDebugbar extends DebugBar
         if ($original) {
             $response->original = $original;
         }
+    }
+
+    /**
+     * Checks if there is stacked data in the session
+     *
+     * @return boolean
+     */
+    public function hasStackedData()
+    {
+        return count($this->getStackedData(false)) > 0;
+    }
+
+    /**
+     * Returns the data stacked in the session
+     *
+     * @param boolean $delete Whether to delete the data in the session
+     * @return array
+     */
+    public function getStackedData($delete = true): array
+    {
+        $this->stackedData = array_merge($this->stackedData, parent::getStackedData($delete));
+
+        return $this->stackedData;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,17 +2,16 @@
 
 namespace Barryvdh\Debugbar;
 
-use Barryvdh\Debugbar\Middleware\DebugbarEnabled;
 use Barryvdh\Debugbar\Middleware\InjectDebugbar;
 use DebugBar\DataFormatter\DataFormatter;
 use DebugBar\DataFormatter\DataFormatterInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Routing\Router;
 use Illuminate\Session\SessionManager;
 use Illuminate\Support\Collection;
-use Barryvdh\Debugbar\Facade as DebugBar;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -106,6 +105,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->loadRoutesFrom(__DIR__ . '/debugbar-routes.php');
 
+        $this->registerResponseListener();
         $this->registerMiddleware(InjectDebugbar::class);
 
         $this->commands(['command.debugbar.clear']);
@@ -150,5 +150,31 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $kernel = $this->app[Kernel::class];
         $kernel->pushMiddleware($middleware);
+    }
+
+    /**
+     * Register the Response Listener
+     *
+     * @param  string $middleware
+     */
+    protected function registerResponseListener()
+    {
+        if (!isset($this->app['events']) || !class_exists(ResponsePrepared::class)) {
+            return;
+        }
+
+        /**
+         * For redirects, prepare the response early to store in the session.
+         * For regular requests, get the stacked data early
+         */
+        $this->app['events']->listen(ResponsePrepared::class, function (ResponsePrepared $event) {
+            /** @var LaravelDebugbar $debugbar */
+            $debugbar = $this->app->make(LaravelDebugbar::class);
+            if ($event->response->isRedirection()) {
+                $debugbar->modifyResponse($event->request, $event->response);
+            } else {
+                $debugbar->getStackedData();
+            }
+        });
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -170,10 +170,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->app['events']->listen(ResponsePrepared::class, function (ResponsePrepared $event) {
             /** @var LaravelDebugbar $debugbar */
             $debugbar = $this->app->make(LaravelDebugbar::class);
-            if ($event->response->isRedirection()) {
-                $debugbar->modifyResponse($event->request, $event->response);
-            } else {
-                $debugbar->getStackedData();
+            if ($debugbar->isEnabled()) {
+                if ($event->response->isRedirection()) {
+                    $debugbar->modifyResponse($event->request, $event->response);
+                } else {
+                    $debugbar->getStackedData();
+                }
             }
         });
     }

--- a/tests/DebugbarBrowserTest.php
+++ b/tests/DebugbarBrowserTest.php
@@ -7,6 +7,7 @@ use Laravel\Dusk\Browser;
 
 class DebugbarBrowserTest extends BrowserTestCase
 {
+
     /**
      * Define environment setup.
      *

--- a/tests/DebugbarBrowserTest.php
+++ b/tests/DebugbarBrowserTest.php
@@ -3,6 +3,7 @@
 namespace Barryvdh\Debugbar\Tests;
 
 use Illuminate\Routing\Router;
+use Laravel\Dusk\Browser;
 
 class DebugbarBrowserTest extends BrowserTestCase
 {
@@ -25,6 +26,9 @@ class DebugbarBrowserTest extends BrowserTestCase
         $this->addWebRoutes($router);
         $this->addApiRoutes($router);
 
+        $kernel = app('Illuminate\Contracts\Http\Kernel');
+        $kernel->pushMiddleware('Illuminate\Session\Middleware\StartSession');
+
         \Orchestra\Testbench\Dusk\Options::withoutUI();
     }
 
@@ -33,6 +37,12 @@ class DebugbarBrowserTest extends BrowserTestCase
      */
     protected function addWebRoutes(Router $router)
     {
+        $router->get('web/redirect', [
+            'uses' => function () {
+                return redirect($this->applicationBaseUrl() . '/web/plain');
+            }
+        ]);
+
         $router->get('web/plain', [
             'uses' => function () {
                 return 'PONG';
@@ -56,6 +66,20 @@ class DebugbarBrowserTest extends BrowserTestCase
                 return response()->json(['status' => 'pong']);
             }
         ]);
+    }
+
+    public function testItStacksOnRedirect()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('web/redirect')
+                ->assertSee('PONG')
+                ->waitFor('.phpdebugbar-fa-history')
+                ->assertSee('GET web/plain')
+                ->click('.phpdebugbar-tab-history')
+                ->waitFor('.phpdebugbar-widgets-dataset-history')
+                ->waitForTextIn('.phpdebugbar-widgets-dataset-history', 'web/redirect (stacked)')
+                ->assertSee('web/redirect');
+        });
     }
 
     public function testItInjectsOnPlainText()

--- a/tests/DebugbarBrowserTest.php
+++ b/tests/DebugbarBrowserTest.php
@@ -17,6 +17,8 @@ class DebugbarBrowserTest extends BrowserTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
+        parent::getEnvironmentSetUp($app);
+
         $app['env'] = 'local';
 
 //        $app['config']->set('app.debug', true);
@@ -74,10 +76,9 @@ class DebugbarBrowserTest extends BrowserTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit('web/redirect')
                 ->assertSee('PONG')
-                ->waitFor('.phpdebugbar-fa-history')
+                ->waitFor('.phpdebugbar')
                 ->assertSee('GET web/plain')
                 ->click('.phpdebugbar-tab-history')
-                ->waitFor('.phpdebugbar-widgets-dataset-history')
                 ->waitForTextIn('.phpdebugbar-widgets-dataset-history', 'web/redirect (stacked)')
                 ->assertSee('web/redirect');
         });


### PR DESCRIPTION
Get the response early for redirects, and get the stacked data also early.

Since some time the redirects are not stacked anymore, I think because the session is saved before the debugbar is injected.
This moves the session stuff earlier in the cycle. It will continue for the regular request.