### PR TITLE
Add option to hide queries

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -213,6 +213,9 @@ return [
         ],
         'db' => [
             'with_params'       => true,   // Render SQL with the parameters substituted
+            'exclude_paths'     => [       // Paths to exclude entirely from the collector
+//                'vendor/laravel/framework/src/Illuminate/Session', // Exclude sessions queries
+            ],
             'backtrace'         => true,   // Use a backtrace to find the origin of the query in your files.
             'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
             'timeline'          => false,  // Add the queries to the timeline

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -309,8 +309,12 @@ class LaravelDebugbar extends DebugBar
                 $queryCollector->setFindSource($dbBacktrace, $middleware);
             }
 
-            if ($excludePaths = $config->get('debugbar.options.db.backtrace_exclude_paths')) {
-                $queryCollector->mergeBacktraceExcludePaths($excludePaths);
+            if ($excludePaths = $config->get('debugbar.options.db.exclude_paths')) {
+                $queryCollector->mergeExcludePaths($excludePaths);
+            }
+
+            if ($excludeBacktracePaths = $config->get('debugbar.options.db.backtrace_exclude_paths')) {
+                $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
             }
 
             if ($config->get('debugbar.options.db.explain.enabled')) {

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -161,6 +161,9 @@
             }
 
             const $text = $('<span />').text(`${data.nb_statements} statements were executed`);
+            if (data.nb_excluded_statements) {
+                $text.append(`, ${data.nb_excluded_statements} have been excluded`);
+            }
             if (data.nb_failed_statements > 0 || this.duplicateQueries.size > 0) {
                 const details = [];
                 if (data.nb_failed_statements) {


### PR DESCRIPTION
Gives the option to hide query paths by default.

Not sure if anyone actually wants to see them, or we should just make it default. Shows they are hidden in the UI:

![image](https://github.com/user-attachments/assets/9dbbeb4c-781a-44ea-84df-32e0df54d182)
