### PR TITLE
Inject data on every request, not just store

### DIFF
--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -35,6 +35,7 @@ class DebugbarTest extends TestCase
 
         $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 
     public function testItInjectsOnHtml()
@@ -43,6 +44,7 @@ class DebugbarTest extends TestCase
 
         $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 
     public function testItDoesntInjectOnJson()
@@ -51,6 +53,16 @@ class DebugbarTest extends TestCase
 
         $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
+    }
+
+    public function testItDoesntInjectOnJsonLookingString()
+    {
+        $crawler = $this->call('GET', 'web/fakejson');
+
+        $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 
     public function testItDoesntInjectsOnHxRequestWithHxTarget()
@@ -62,6 +74,7 @@ class DebugbarTest extends TestCase
 
         $this->assertFalse(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 
     public function testItInjectsOnHxRequestWithoutHxTarget()
@@ -72,5 +85,6 @@ class DebugbarTest extends TestCase
 
         $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
         $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -66,6 +66,10 @@ class TestCase extends Orchestra
             return '<html><head></head><body>Pong</body></html>';
         });
 
+        $router->get('web/fakejson', function () {
+            return '{"foo":"bar"}';
+        });
+
         $router->get('web/show', [ MockController::class, 'show' ]);
 
         $router->get('web/view', MockViewComponent::class);

--- a/tests/resources/views/ajax.blade.php
+++ b/tests/resources/views/ajax.blade.php
@@ -7,7 +7,7 @@
 <script>
     async function loadAjax() {
         try {
-            const response = await fetch('/api/ping', {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+            const response = await fetch('/api/ping');
             if (!response.ok) {
                 throw new Error(`Response status: ${response.status}`);
             }


### PR DESCRIPTION
So more of a brainfart, but we could just inject the debugbar id in the header, if we're not sure it's actually ajax. This would catch more cases.

Still only inject when we're sure it's html though.