### PR TITLE
Explain Improvements

### DIFF
--- a/src/Controllers/QueriesController.php
+++ b/src/Controllers/QueriesController.php
@@ -21,14 +21,21 @@ class QueriesController extends BaseController
         }
 
         try {
-            $data = match ($request->json('mode')) {
-                'visual' => (new Explain())->generateVisualExplain($request->json('connection'), $request->json('query'), $request->json('bindings'), $request->json('hash')),
-                default => (new Explain())->generateRawExplain($request->json('connection'), $request->json('query'), $request->json('bindings'), $request->json('hash')),
-            };
+            $explain = new Explain();
+
+            if ($request->json('mode') === 'visual') {
+                return response()->json([
+                    'success' => true,
+                    'data' => $explain->generateVisualExplain($request->json('connection'), $request->json('query'), $request->json('bindings'), $request->json('hash')),
+                ]);
+            }
 
             return response()->json([
                 'success' => true,
-                'data' => $data,
+                'data' => $explain->generateRawExplain($request->json('connection'), $request->json('query'), $request->json('bindings'), $request->json('hash')),
+                'visual' => $explain->isVisualExplainSupported($request->json('connection')) ? [
+                    'confirm' => $explain->confirmVisualExplain($request->json('connection')),
+                ] : null,
             ]);
         } catch (Exception $e) {
             return response()->json([

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -500,7 +500,7 @@ class QueryCollector extends PDOCollector
             }
 
             $canExplainQuery = match (true) {
-                in_array($query['driver'], ['mysql', 'pgsql']) => $query['bindings'] !== null && preg_match('/^\s*(' . implode('|', $this->explainTypes) . ') /i', $query['query']),
+                in_array($query['driver'], ['mariadb', 'mysql', 'pgsql']) => $query['bindings'] !== null && preg_match('/^\s*(' . implode('|', $this->explainTypes) . ') /i', $query['query']),
                 default => false,
             };
 

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -482,6 +482,7 @@ class QueryCollector extends PDOCollector
         $totalTime = 0;
         $totalMemory = 0;
         $queries = $this->queries;
+        $explain = new Explain();
 
         $statements = [];
         foreach ($queries as $query) {
@@ -526,10 +527,10 @@ class QueryCollector extends PDOCollector
                     'driver' => $query['driver'],
                     'connection' => $query['connection'],
                     'query' => $query['query'],
-                    'hash' => (new Explain())->hash($query['connection'], $query['query'], $query['bindings']),
-                    'visual' => [
-                        'confirm' => (new Explain())->confirm($query['connection']),
-                    ],
+                    'hash' => $explain->hash($query['connection'], $query['query'], $query['bindings']),
+                    'visual' => $explain->isVisualExplainSupported($query['connection']) ? [
+                        'confirm' => $explain->confirmVisualExplain($query['connection']),
+                    ] : null,
                 ] : null,
             ];
         }

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -482,7 +482,6 @@ class QueryCollector extends PDOCollector
         $totalTime = 0;
         $totalMemory = 0;
         $queries = $this->queries;
-        $explain = new Explain();
 
         $statements = [];
         foreach ($queries as $query) {
@@ -527,10 +526,7 @@ class QueryCollector extends PDOCollector
                     'driver' => $query['driver'],
                     'connection' => $query['connection'],
                     'query' => $query['query'],
-                    'hash' => $explain->hash($query['connection'], $query['query'], $query['bindings']),
-                    'visual' => $explain->isVisualExplainSupported($query['connection']) ? [
-                        'confirm' => $explain->confirmVisualExplain($query['connection']),
-                    ] : null,
+                    'hash' => (new Explain())->hash($query['connection'], $query['query'], $query['bindings']),
                 ] : null,
             ];
         }

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -523,11 +523,13 @@ class QueryCollector extends PDOCollector
                 'connection' => $connectionName,
                 'explain' => $this->explainQuery && $canExplainQuery ? [
                     'url' => route('debugbar.queries.explain'),
-                    'visual-confirm' =>  (new Explain())->confirm($query['connection']),
                     'driver' => $query['driver'],
                     'connection' => $query['connection'],
                     'query' => $query['query'],
                     'hash' => (new Explain())->hash($query['connection'], $query['query'], $query['bindings']),
+                    'visual' => [
+                        'confirm' => (new Explain())->confirm($query['connection']),
+                    ],
                 ] : null,
             ];
         }

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -309,7 +309,7 @@
             if (statement.backtrace && !$.isEmptyObject(statement.backtrace)) {
                 $details.append(this.renderDetailBacktrace('Backtrace', 'list-ul', statement.backtrace));
             }
-            if (statement.explain && statement.explain.driver === 'mysql') {
+            if (statement.explain && ['mariadb', 'mysql'].includes(statement.explain.driver)) {
                 $details.append(this.renderDetailExplain('Performance', 'tachometer', statement, this.explainMysql.bind(this)));
             }
             if (statement.explain && statement.explain.driver === 'pgsql') {

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -41,7 +41,7 @@
             return isCopied;
         },
 
-        explainMysql: function ($element, statement, rows) {
+        explainMysql: function ($element, statement, rows, visual) {
             const headings = [];
             for (const key in rows[0]) {
                 headings.push($('<th/>').text(key));
@@ -61,12 +61,12 @@
             $table.find('tbody').append(values);
 
             $element.append($table);
-            if (statement.explain.visual) {
-                $element.append(this.explainVisual(statement));
+            if (visual) {
+                $element.append(this.explainVisual(statement, visual.confirm));
             }
         },
 
-        explainPgsql: function ($element, statement, rows) {
+        explainPgsql: function ($element, statement, rows, visual) {
             const $ul = $('<ul />').addClass(csscls('table-list'));
             const $li = $('<li />').addClass(csscls('table-list-item'));
 
@@ -74,16 +74,16 @@
                 $ul.append($li.clone().html($('<span/>').text(row).text().replaceAll(' ', '&nbsp;')));
             }
 
-            $element.append([$ul, this.explainVisual(statement)]);
+            $element.append([$ul, this.explainVisual(statement, visual.confirm)]);
         },
 
-        explainVisual: function (statement) {
+        explainVisual: function (statement, confirmMessage) {
             const $explainLink = $('<a href="#" target="_blank" rel="noopener"/>')
                 .addClass(csscls('visual-link'));
             const $explainButton = $('<a>Visual Explain</a>')
                 .addClass(csscls('visual-explain'))
                 .on('click', () => {
-                      if (confirm(statement.explain.visual.confirm)) {
+                      if (confirm(confirmMessage)) {
                           fetch(statement.explain.url, {
                               method: "POST",
                               body: JSON.stringify({
@@ -402,7 +402,7 @@
                             response.json()
                                 .then((json) => {
                                     $detail.find(`.${csscls('value')}`).children().remove();
-                                    explainFn($detail.find(`.${csscls('value')}`), statement, json.data);
+                                    explainFn($detail.find(`.${csscls('value')}`), statement, json.data, json.visual);
                                 })
                                 .catch((err) => alert(`Response body could not be parsed. (${err})`));
                         } else {

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -60,7 +60,10 @@
             $table.find('thead').append($('<tr/>').append(headings));
             $table.find('tbody').append(values);
 
-            $element.append([$table, this.explainVisual(statement)]);
+            $element.append($table);
+            if (statement.explain.visual) {
+                $element.append(this.explainVisual(statement));
+            }
         },
 
         explainPgsql: function ($element, statement, rows) {

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -71,7 +71,7 @@
             const $li = $('<li />').addClass(csscls('table-list-item'));
 
             for (const row of rows) {
-                $ul.append($li.clone().append(row));
+                $ul.append($li.clone().html($('<span/>').text(row).text().replaceAll(' ', '&nbsp;')));
             }
 
             $element.append([$ul, this.explainVisual(statement)]);

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -80,7 +80,7 @@
             const $explainButton = $('<a>Visual Explain</a>')
                 .addClass(csscls('visual-explain'))
                 .on('click', () => {
-                      if (confirm(statement.explain['visual-confirm'])) {
+                      if (confirm(statement.explain.visual.confirm)) {
                           fetch(statement.explain.url, {
                               method: "POST",
                               body: JSON.stringify({

--- a/src/Support/Explain.php
+++ b/src/Support/Explain.php
@@ -23,7 +23,7 @@ class Explain
         $bindings = json_encode($bindings);
 
         return match (DB::connection($connection)->getDriverName()) {
-            'mysql', 'pgsql' => hash_hmac('sha256', "{$connection}::{$sql}::{$bindings}", config('app.key')),
+            'mariadb', 'mysql', 'pgsql' => hash_hmac('sha256', "{$connection}::{$sql}::{$bindings}", config('app.key')),
             default => null,
         };
     }
@@ -42,7 +42,7 @@ class Explain
         $connection = DB::connection($connection);
 
         return match ($driver = $connection->getDriverName()) {
-            'mysql' => $connection->select("EXPLAIN {$sql}", $bindings),
+            'mariadb', 'mysql' => $connection->select("EXPLAIN {$sql}", $bindings),
             'pgsql' => array_column($connection->select("EXPLAIN {$sql}", $bindings), 'QUERY PLAN'),
             default => throw new Exception("Visual explain not available for driver '{$driver}'."),
         };

--- a/src/Support/Explain.php
+++ b/src/Support/Explain.php
@@ -70,7 +70,7 @@ class Explain
             'bindings' => $bindings,
             'version' => $connection->selectOne("SELECT VERSION()")->{'VERSION()'},
             'explain_json' => $connection->selectOne("EXPLAIN FORMAT=JSON {$query}", $bindings)->EXPLAIN,
-            'explain_tree' => rescue(fn () => $connection->selectOne("EXPLAIN FORMAT=TREE {$query}", $bindings), report: false)->EXPLAIN,
+            'explain_tree' => rescue(fn () => $connection->selectOne("EXPLAIN FORMAT=TREE {$query}", $bindings)->EXPLAIN, report: false),
         ])->throw()->json('url');
     }
 

--- a/src/Support/Explain.php
+++ b/src/Support/Explain.php
@@ -10,17 +10,11 @@ use Illuminate\Support\Facades\Http;
 
 class Explain
 {
-    private $connections = [];
-
     public function isVisualExplainSupported(string $connection): bool
     {
-        if (isset($this->connections[$connection])) {
-            return $this->connections[$connection];
-        }
-
         $driver = DB::connection($connection)->getDriverName();
         if ($driver === 'pgsql') {
-            return $this->connections[$connection] = true;
+            return true;
         }
         if ($driver === 'mysql') {
             // Laravel 11 added a new MariaDB database driver but older Laravel versions handle MySQL and MariaDB with
@@ -28,15 +22,16 @@ class Explain
             // database. This query uses a feature implemented only in MariaDB to differentiate them.
             try {
                 DB::connection($connection)->select('SELECT * FROM seq_1_to_1');
-                return $this->connections[$connection] = false;
+
+                return false;
             } catch (QueryException) {
                 // This exception is expected when using MySQL as sequence tables are only available with MariaDB. So
                 // the exception gets silenced as the check for MySQL has succeeded.
-                return $this->connections[$connection] = true;
+                return true;
             }
         }
 
-        return $this->connections[$connection] = false;
+        return false;
     }
 
     public function confirmVisualExplain(string $connection): ?string


### PR DESCRIPTION
I made several improvements to the EXPLAIN functionalities of the queries tab:

* The MariaDB driver (introduced in Laravel 11) can now also run explain
* The visual explain option has been disabled for MariaDB databases using the `mysql` or `mariadb` driver (because it is not supported by mysqlexplain.com)
* The PostgreSQL explain didn't show indentations correctly because multiple spaces had been displayed as just one space 