### PR TITLE
Fix `You have an error in your SQL syntax` on sql copy

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -234,7 +234,6 @@
                     $('<span title="Copy to clipboard" />')
                         .addClass(csscls('copy-clipboard'))
                         .css('cursor', 'pointer')
-                        .html("&#8203;")
                         .on('click', (event) => {
                             event.stopPropagation();
                             if (this.copyToClipboard($code.get(0))) {


### PR DESCRIPTION
Apparently when copying, an unsupported character is added, i'm getting:
```
SQL Error [1064] [42000]: (conn=3930395) 
You have an error in your SQL syntax;
check the manual that corresponds to your MariaDB server version for the right syntax to use near '​' at line 1
```
The character is `&ZeroWidthSpace;` from `&#8203;`
```html
<span title="Copy to clipboard" class="phpdebugbar-widgets-copy-clipboard" style="cursor: pointer;">
    &ZeroWidthSpace;
</span>
```
Is there any reason why it can't be a simple blank space(`&nbsp;`)?