### PR TITLE
Sql copy button at line start

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -927,6 +927,7 @@ pre.phpdebugbar-widgets-code-block ul.phpdebugbar-widgets-numbered-code li {
 
 div.phpdebugbar-widgets-sqlqueries span.phpdebugbar-widgets-copy-clipboard {
     float: none !important;
+    margin-left: 0 !important;
 }
 
 .phpdebugbar-widgets-bg-measure .phpdebugbar-widgets-value {

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -243,7 +243,7 @@
                                     $(event.target).removeClass(csscls('copy-clipboard-check'));
                                 }, 2000)
                             }
-                        }).appendTo($code);
+                        }).prependTo($code);
                 }
                 $li.attr('data-connection', statement.connection)
                     .attr('data-duplicate', this.duplicateQueries.has(statement))


### PR DESCRIPTION
I don't see much usability to put the button at the end of the query,
when the queries are very long it is annoying to go down and look for the button,
besides the position depends on the length of the last line of the query, the button place is being variable.

![image](https://github.com/user-attachments/assets/0f3fdac6-e9d6-444c-89e0-a1fc69363449)
