### PR TITLE
Fix ErrorException on empty responses

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -905,7 +905,7 @@ class LaravelDebugbar extends DebugBar
 
         // Check if content looks like JSON without actually validating
         $content = $response->getContent();
-        if ($content !== false && in_array($content[0], ['{', '['], true)) {
+        if ($content && in_array($content[0], ['{', '['], true)) {
             return true;
         }
 

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -38,6 +38,15 @@ class DebugbarTest extends TestCase
         $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
     }
 
+    public function testItInjectsOnEmptyResponse()
+    {
+        $crawler = $this->call('GET', 'web/empty');
+
+        $this->assertTrue(Str::contains($crawler->content(), 'debugbar'));
+        $this->assertEquals(200, $crawler->getStatusCode());
+        $this->assertNotEmpty($crawler->headers->get('phpdebugbar-id'));
+    }
+
     public function testItInjectsOnHtml()
     {
         $crawler = $this->call('GET', 'web/html');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,10 @@ class TestCase extends Orchestra
             return 'PONG';
         });
 
+        $router->get('web/empty', function () {
+            return '';
+        });
+
         $router->get('web/html', function () {
             return '<html><head></head><body>Pong</body></html>';
         });


### PR DESCRIPTION
For example, the spatie/laravel-honeypot package returns an empty response if the honeypot field is filled in. In this case, the Laravel Debugbar triggers an ErrorException with the message “Uninitialized string offset 0.”