### PR TITLE
Fix console error when using custom Array prototype functions

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -334,7 +334,7 @@
             const $li = $('<li />').addClass(csscls('table-list-item'));
             const $muted = $('<span />').addClass(css('text-muted'));
 
-            for (const i in values) {
+            for (const i in values.values()) {
                 if (showLineNumbers) {
                     $ul.append($li.clone().append([$muted.clone().text(`${i}:`), '&nbsp;', $('<span/>').text(values[i])]));
                 } else {
@@ -353,7 +353,7 @@
             const $muted = $('<span />').addClass(css('text-muted'));
 
             const values = [];
-            for (const trace of traces) {
+            for (const trace of traces.values()) {
                 const $span = $('<span/>').text(trace.name || trace.file);
                 if (trace.namespace) {
                     $span.prepend(`${trace.namespace}::`);


### PR DESCRIPTION
If you've added a function to the Array prototype, using `for (value in values)` will iterate through the functions attached to the prototype in addition to the values, which can throw a console error. Instead, we should use `for (value in values.values())`.

To reproduce this issue:
- Create a new blank Laravel project (`composer create-project laravel/laravel debugbar-test && cd debugbar-test`)
- Install Debugbar (`composer require barryvdh/laravel-debugbar --dev`)
- Add an Array prototype function to `resources/views/welcome.blade.php`:
```
<script>
            Array.prototype.customRemove = function(item) {
                const i = this.indexOf(item)
                if (i > -1) {
                    this.splice(i, 1)
                }
                return this
            }
        </script>
```
- `php artisan serve` and load in a browser
- Observe the console error:
![image](https://github.com/user-attachments/assets/84db7906-7046-4cee-a44f-b8a0ef7d068a)
