### PR TITLE
Query widget number-verb number agreement

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -168,7 +168,7 @@
                     details.push(`${data.nb_failed_statements} failed`);
                 }
                 if (this.duplicateQueries.size > 0) {
-                    details.push(`${duplicateQueries.size} ${duplicateQueries.size == 1 ? 'duplicate' : 'duplicates'}`);
+                    details.push(`${this.duplicateQueries.size} ${this.duplicateQueries.size == 1 ? 'duplicate' : 'duplicates'}`);
                 }
                 $text.append(` (${details.join(', ')})`);
             }

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -158,9 +158,9 @@
                 connections.add(statement.connection);
             }
 
-            const $text = $('<span />').text(`${data.nb_statements} statements were executed`);
+            const $text = $('<span />').text(`${data.nb_statements} ${data.nb_statements == 1 ? 'statement was' : 'statements were'} executed`);
             if (data.nb_excluded_statements) {
-                $text.append(`, ${data.nb_excluded_statements} have been excluded`);
+                $text.append(`, ${data.nb_excluded_statements} ${data.nb_excluded_statements == 1 ? 'has' : 'have'} been excluded`);
             }
             if (data.nb_failed_statements > 0 || this.duplicateQueries.size > 0) {
                 const details = [];
@@ -168,7 +168,7 @@
                     details.push(`${data.nb_failed_statements} failed`);
                 }
                 if (this.duplicateQueries.size > 0) {
-                    details.push(`${this.duplicateQueries.size} duplicates`);
+                    details.push(`${duplicateQueries.size} ${duplicateQueries.size == 1 ? 'duplicate' : 'duplicates'}`);
                 }
                 $text.append(` (${details.join(', ')})`);
             }


### PR DESCRIPTION
Sorry, boring pedantry PR here to get those language-is-ridiculous "1 statement _was_ executed, 5 statements _were_ executed" strings in the Query widget.

![Screenshot 2024-09-27 at 11 57 14@2x](https://github.com/user-attachments/assets/4a01f384-1497-4df7-a7f6-d43542854e37)
![Screenshot 2024-09-27 at 11 57 25@2x](https://github.com/user-attachments/assets/56df5627-5d33-4125-8c97-75d471e4337f)
