### PR TITLE
Do not open query details on text selecting

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -308,6 +308,10 @@
             if($details.children().length) {
                 $li.addClass(csscls('expandable'))
                     .on('click', (event) => {
+                        if (window.getSelection().type == "Range") {
+                            return;
+                        }
+
                         if ($(event.target).closest(`.${csscls('params')}`).length) {
                             return;
                         }


### PR DESCRIPTION
When trying to copy a portion of the query the params/backtrace table opens, it is annoying