### PR TITLE
Fix sql-duplicate highlight

### DIFF
--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -229,9 +229,11 @@
                     .attr('data-duplicate', false)
                     .append($('<strong />').addClass(csscls('sql name')).text(statement.sql));
             } else {
-                const $code = $('<code />').html(PhpDebugBar.Widgets.highlight(statement.sql, 'sql')).addClass(csscls('sql'));
+                const $code = $('<code />').html(PhpDebugBar.Widgets.highlight(statement.sql, 'sql')).addClass(csscls('sql')),
+                    duplicated = this.duplicateQueries.has(statement);
                 $li.attr('data-connection', statement.connection)
-                    .attr('data-duplicate', this.duplicateQueries.has(statement))
+                    .attr('data-duplicate', duplicated)
+                    .toggleClass(csscls('sql-duplicate'), duplicated)
                     .append($code);
 
                 if (statement.show_copy) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6b8d8eaf-e320-4aa0-a903-2199989ae0d3)

It seems that the highlight to duplicate sql functionality was removed by mistake when refactoring the detecting duplicates method 

[maximebf/php-debugbar/src/DebugBar/Resources/widgets/sqlqueries/widget.js#L208](https://github.com/maximebf/php-debugbar/blob/933e1b632cc4d64768d6d35b6ad804cc75f643b1/src/DebugBar/Resources/widgets/sqlqueries/widget.js#L208)