### PR TITLE
Fix Exception when QueryCollector softLimit exceeded

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -183,7 +183,7 @@ class QueryCollector extends PDOCollector
         }
 
         $bindings = match (true) {
-            $limited && filled($query->bindings) => null,
+            $limited && filled($query->bindings) => [],
             default => $query->connection->prepareBindings($query->bindings),
         };
 


### PR DESCRIPTION
The other match() case is:

```
$query->connection->prepareBindings($query->bindings)
```

This method always returns an array.

Before this PR the `match()` case would return null when the softLimit had been exceeded, which is the wrong data type used downstream. This resulted in Exception:

```
Debugbar exception: foreach() argument must be of type array|object, null given
```

### Background

I discovered this issue while debugging a Laravel application that executed a lot of queries. I saw that the `phpdebugbar-id:` Response header was being omitted on a specific Response that was executing the queries. After some digging I found the `soft_limit` number and increased it to just above my query count. The debug bar then appeared.

When tailing the application log I found the Exception:

```
Debugbar exception: foreach() argument must be of type array|object, null given
```

I used Xdebug to trace where in the library the Exception was thrown, and dove into the code to find the softLimit usage and eventually the type mismatch.

Let me know if you require unit tests for this change, but I didn't see any existing tests for this feature.