### PR TITLE
Add middleware to web to save session

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -136,5 +136,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $kernel = $this->app[Kernel::class];
         $kernel->pushMiddleware($middleware);
+        $kernel->appendMiddlewareToGroup('web', $middleware);
     }
 }


### PR DESCRIPTION
The Web middlewaregoup contains the SaveSession middleware, which closes the session. This makes it impossible (as far as I can tell) to save to the session, eg. for redirects.

This will add the middleware to both the regular and the normal group. It will still only boot once and inject once because of the checks, but this should make redirects work again, without any of the workarounds. (#1666 #1662 #1657 #1613 #1591 #1574 #1573) and fixes #1704