### PR TITLE
Add special `dev` to composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,14 @@
 {
     "name": "barryvdh/laravel-debugbar",
     "description": "PHP Debugbar integration for Laravel",
-    "keywords": ["laravel", "debugbar", "profiler", "debug", "webprofiler"],
+    "keywords": [
+        "laravel",
+        "debugbar",
+        "profiler",
+        "debug",
+        "webprofiler",
+        "dev"
+    ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The special `dev` keyword will warn users who run `composer require barryvdh/laravel-debugbar` with the following prompt:
```
> composer require barryvdh/laravel-debugbar
The package you required is recommended to be placed in require-dev (because it is tagged as "dev") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]?
```

See also https://getcomposer.org/doc/04-schema.md#keywords.