### PR TITLE
fix: The log is not processed correctly when it consists of multiple lines.

### DIFF
--- a/src/DataCollector/LogsCollector.php
+++ b/src/DataCollector/LogsCollector.php
@@ -100,7 +100,7 @@ class LogsCollector extends MessagesCollector
      */
     public function getLogs($file)
     {
-        $pattern = "/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\].*/";
+        $pattern = "/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\](?:(?!\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\])[\s\S])*/";
 
         $log_levels = $this->getLevels();
 


### PR DESCRIPTION
It seems that the regular expression `.*` does not include LF (Line Feed).