### PR TITLE
fix: Ignore info query statements in Clockwork converter

### DIFF
--- a/src/Support/Clockwork/Converter.php
+++ b/src/Support/Clockwork/Converter.php
@@ -97,7 +97,7 @@ class Converter
         if (isset($data['queries'])) {
             $queries = $data['queries'];
             foreach ($queries['statements'] as $statement) {
-                if ($statement['type'] === 'explain') {
+                if ($statement['type'] === 'explain' || $statement['type'] === 'info') {
                     continue;
                 }
                 $output['databaseQueries'][] = [


### PR DESCRIPTION
The Clockwork converter will currently only ignore `explain` query statements. If debugbar is configured with a query limit this will yield a query statements with the `info` type. Without this fix, this will result in an exception, because the `info` statement does not contain a `params` key.

### Info statement example:
```
array:2 [▼ // vendor/barryvdh/laravel-debugbar/src/Support/Clockwork/Converter.php:104
  "sql" => "
# Query soft and hard limit for Debugbar are reached. Only the first 250 queries show details. Queries after the first 500 are ignored. Limits can be raised in the config (debugbar.options.db.soft/hard_limit).
 ◀
"
  "type" => "info"
]