### PR TITLE
Fix support for PDOExceptions

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -721,7 +721,7 @@ class LaravelDebugbar extends DebugBar
         $this->addThrowable(
             new Exception(
                 $message . ' on Laravel Debugbar: ' . $exception->getMessage(),
-                $exception->getCode(),
+                (int) $exception->getCode(),
                 $exception
             )
         );


### PR DESCRIPTION
When a PDOException is thrown (i.e. Illuminate's QueryException) during the initialization of a Collector, the current code falls over because the code property on PDOExceptions are actually strings, and not ints. 

See [this comment from 15 years ago](https://www.php.net/manual/en/class.pdoexception.php#95812), https://github.com/php/php-src/issues/9529, & https://github.com/php/php-src/issues/12294