### PR TITLE
Preserve laravel error handler

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -658,6 +658,10 @@ class LaravelDebugbar extends DebugBar
             $this['messages']->addMessage($message . $file, 'deprecation');
         }
 
+        if (! $this->prevErrorHandler) {
+            return;
+        }
+
         return call_user_func($this->prevErrorHandler, $level, $message, $file, $line, $context);
     }
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -101,6 +101,13 @@ class LaravelDebugbar extends DebugBar
      */
     protected $is_lumen = false;
 
+    /**
+     * Laravel default error handler
+     *
+     * @var callable|null
+     */
+    protected $prevErrorHandler = null;
+
     protected ?string $editorTemplateLink = null;
     protected array $remoteServerReplacements = [];
     protected bool $responseIsModified = false;
@@ -173,7 +180,7 @@ class LaravelDebugbar extends DebugBar
 
         // Set custom error handler
         if ($config->get('debugbar.error_handler', false)) {
-            set_error_handler([$this, 'handleError']);
+            $this->prevErrorHandler = set_error_handler([$this, 'handleError']);
         }
 
         $this->selectStorage($this);
@@ -645,16 +652,13 @@ class LaravelDebugbar extends DebugBar
      */
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
-        $exception = new \ErrorException($message, 0, $level, $file, $line);
-        if (error_reporting() & $level) {
-            throw $exception;
-        }
-
-        $this->addThrowable($exception);
+        $this->addThrowable(new \ErrorException($message, 0, $level, $file, $line));
         if ($this->hasCollector('messages')) {
             $file = $file ? ' on ' . $this['messages']->normalizeFilePath($file) . ":{$line}" : '';
             $this['messages']->addMessage($message . $file, 'deprecation');
         }
+
+        return call_user_func($this->prevErrorHandler, $level, $message, $file, $line, $context);
     }
 
     /**


### PR DESCRIPTION
Based on https://github.com/php-debugbar/php-debugbar/pull/748
> Wouldn't this conflict with the existing error handler?
> https://github.com/php-debugbar/php-debugbar/pull/748#issuecomment-2703131706

We are currently replacing the Laravel error handler,
this removes some functionality, such as [deprecation control](https://github.com/php-debugbar/php-debugbar/pull/748#issuecomment-2704412893), look at: [laravel/framework/Illuminate/Foundation/Bootstrap/HandleExceptions.php#L69-L76](https://github.com/laravel/framework/blob/e6753fc3836bb5fdddd1ee95835d8065bd7c5b16/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php#L69-L76)

The `throw` is returned to the framework and only the data is captured

-----

If https://github.com/php-debugbar/php-debugbar/pull/748 get merged, we could go from this
https://github.com/barryvdh/laravel-debugbar/blob/008dfe9ee0dc2256db2138b96d1062abaf0b3b60/src/LaravelDebugbar.php#L653
to this
```php
$this->addWarning($level, $message, $file, $line);
```
which would considerably reduce the size of the collect in case of many notices/deprecations


