### PR TITLE
Fix `capture_dumps` option on laravel `dd();`

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -189,8 +189,12 @@ class LaravelDebugbar extends DebugBar
                 $this['messages']->collectFileTrace(true);
             }
 
-            if ($config->get('debugbar.options.messages.capture_dumps', false)) {
-                \Symfony\Component\VarDumper\VarDumper::setHandler(function ($var) {
+            if ($config->get('debugbar.options.messages.capture_dumps', true)) {
+                $originalHandler = \Symfony\Component\VarDumper\VarDumper::setHandler(function ($var) use (&$originalHandler) {
+                    if ($originalHandler) {
+                        $originalHandler($var);
+                    }
+
                     self::addMessage($var);
                 });
             }


### PR DESCRIPTION
Using laravel `dd();` it shows nothing, this fix it, 
Apparently there is no way to differentiate dumps from dds, since Laravel's dd first executes a `dump();` and then an `exit(1);`