### PR TITLE
Fix laravel-debugbar.css on query widget

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -540,7 +540,7 @@ div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td {
 }
 
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params th {
-    background-color: var(--debugbar-header);
+    background-color: var(--debugbar-background-alt);
 }
 
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td.phpdebugbar-widgets-name {
@@ -712,7 +712,7 @@ div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain {
 }
 
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain th {
-    border: 1px solid var(--debugbar-header);
+    border: 1px solid var(--debugbar-border);
     text-align: center;
 }
 

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -543,6 +543,10 @@ div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params th {
     background-color: var(--debugbar-background-alt);
 }
 
+div.phpdebugbar-widgets-sqlqueries ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:nth-child(even) table.phpdebugbar-widgets-params th {
+    background-color: var(--debugbar-background);
+}
+
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-params td.phpdebugbar-widgets-name {
     text-align: right;
     vertical-align: top;


### PR DESCRIPTION
From
![image](https://github.com/user-attachments/assets/329c59f7-290c-4f94-aa11-230b090c95ca)
To
![image](https://github.com/user-attachments/assets/812a9e09-25bb-4bd9-8cd6-9a292d78558f)

or, Is it intentional?

Fix on even
![image](https://github.com/user-attachments/assets/71aab176-d140-446d-93c7-c6008b1cdfd4)
