### PR TITLE
Use htmlvardumper if available on CacheCollector

### DIFF
--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -3,6 +3,7 @@
 namespace Barryvdh\Debugbar\DataCollector;
 
 use DebugBar\DataCollector\TimeDataCollector;
+use DebugBar\DataFormatter\HasDataFormatter;
 use Illuminate\Cache\Events\CacheEvent;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Cache\Events\CacheMissed;
@@ -12,6 +13,8 @@ use Illuminate\Events\Dispatcher;
 
 class CacheCollector extends TimeDataCollector
 {
+    use HasDataFormatter;
+
     /** @var bool */
     protected $collectValues;
 
@@ -39,7 +42,11 @@ class CacheCollector extends TimeDataCollector
 
         if (isset($params['value'])) {
             if ($this->collectValues) {
-                $params['value'] = htmlspecialchars($this->getDataFormatter()->formatVar($event->value));
+                if ($this->isHtmlVarDumperUsed()) {
+                    $params['value'] = $this->getVarDumper()->renderVar($params['value']);
+                } else {
+                    $params['value'] = htmlspecialchars($this->getDataFormatter()->formatVar($params['value']));
+                }
             } else {
                 unset($params['value']);
             }


### PR DESCRIPTION
From 
![image](https://github.com/user-attachments/assets/593aed4e-4f90-44e0-93cb-157f186a0d2a)

To
![image](https://github.com/user-attachments/assets/9cd9dbfc-efb0-41b6-97fd-1fc9a1896bc9)

Works better with 
- https://github.com/php-debugbar/php-debugbar/pull/760
- https://github.com/php-debugbar/php-debugbar/pull/757
