### PR TITLE
Use `addWarning` on warnings, silenced errors, notices

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -657,7 +657,7 @@ class LaravelDebugbar extends DebugBar
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
         if ($this->hasCollector('exceptions')) {
-            $this->getCollector('exceptions')->addWarning($level, $message, $file, $line);
+            $this['exceptions']->addWarning($level, $message, $file, $line);
         }
 
         if ($this->hasCollector('messages')) {

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -656,7 +656,10 @@ class LaravelDebugbar extends DebugBar
      */
     public function handleError($level, $message, $file = '', $line = 0, $context = [])
     {
-        $this->addThrowable(new \ErrorException($message, 0, $level, $file, $line));
+        if ($this->hasCollector('exceptions')) {
+            $this->getCollector('exceptions')->addWarning($level, $message, $file, $line);
+        }
+
         if ($this->hasCollector('messages')) {
             $file = $file ? ' on ' . $this['messages']->normalizeFilePath($file) . ":{$line}" : '';
             $this['messages']->addMessage($message . $file, 'deprecation');


### PR DESCRIPTION
It seems like a lighter option if there are many deprecations, notices(_doesn't collect/format stacktraces, nor create an ErrorException_)

**NOTE:** `addWarning` was added on https://github.com/php-debugbar/php-debugbar/pull/748 but it has not yet been released