### PR TITLE
Make all scalar config values configurable through environment variables

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -15,7 +15,7 @@ return [
      */
 
     'enabled' => env('DEBUGBAR_ENABLED', null),
-    'hide_empty_tabs' => true, // Hide tabs until they have content
+    'hide_empty_tabs' => env('DEBUGBAR_HIDE_EMPTY_TABS', true), // Hide tabs until they have content
     'except' => [
         'telescope*',
         'horizon*',
@@ -38,14 +38,14 @@ return [
      | Leaving it to null will allow localhost only.
      */
     'storage' => [
-        'enabled'    => true,
+        'enabled'    => env('DEBUGBAR_STORAGE_ENABLED', true),
         'open'       => env('DEBUGBAR_OPEN_STORAGE'), // bool/callback.
-        'driver'     => 'file', // redis, file, pdo, socket, custom
-        'path'       => storage_path('debugbar'), // For file driver
-        'connection' => null,   // Leave null for default connection (Redis/PDO)
-        'provider'   => '', // Instance of StorageInterface for custom driver
-        'hostname'   => '127.0.0.1', // Hostname to use with the "socket" driver
-        'port'       => 2304, // Port to use with the "socket" driver
+        'driver'     => env('DEBUGBAR_STORAGE_DRIVER', 'file'), // redis, file, pdo, socket, custom
+        'path'       => env('DEBUGBAR_STORAGE_PATH', storage_path('debugbar')), // For file driver
+        'connection' => env('DEBUGBAR_STORAGE_CONNECTION', null), // Leave null for default connection (Redis/PDO)
+        'provider'   => env('DEBUGBAR_STORAGE_PROVIDER', ''), // Instance of StorageInterface for custom driver
+        'hostname'   => env('DEBUGBAR_STORAGE_HOSTNAME', '127.0.0.1'), // Hostname to use with the "socket" driver
+        'port'       => env('DEBUGBAR_STORAGE_PORT', 2304), // Port to use with the "socket" driver
     ],
 
     /*
@@ -104,7 +104,7 @@ return [
      |
      */
 
-    'include_vendors' => true,
+    'include_vendors' => env('DEBUGBAR_INCLUDE_VENDORS', true),
 
     /*
      |--------------------------------------------------------------------------
@@ -125,11 +125,11 @@ return [
      | You can defer loading the dataset, so it will be loaded with ajax after the request is done. (Experimental)
      */
 
-    'capture_ajax' => true,
-    'add_ajax_timing' => false,
-    'ajax_handler_auto_show' => true,
-    'ajax_handler_enable_tab' => true,
-    'defer_datasets' => false,
+    'capture_ajax' => env('DEBUGBAR_CAPTURE_AJAX', true),
+    'add_ajax_timing' => env('DEBUGBAR_ADD_AJAX_TIMING', false),
+    'ajax_handler_auto_show' => env('DEBUGBAR_AJAX_HANDLER_AUTO_SHOW', true),
+    'ajax_handler_enable_tab' => env('DEBUGBAR_AJAX_HANDLER_ENABLE_TAB', true),
+    'defer_datasets' => env('DEBUGBAR_DEFER_DATASETS', false),
     /*
      |--------------------------------------------------------------------------
      | Custom Error Handler for Deprecated warnings
@@ -139,7 +139,7 @@ return [
      | in the Messages tab.
      |
      */
-    'error_handler' => false,
+    'error_handler' => env('DEBUGBAR_ERROR_HANDLER', false),
 
     /*
      |--------------------------------------------------------------------------
@@ -150,7 +150,7 @@ return [
      | Extension, without the server-side code. It uses Debugbar collectors instead.
      |
      */
-    'clockwork' => false,
+    'clockwork' => env('DEBUGBAR_CLOCKWORK', false),
 
     /*
      |--------------------------------------------------------------------------
@@ -162,31 +162,31 @@ return [
      */
 
     'collectors' => [
-        'phpinfo'         => false,  // Php version
-        'messages'        => true,  // Messages
-        'time'            => true,  // Time Datalogger
-        'memory'          => true,  // Memory usage
-        'exceptions'      => true,  // Exception displayer
-        'log'             => true,  // Logs from Monolog (merged in messages if enabled)
-        'db'              => true,  // Show database (PDO) queries and bindings
-        'views'           => true,  // Views with their data
-        'route'           => false,  // Current route information
-        'auth'            => false, // Display Laravel authentication status
-        'gate'            => true,  // Display Laravel Gate checks
-        'session'         => false,  // Display session data
-        'symfony_request' => true,  // Only one can be enabled..
-        'mail'            => true,  // Catch mail messages
-        'laravel'         => true, // Laravel version and environment
-        'events'          => false, // All events fired
-        'default_request' => false, // Regular or special Symfony request logger
-        'logs'            => false, // Add the latest log messages
-        'files'           => false, // Show the included files
-        'config'          => false, // Display config settings
-        'cache'           => false, // Display cache events
-        'models'          => true,  // Display models
-        'livewire'        => true,  // Display Livewire (when available)
-        'jobs'            => false, // Display dispatched jobs
-        'pennant'         => false, // Display Pennant feature flags
+        'phpinfo'         => env('DEBUGBAR_COLLECTORS_PHPINFO', false),         // Php version
+        'messages'        => env('DEBUGBAR_COLLECTORS_MESSAGES', true),         // Messages
+        'time'            => env('DEBUGBAR_COLLECTORS_TIME', true),             // Time Datalogger
+        'memory'          => env('DEBUGBAR_COLLECTORS_MEMORY', true),           // Memory usage
+        'exceptions'      => env('DEBUGBAR_COLLECTORS_EXCEPTIONS', true),       // Exception displayer
+        'log'             => env('DEBUGBAR_COLLECTORS_LOG', true),              // Logs from Monolog (merged in messages if enabled)
+        'db'              => env('DEBUGBAR_COLLECTORS_DB', true),               // Show database (PDO) queries and bindings
+        'views'           => env('DEBUGBAR_COLLECTORS_VIEWS', true),            // Views with their data
+        'route'           => env('DEBUGBAR_COLLECTORS_ROUTE', false),           // Current route information
+        'auth'            => env('DEBUGBAR_COLLECTORS_AUTH', false),            // Display Laravel authentication status
+        'gate'            => env('DEBUGBAR_COLLECTORS_GATE', true),             // Display Laravel Gate checks
+        'session'         => env('DEBUGBAR_COLLECTORS_SESSION', false),         // Display session data
+        'symfony_request' => env('DEBUGBAR_COLLECTORS_SYMFONY_REQUEST', true),  // Only one can be enabled..
+        'mail'            => env('DEBUGBAR_COLLECTORS_MAIL', true),             // Catch mail messages
+        'laravel'         => env('DEBUGBAR_COLLECTORS_LARAVEL', true),          // Laravel version and environment
+        'events'          => env('DEBUGBAR_COLLECTORS_EVENTS', false),          // All events fired
+        'default_request' => env('DEBUGBAR_COLLECTORS_DEFAULT_REQUEST', false), // Regular or special Symfony request logger
+        'logs'            => env('DEBUGBAR_COLLECTORS_LOGS', false),            // Add the latest log messages
+        'files'           => env('DEBUGBAR_COLLECTORS_FILES', false),           // Show the included files
+        'config'          => env('DEBUGBAR_COLLECTORS_CONFIG', false),          // Display config settings
+        'cache'           => env('DEBUGBAR_COLLECTORS_CACHE', false),           // Display cache events
+        'models'          => env('DEBUGBAR_COLLECTORS_MODELS', true),           // Display models
+        'livewire'        => env('DEBUGBAR_COLLECTORS_LIVEWIRE', true),         // Display Livewire (when available)
+        'jobs'            => env('DEBUGBAR_COLLECTORS_JOBS', false),            // Display dispatched jobs
+        'pennant'         => env('DEBUGBAR_COLLECTORS_PENNANT', false),         // Display Pennant feature flags
     ],
 
     /*
@@ -200,70 +200,70 @@ return [
 
     'options' => [
         'time' => [
-            'memory_usage' => false,  // Calculated by subtracting memory start and end, it may be inaccurate
+            'memory_usage' => env('DEBUGBAR_OPTIONS_TIME_MEMORY_USAGE', false), // Calculated by subtracting memory start and end, it may be inaccurate
         ],
         'messages' => [
-            'trace' => true,          // Trace the origin of the debug message
-            'capture_dumps' => false, // Capture laravel `dump();` as message
+            'trace' => env('DEBUGBAR_OPTIONS_MESSAGES_TRACE', true),                  // Trace the origin of the debug message
+            'capture_dumps' => env('DEBUGBAR_OPTIONS_MESSAGES_CAPTURE_DUMPS', false), // Capture laravel `dump();` as message
         ],
         'memory' => [
-            'reset_peak' => false,     // run memory_reset_peak_usage before collecting
-            'with_baseline' => false,  // Set boot memory usage as memory peak baseline
-            'precision' => 0,          // Memory rounding precision
+            'reset_peak' => env('DEBUGBAR_OPTIONS_MEMORY_RESET_PEAK', false),       // run memory_reset_peak_usage before collecting
+            'with_baseline' => env('DEBUGBAR_OPTIONS_MEMORY_WITH_BASELINE', false), // Set boot memory usage as memory peak baseline
+            'precision' => (int) env('DEBUGBAR_OPTIONS_MEMORY_PRECISION', 0),       // Memory rounding precision
         ],
         'auth' => [
-            'show_name' => true,   // Also show the users name/email in the debugbar
-            'show_guards' => true, // Show the guards that are used
+            'show_name' => env('DEBUGBAR_OPTIONS_AUTH_SHOW_NAME', true),     // Also show the users name/email in the debugbar
+            'show_guards' => env('DEBUGBAR_OPTIONS_AUTH_SHOW_GUARDS', true), // Show the guards that are used
         ],
         'db' => [
-            'with_params'       => true,   // Render SQL with the parameters substituted
+            'with_params'       => env('DEBUGBAR_OPTIONS_WITH_PARAMS', true),   // Render SQL with the parameters substituted
             'exclude_paths'     => [       // Paths to exclude entirely from the collector
 //                'vendor/laravel/framework/src/Illuminate/Session', // Exclude sessions queries
             ],
-            'backtrace'         => true,   // Use a backtrace to find the origin of the query in your files.
+            'backtrace'         => env('DEBUGBAR_OPTIONS_DB_BACKTRACE', true),   // Use a backtrace to find the origin of the query in your files.
             'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
-            'timeline'          => false,  // Add the queries to the timeline
-            'duration_background'  => true,   // Show shaded background on each query relative to how long it took to execute.
+            'timeline'          => env('DEBUGBAR_OPTIONS_DB_TIMELINE', false),  // Add the queries to the timeline
+            'duration_background'  => env('DEBUGBAR_OPTIONS_DB_DURATION_BACKGROUND', true),   // Show shaded background on each query relative to how long it took to execute.
             'explain' => [                 // Show EXPLAIN output on queries
-                'enabled' => false,
+                'enabled' => env('DEBUGBAR_OPTIONS_DB_EXPLAIN_ENABLED', false),
             ],
-            'hints'             => false,   // Show hints for common mistakes
-            'show_copy'         => true,    // Show copy button next to the query,
-            'slow_threshold'    => false,   // Only track queries that last longer than this time in ms
-            'memory_usage'      => false,   // Show queries memory usage
-            'soft_limit'       => 100,      // After the soft limit, no parameters/backtrace are captured
-            'hard_limit'       => 500,      // After the hard limit, queries are ignored
+            'hints'             => env('DEBUGBAR_OPTIONS_DB_HINTS', false),          // Show hints for common mistakes
+            'show_copy'         => env('DEBUGBAR_OPTIONS_DB_SHOW_COPY', true),       // Show copy button next to the query,
+            'slow_threshold'    => env('DEBUGBAR_OPTIONS_DB_SLOW_THRESHOLD', false), // Only track queries that last longer than this time in ms
+            'memory_usage'      => env('DEBUGBAR_OPTIONS_DB_MEMORY_USAGE', false),   // Show queries memory usage
+            'soft_limit'       => (int) env('DEBUGBAR_OPTIONS_DB_SOFT_LIMIT', 100),  // After the soft limit, no parameters/backtrace are captured
+            'hard_limit'       => (int) env('DEBUGBAR_OPTIONS_DB_HARD_LIMIT', 500),  // After the hard limit, queries are ignored
         ],
         'mail' => [
-            'timeline' => true,  // Add mails to the timeline
-            'show_body' => true,
+            'timeline' => env('DEBUGBAR_OPTIONS_MAIL_TIMELINE', true),  // Add mails to the timeline
+            'show_body' => env('DEBUGBAR_OPTIONS_MAIL_SHOW_BODY', true),
         ],
         'views' => [
-            'timeline' => true,    // Add the views to the timeline
-            'data' => false,        // True for all data, 'keys' for only names, false for no parameters.
-            'group' => 50,          // Group duplicate views. Pass value to auto-group, or true/false to force
+            'timeline' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE', true), // Add the views to the timeline
+            'data' => env('DEBUGBAR_OPTIONS_VIEWS_DATA', false),        // True for all data, 'keys' for only names, false for no parameters.
+            'group' => (int) env('DEBUGBAR_OPTIONS_VIEWS_GROUP', 50),   // Group duplicate views. Pass value to auto-group, or true/false to force
             'exclude_paths' => [    // Add the paths which you don't want to appear in the views
                 'vendor/filament'   // Exclude Filament components by default
             ],
         ],
         'route' => [
-            'label' => true,  // Show complete route on bar
+            'label' => env('DEBUGBAR_OPTIONS_ROUTE_LABEL', true),  // Show complete route on bar
         ],
         'session' => [
             'hiddens' => [], // Hides sensitive values using array paths
         ],
         'symfony_request' => [
-            'label' => true,  // Show route on bar
+            'label' => env('DEBUGBAR_OPTIONS_SYMFONY_REQUEST_LABEL', true),  // Show route on bar
             'hiddens' => [], // Hides sensitive values using array paths, example: request_request.password
         ],
         'events' => [
-            'data' => false, // Collect events data, listeners
+            'data' => env('DEBUGBAR_OPTIONS_EVENTS_DATA', false), // Collect events data, listeners
         ],
         'logs' => [
-            'file' => null,
+            'file' => env('DEBUGBAR_OPTIONS_LOGS_FILE', null),
         ],
         'cache' => [
-            'values' => true, // Collect cache values
+            'values' => env('DEBUGBAR_OPTIONS_CACHE_VALUES', true), // Collect cache values
         ],
     ],
 
@@ -278,7 +278,7 @@ return [
      |
      */
 
-    'inject' => true,
+    'inject' => env('DEBUGBAR_INJECT', true),
 
     /*
      |--------------------------------------------------------------------------
@@ -290,7 +290,7 @@ return [
      | from trying to overcome bugs like this: http://trac.nginx.org/nginx/ticket/97
      |
      */
-    'route_prefix' => '_debugbar',
+    'route_prefix' => env('DEBUGBAR_ROUTE_PREFIX', '_debugbar'),
 
     /*
      |--------------------------------------------------------------------------
@@ -309,7 +309,7 @@ return [
      | By default Debugbar route served from the same domain that request served.
      | To override default domain, specify it as a non-empty value.
      */
-    'route_domain' => null,
+    'route_domain' => env('DEBUGBAR_ROUTE_DOMAIN', null),
 
     /*
      |--------------------------------------------------------------------------
@@ -329,5 +329,5 @@ return [
      | By default, the Debugbar limits the number of frames returned by the 'debug_backtrace()' function.
      | If you need larger stacktraces, you can increase this number. Setting it to 0 will result in no limit.
      */
-    'debug_backtrace_limit' => 50,
+    'debug_backtrace_limit' => (int) env('DEBUGBAR_DEBUG_BACKTRACE_LIMIT', 50),
 ];


### PR DESCRIPTION
This PR makes all scalar values in `config/debugbar.php` configurable through environment variables. The original values are kept as defaults to be backwards-compatible. The naming of the environment variables always follows these rules:
* start with the package name
* use exact keys, including nesting
* use `_` as separator between parts
* uppercase all

This feature makes it easy to configure the debug bar for specific debugging situations, without having to make actual changes to the config file.