### PR TITLE
Check if file exists on FilesystemStorage

### DIFF
--- a/src/Storage/FilesystemStorage.php
+++ b/src/Storage/FilesystemStorage.php
@@ -81,7 +81,12 @@ class FilesystemStorage implements StorageInterface
      */
     public function get($id)
     {
-        return json_decode($this->files->get($this->makeFilename($id)), true);
+        $fileName = $this->makeFilename($id);
+        if (!$this->files->exists($fileName)) {
+            return [];
+        }
+
+        return json_decode($this->files->get($fileName), true);
     }
 
     /**


### PR DESCRIPTION
- Closes #1758

This bug prevents the debugbar from being displayed, it can only be seen from the log file
```
Debugbar exception: File does not exist at path /var/www/storage/debugbar/976f3e1e7548.json. 

#0 /var/www/vendor/barryvdh/laravel-debugbar/src/Storage/FilesystemStorage.php(84):
    Illuminate\Filesystem\Filesystem->get('/var/www/storag...')
#1 /var/www/vendor/php-debugbar/php-debugbar/src/DebugBar/DebugBar.php(383):
    Barryvdh\Debugbar\Storage\FilesystemStorage->get('976f3e1e7548')
#2 /var/www/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php(1118):
    DebugBar\DebugBar->getStackedData(false)
#3 /var/www/vendor/barryvdh/laravel-debugbar/src/LaravelDebugbar.php(1107):
    Barryvdh\Debugbar\LaravelDebugbar->getStackedData(false)
```
Complement of https://github.com/php-debugbar/php-debugbar/pull/777