### PR TITLE
Time measure on cache events

### DIFF
--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -44,7 +44,7 @@ class CacheCollector extends TimeDataCollector
 
     public function __construct($requestStartTime, $collectValues)
     {
-        parent::__construct();
+        parent::__construct($requestStartTime);
 
         $this->collectValues = $collectValues;
     }

--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -7,12 +7,16 @@ use DebugBar\DataFormatter\HasDataFormatter;
 use Illuminate\Cache\Events\{
     CacheFlushed,
     CacheFlushFailed,
+    CacheFlushing,
     CacheHit,
     CacheMissed,
+    ForgettingKey,
     KeyForgetFailed,
     KeyForgotten,
     KeyWriteFailed,
     KeyWritten,
+    RetrievingKey,
+    WritingKey,
 };
 use Illuminate\Events\Dispatcher;
 
@@ -24,15 +28,18 @@ class CacheCollector extends TimeDataCollector
     protected $collectValues;
 
     /** @var array */
+    protected $eventStarts = [];
+
+    /** @var array */
     protected $classMap = [
-        CacheHit::class => 'hit',
-        CacheMissed::class => 'missed',
-        CacheFlushed::class => 'flushed',
-        CacheFlushFailed::class => 'flush_failed',
-        KeyWritten::class => 'written',
-        KeyWriteFailed::class => 'write_failed',
-        KeyForgotten::class => 'forgotten',
-        KeyForgetFailed::class => 'forget_failed',
+        CacheHit::class => ['hit', RetrievingKey::class],
+        CacheMissed::class => ['missed', RetrievingKey::class],
+        CacheFlushed::class => ['flushed', CacheFlushing::class],
+        CacheFlushFailed::class => ['flush_failed', CacheFlushing::class],
+        KeyWritten::class => ['written', WritingKey::class],
+        KeyWriteFailed::class => ['write_failed', WritingKey::class],
+        KeyForgotten::class => ['forgotten', ForgettingKey::class],
+        KeyForgetFailed::class => ['forget_failed', ForgettingKey::class],
     ];
 
     public function __construct($requestStartTime, $collectValues)
@@ -46,8 +53,7 @@ class CacheCollector extends TimeDataCollector
     {
         $class = get_class($event);
         $params = get_object_vars($event);
-
-        $label = $this->classMap[$class];
+        $label = $this->classMap[$class][0];
 
         if (isset($params['value'])) {
             if ($this->collectValues) {
@@ -61,7 +67,6 @@ class CacheCollector extends TimeDataCollector
             }
         }
 
-
         if (!empty($params['key'] ?? null) && in_array($label, ['hit', 'written'])) {
             $params['delete'] = route('debugbar.cache.delete', [
                 'key' => urlencode($params['key']),
@@ -70,13 +75,37 @@ class CacheCollector extends TimeDataCollector
         }
 
         $time = microtime(true);
-        $this->addMeasure($label . "\t" . ($params['key'] ?? ''), $time, $time, $params);
+        $startHashKey = $this->getEventHash($this->classMap[$class][1] ?? '', $params);
+        $startTime = $this->eventStarts[$startHashKey] ?? $time;
+        $this->addMeasure($label . "\t" . ($params['key'] ?? ''), $startTime, $time, $params);
+    }
+
+    public function onStartCacheEvent($event)
+    {
+        $startHashKey = $this->getEventHash(get_class($event), get_object_vars($event));
+        $this->eventStarts[$startHashKey] = microtime(true);
+    }
+
+    private function getEventHash(string $class, array $params): string
+    {
+        unset($params['value']);
+
+        return $class . ':' . substr(hash('sha256', json_encode($params)), 0, 12);
     }
 
     public function subscribe(Dispatcher $dispatcher)
     {
         foreach (array_keys($this->classMap) as $eventClass) {
             $dispatcher->listen($eventClass, [$this, 'onCacheEvent']);
+        }
+
+        $startEvents = array_unique(array_filter(array_map(
+            fn ($values) => $values[1] ?? null,
+            array_values($this->classMap)
+        )));
+
+        foreach ($startEvents as $eventClass) {
+            $dispatcher->listen($eventClass, [$this, 'onStartCacheEvent']);
         }
     }
 


### PR DESCRIPTION
https://github.com/barryvdh/laravel-debugbar/pull/1773#issuecomment-2858945316
>Taking the "starting" events, the elapsed time could be calculated. I think it's possible. Would it be >worth adding it?
>
>**Example:** RetrievingKey for CacheHit/CacheMissed [Illuminate/Cache/Repository.php#L117-L130](https://github.com/laravel/framework/blob/e333cc80b8f5414daec8ef7b15c1333685c4988b/src/Illuminate/Cache/Repository.php#L117-L130)