### PR TITLE
Custom path for Inertia views

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -242,9 +242,10 @@ return [
             'show_body' => env('DEBUGBAR_OPTIONS_MAIL_SHOW_BODY', true),
         ],
         'views' => [
-            'timeline' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE', true), // Add the views to the timeline
-            'data' => env('DEBUGBAR_OPTIONS_VIEWS_DATA', false),        // True for all data, 'keys' for only names, false for no parameters.
-            'group' => (int) env('DEBUGBAR_OPTIONS_VIEWS_GROUP', 50),   // Group duplicate views. Pass value to auto-group, or true/false to force
+            'timeline' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE', true),                  // Add the views to the timeline
+            'data' => env('DEBUGBAR_OPTIONS_VIEWS_DATA', false),                         // True for all data, 'keys' for only names, false for no parameters.
+            'group' => (int) env('DEBUGBAR_OPTIONS_VIEWS_GROUP', 50),                    // Group duplicate views. Pass value to auto-group, or true/false to force
+            'inertia_pages' => env('DEBUGBAR_OPTIONS_VIEWS_INERTIA_PAGES', 'js/Pages'),  // Path for Inertia views
             'exclude_paths' => [    // Add the paths which you don't want to appear in the views
                 'vendor/filament'   // Exclude Filament components by default
             ],

--- a/src/DataCollector/ViewCollector.php
+++ b/src/DataCollector/ViewCollector.php
@@ -125,7 +125,7 @@ class ViewCollector extends DataCollector implements Renderable, AssetProvider
             $name = $data['component'];
             $data = $data['props'];
 
-            if ($files = glob(resource_path('js/Pages/' . $name . '.*'))) {
+            if ($files = glob(resource_path(config('debugbar.options.views.inertia_pages') .'/'. $name . '.*'))) {
                 $path = $files[0];
                 $type = pathinfo($path, PATHINFO_EXTENSION);
 


### PR DESCRIPTION
Adds a config option to set the path for Inertia pages, `debugbar.options.views.inertia_pages`. Also supports the use of an environment variable, `DEBUGBAR_OPTIONS_VIEWS_INERTIA_PAGES`.
Defaults to `js/Pages`, like the original code.