### PR TITLE
Better contrast in dark theme titles.

### DIFF
--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -69,6 +69,13 @@ div.phpdebugbar-openhandler[data-theme='dark'] {
     --debugbar-hover-bg: var(--debugbar-gray-700);
 }
 
+div.phpdebugbar[data-theme='dark'] code.phpdebugbar-widgets-sql,
+div.phpdebugbar[data-theme='dark'] .phpdebugbar-widgets-name,
+div.phpdebugbar[data-theme='dark'] .phpdebugbar-widgets-key,
+div.phpdebugbar[data-theme='dark'] .phpdebugbar-widgets-success > pre.sf-dump > .sf-dump-note {
+    color: #fdfd96;
+}
+
 /* Force Laravel Whoops exception handler to be displayed under the debug bar */
 .Whoops.container {
     z-index: 5999999;


### PR DESCRIPTION
In the light theme it is differentiated by the `bold`, but this does not make much difference in the dark theme.

![image](https://github.com/user-attachments/assets/d7fef24b-822f-4148-a885-c238e6793435)
![image](https://github.com/user-attachments/assets/19b3e6a2-928c-41dc-9381-7abad786ac7f)
![image](https://github.com/user-attachments/assets/04021bc5-fbd4-4e78-a584-91b4e27b0688)
![image](https://github.com/user-attachments/assets/e2851128-661c-49ff-ac96-19fe29739a39)
![image](https://github.com/user-attachments/assets/daa287b9-f9f4-40e4-9857-8eae38b27ac6)
