### PR TITLE
Slow threshold highlight on queries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "php-debugbar/php-debugbar": "~2.2.0",
+        "php-debugbar/php-debugbar": "^2.2.4",
         "illuminate/routing": "^9|^10|^11|^12",
         "illuminate/session": "^9|^10|^11|^12",
         "illuminate/support": "^9|^10|^11|^12",

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -232,7 +232,8 @@ return [
             ],
             'hints'             => env('DEBUGBAR_OPTIONS_DB_HINTS', false),          // Show hints for common mistakes
             'show_copy'         => env('DEBUGBAR_OPTIONS_DB_SHOW_COPY', true),       // Show copy button next to the query,
-            'slow_threshold'    => env('DEBUGBAR_OPTIONS_DB_SLOW_THRESHOLD', false), // Only track queries that last longer than this time in ms
+            'only_slow_queries' => env('DEBUGBAR_OPTIONS_DB_ONLY_SLOW_QUERIES', true), // Only track queries that last longer than `slow_threshold`
+            'slow_threshold'    => env('DEBUGBAR_OPTIONS_DB_SLOW_THRESHOLD', false), // Max query execution time (ms). Exceeding queries will be highlighted
             'memory_usage'      => env('DEBUGBAR_OPTIONS_DB_MEMORY_USAGE', false),   // Show queries memory usage
             'soft_limit'       => (int) env('DEBUGBAR_OPTIONS_DB_SOFT_LIMIT', 100),  // After the soft limit, no parameters/backtrace are captured
             'hard_limit'       => (int) env('DEBUGBAR_OPTIONS_DB_HARD_LIMIT', 500),  // After the hard limit, queries are ignored

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -517,6 +517,7 @@ class QueryCollector extends PDOCollector
                 'start' => $query['start'] ?? null,
                 'duration' => $query['time'],
                 'duration_str' => ($query['type'] == 'transaction') ? '' : $this->formatDuration($query['time']),
+                'slow' => $this->slowThreshold && $this->slowThreshold <= $query['time'],
                 'memory' => $query['memory'],
                 'memory_str' => $query['memory'] ? $this->getDataFormatter()->formatBytes($query['memory']) : null,
                 'filename' => $this->getDataFormatter()->formatSource($source, true),

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -363,6 +363,11 @@ class LaravelDebugbar extends DebugBar
             $queryCollector->setLimits($config->get('debugbar.options.db.soft_limit'), $config->get('debugbar.options.db.hard_limit'));
             $queryCollector->setDurationBackground($config->get('debugbar.options.db.duration_background'));
 
+            $threshold = $config->get('debugbar.options.db.slow_threshold', false);
+            if ($threshold && !$config->get('debugbar.options.db.only_slow_queries', true)) {
+                $queryCollector->setSlowThreshold($threshold);
+            }
+
             if ($config->get('debugbar.options.db.with_params')) {
                 $queryCollector->setRenderSqlWithParams(true);
             }
@@ -402,9 +407,10 @@ class LaravelDebugbar extends DebugBar
                             return; // Issue 776 : We've turned off collecting after the listener was attached
                         }
 
-                        //allow collecting only queries slower than a specified amount of milliseconds
                         $threshold = app('config')->get('debugbar.options.db.slow_threshold', false);
-                        if (!$threshold || $query->time > $threshold) {
+                        $onlyThreshold = app('config')->get('debugbar.options.db.only_slow_queries', true);
+                        //allow collecting only queries slower than a specified amount of milliseconds
+                        if (!$onlyThreshold || !$threshold || $query->time > $threshold) {
                             $this['queries']->addQuery($query);
                         }
                     }

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -231,6 +231,9 @@
                     .attr('data-duplicate', false)
                     .append($('<strong />').addClass(csscls('sql name')).text(statement.sql));
             } else {
+                if (statement.slow) {
+                    $li.addClass(csscls('sql-slow'));
+                }
                 const $code = $('<code />').html(PhpDebugBar.Widgets.highlight(statement.sql, 'sql')).addClass(csscls('sql')),
                     duplicated = this.duplicateQueries.has(statement);
                 $li.attr('data-connection', statement.connection)


### PR DESCRIPTION
When `only_slow_queries => false`, it highlights slow queries 
```php
'only_slow_queries' => false,
'slow_threshold'    => 2000,
```
<img width="56" height="139" alt="image" src="https://github.com/user-attachments/assets/db7b3b1a-203c-4e59-a923-c19b7a5f04bb" />


---

When `only_slow_queries => true`(default value), only tracks slow queries(original functionality)
```php
'only_slow_queries' => true,
'slow_threshold'    => 2000,
```