### PR TITLE
(fix) trim last line breaks on logs

### DIFF
--- a/src/DataCollector/LogsCollector.php
+++ b/src/DataCollector/LogsCollector.php
@@ -45,7 +45,7 @@ class LogsCollector extends MessagesCollector
 
         foreach ($this->getLogs($file) as $log) {
             $this->messages[] = [
-                'message' => $log['header'] . $log['stack'],
+                'message' => trim($log['header'] . $log['stack']),
                 'label' => $log['level'],
                 'time' => substr($log['header'], 1, 19),
                 'collector' => $basename,


### PR DESCRIPTION
This causes the rows to grow unnecessarily when clicked.