### PR TITLE
Remove --ignore-platform-req=php+ on integration test setup

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -46,15 +46,15 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer create-project --prefer-dist --ignore-platform-req=php+ laravel/laravel:${{ matrix.laravel }} --stability=dev --no-progress sample
+                  composer create-project --prefer-dist laravel/laravel:${{ matrix.laravel }} --stability=dev --no-progress sample
                   cd sample
                   composer config minimum-stability dev
-                  composer update --prefer-stable --prefer-dist --no-progress --ignore-platform-req=php+
+                  composer update --prefer-stable --prefer-dist --no-progress
             - name: Add package from source
               run: |
                   cd sample
                   sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../src" } ],|' -i composer.json
-                  composer require --dev --ignore-platform-req=php+ "barryvdh/laravel-debugbar:*"
+                  composer require --dev "barryvdh/laravel-debugbar:*"
             - name: Execute generate run
               run: |
                   cd sample


### PR DESCRIPTION
It bypasses the PHP version check