### PR TITLE
Add '_boost*' to debugbar exceptions

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -19,7 +19,7 @@ return [
     'except' => [
         'telescope*',
         'horizon*',
-        '_boost*',
+        '_boost/browser-logs',
     ],
 
     /*


### PR DESCRIPTION
Dont show the Browser Logs 