### PR TITLE
Remove calls to PHP 8.5-deprecated `setAccessible`

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -167,7 +167,6 @@ class GateCollector extends MessagesCollector
         } else {
             $reflection = new \ReflectionClass($finder);
             $property = $reflection->getProperty('views');
-            $property->setAccessible(true);
             $this->reflection['viewfinderViews'] = $property;
         }
 

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -399,7 +399,6 @@ class QueryCollector extends PDOCollector
         } else {
             $reflection = new \ReflectionClass($finder);
             $property = $reflection->getProperty('views');
-            $property->setAccessible(true);
             $this->reflection['viewfinderViews'] = $property;
         }
 

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -24,7 +24,6 @@ class DebugbarTest extends TestCase
         $app->resolving(LaravelDebugbar::class, function ($debugbar) {
                 $refObject = new \ReflectionObject($debugbar);
                 $refProperty = $refObject->getProperty('enabled');
-                $refProperty->setAccessible(true);
                 $refProperty->setValue($debugbar, true);
         });
     }


### PR DESCRIPTION
These are no-op as of PHP 8.1 and thus no longer needed:
https://github.com/barryvdh/laravel-debugbar/blob/00e75ec30b153c4630a4c126afcf6a11ebab0bc8/composer.json#L20

See also https://wiki.php.net/rfc/make-reflection-setaccessible-no-op