### PR TITLE
Add error_level config option to filter error handler reporting (#1373)

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -139,8 +139,18 @@ return [
      | When enabled, the Debugbar shows deprecated warnings for Symfony components
      | in the Messages tab.
      |
+     | You can set a custom error reporting level to filter which errors are
+     | handled. For example, to exclude deprecation warnings:
+     |   E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+     |
+     | To exclude notices, strict warnings, and deprecations:
+     |   E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_USER_DEPRECATED
+     |
+     | Defaults to E_ALL (all errors).
+     |
      */
     'error_handler' => env('DEBUGBAR_ERROR_HANDLER', false),
+    'error_level' => env('DEBUGBAR_ERROR_LEVEL', E_ALL),
 
     /*
      |--------------------------------------------------------------------------

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -181,7 +181,11 @@ class LaravelDebugbar extends DebugBar
 
         // Set custom error handler
         if ($config->get('debugbar.error_handler', false)) {
-            $this->prevErrorHandler = set_error_handler([$this, 'handleError']);
+            // Get the error_level config, default to E_ALL
+            $errorLevel = $config->get('debugbar.error_level', E_ALL);
+
+            // set error handler with configured error reporting level
+            $this->prevErrorHandler = set_error_handler([$this, 'handleError'], $errorLevel);
         }
 
         $this->selectStorage($this);

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests;
+
+use Barryvdh\Debugbar\LaravelDebugbar;
+use ReflectionObject;
+
+class ErrorHandlerTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Force the Debugbar to Enable on test/cli applications
+        $app->resolving(LaravelDebugbar::class, function ($debugbar) {
+            $refObject = new ReflectionObject($debugbar);
+            $refProperty = $refObject->getProperty('enabled');
+            $refProperty->setValue($debugbar, true);
+        });
+
+        // Enable collectors needed for error handling
+        $app['config']->set('debugbar.collectors.messages', true);
+        $app['config']->set('debugbar.collectors.exceptions', true);
+    }
+
+    public function testErrorHandlerRespectsCustomErrorLevel()
+    {
+        $app = $this->app;
+        $app['config']->set('debugbar.error_handler', true);
+        // Exclude deprecation warnings
+        $app['config']->set('debugbar.error_level', E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
+        $debugbar = $app->make(LaravelDebugbar::class);
+        $debugbar->boot();
+
+        // Get initial message count
+        $initialCount = 0;
+        if ($debugbar->hasCollector('messages')) {
+            $initialCount = count($debugbar->getCollector('messages')->collect()['messages']);
+        }
+
+        // Trigger a deprecation warning - should NOT be captured
+        @trigger_error('Test deprecation warning', E_USER_DEPRECATED);
+
+        // Check that error was NOT captured
+        if ($debugbar->hasCollector('messages')) {
+            $messages = $debugbar->getCollector('messages')->collect();
+            $newCount = count($messages['messages']);
+            $this->assertEquals($initialCount, $newCount, 'Deprecation warning should not be captured when excluded from error_level');
+        }
+
+        // Trigger a warning (not a deprecation) - should be captured
+        @trigger_error('Test warning', E_USER_WARNING);
+
+        // Check that warning WAS captured
+        if ($debugbar->hasCollector('messages')) {
+            $messages = $debugbar->getCollector('messages')->collect();
+            $finalCount = count($messages['messages']);
+            $this->assertGreaterThan($initialCount, $finalCount, 'Non-deprecation errors should still be captured');
+        }
+    }
+}


### PR DESCRIPTION
Implements feature request #1373 to allow customizing which error types are handled by the debugbar error handler. This is especially useful for PHP 8.2 projects using dynamic properties where deprecation warnings can be filtered out.

- Add `error_level` config option (defaults to E_ALL)
- Pass error_level to set_error_handler() as second parameter
- Add tests to verify custom error level filtering works correctly

Users can now exclude deprecation warnings by setting:

`error_level: E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED`

#1373 