### PR TITLE
Allow Symfony v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/routing": "^10|^11|^12",
         "illuminate/session": "^10|^11|^12",
         "illuminate/support": "^10|^11|^12",
-        "symfony/finder": "^6|^7"
+        "symfony/finder": "^6|^7|^8"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",


### PR DESCRIPTION
See also https://symfony.com/releases/8.0 and https://github.com/symfony/finder/blob/8.0/CHANGELOG.md (i.e. this should effectively be no change).