### PR TITLE
docs: Add conditional check for Debugbar alias registration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,8 +71,10 @@ If you want to use the facade to log messages, add this within the `register` me
 ```php
 public function register(): void
 {
-    $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-    $loader->alias('Debugbar', \Barryvdh\Debugbar\Facades\Debugbar::class);
+    if (class_exists(\Barryvdh\Debugbar\Facades\Debugbar::class)) {
+        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+        $loader->alias('Debugbar', \Barryvdh\Debugbar\Facades\Debugbar::class);
+    }
 }
 ```
 


### PR DESCRIPTION
## Description
This PR updates the documentation example regarding the manual registration of the Facade alias in the `register` method.

## Motivation & Context
The previous example suggested adding the `AliasLoader` code directly. However, if this code is placed in the `AppServiceProvider` and the application is deployed to a production environment where `composer install --no-dev` is used (meaning `laravel-debugbar` is not present), it causes a **"Class not found" fatal error**.

## Changes
I have wrapped the alias registration logic within a `if (class_exists(...))` check. This ensures the code only executes if the Debugbar class is actually available, preventing crashes in environments where the package is not installed.