### PR TITLE
Feature/floating draggable position

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -345,7 +345,7 @@ return [
      |--------------------------------------------------------------------------
      |
      | Controls where the debugbar appears on the page.
-     | Possible values: bottom, floating
+     | Possible values: bottom, top, floating
      |
      | When set to 'floating', the debugbar can be dragged anywhere on the screen.
      */

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -341,6 +341,34 @@ return [
 
     /*
      |--------------------------------------------------------------------------
+     | Debugbar Position
+     |--------------------------------------------------------------------------
+     |
+     | Controls where the debugbar appears on the page.
+     | Possible values: bottom, floating
+     |
+     | When set to 'floating', the debugbar can be dragged anywhere on the screen.
+     */
+    'position' => 'bottom',
+
+    /*
+     |--------------------------------------------------------------------------
+     | Floating Position Options
+     |--------------------------------------------------------------------------
+     |
+     | When position is set to 'floating', these options control the behavior.
+     |
+     | 'initial_x' and 'initial_y' set the starting position (null = auto position at bottom-right)
+     | 'remember_position' persists the position in localStorage across page reloads
+     */
+    'floating' => [
+        'initial_x' => env('DEBUGBAR_FLOATING_X'),
+        'initial_y' => env('DEBUGBAR_FLOATING_Y'),
+        'remember_position' => env('DEBUGBAR_FLOATING_REMEMBER', true),
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
      | Backtrace stack limit
      |--------------------------------------------------------------------------
      |

--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,41 @@ Make sure you only do this on local development, because otherwise other people 
 In general, Debugbar should only be used locally or at least restricted by IP.
 It's possible to pass a callback, which will receive the Request object, so you can determine access to the OpenHandler storage.
 
+## Floating/Draggable Position
+
+By default, the Debugbar is fixed to the bottom of the screen. You can enable a floating/draggable mode that allows you to drag the Debugbar anywhere on the screen.
+
+To enable floating mode, set the `position` option in your `config/debugbar.php`:
+
+```php
+'position' => 'floating',
+```
+
+### Floating Options
+
+When using floating mode, you can configure additional options:
+
+```php
+'floating' => [
+    'initial_x' => null,           // Initial X position (null = auto, bottom-right)
+    'initial_y' => null,           // Initial Y position (null = auto, bottom-right)
+    'remember_position' => true,   // Persist position in localStorage across page reloads
+],
+```
+
+### Features
+
+- **Drag anywhere**: Click and drag the Debugbar header to move it anywhere on screen
+- **Touch support**: Works on mobile devices with touch events
+- **Position persistence**: When `remember_position` is enabled, your position is saved in localStorage
+- **Viewport constraints**: The Debugbar stays within the visible viewport
+- **Works with minimize/maximize**: Fully compatible with the Debugbar's minimize/maximize functionality
+
+### Available Positions
+
+- `bottom` (default): Fixed to the bottom of the screen
+- `floating`: Draggable anywhere on the screen (can snap to edges)
+
 ## Twig Integration
 
 Laravel Debugbar comes with two Twig Extensions. These are tested with [rcrowe/TwigBridge](https://github.com/rcrowe/TwigBridge) 0.6.x

--- a/src/JavascriptRenderer.php
+++ b/src/JavascriptRenderer.php
@@ -36,7 +36,7 @@ class JavascriptRenderer extends BaseJavascriptRenderer
     /**
      * Set the position configuration for the debugbar
      *
-     * @param string $position Position setting: 'bottom' or 'floating'
+     * @param string $position Position setting: 'bottom', 'top', or 'floating'
      * @param array $floatingOptions Options for floating mode
      * @return void
      */

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -636,6 +636,11 @@ class LaravelDebugbar extends DebugBar
         $renderer->setBindAjaxHandlerToXHR($config->get('debugbar.capture_ajax', true));
         $renderer->setDeferDatasets($config->get('debugbar.defer_datasets', false));
 
+        // Set position configuration for draggable/floating support
+        $position = $config->get('debugbar.position', 'bottom');
+        $floatingOptions = $config->get('debugbar.floating', []);
+        $renderer->setPositionOptions($position, $floatingOptions);
+
         $this->booted = true;
     }
 

--- a/src/Resources/draggable.js
+++ b/src/Resources/draggable.js
@@ -1,0 +1,766 @@
+(function() {
+    'use strict';
+
+    const STORAGE_KEY = 'phpdebugbar_floating_position';
+    const SETTINGS_KEY = 'phpdebugbar-settings';
+    const SNAP_CHECK_THRESHOLD = 10;
+    const MUTATION_OBSERVER_MAX_COUNT = 100;
+
+    function getEventCoordinates(e) {
+        const touch = e.touches?.[0] || e.changedTouches?.[0];
+        return touch
+            ? { x: touch.clientX, y: touch.clientY }
+            : { x: e.clientX, y: e.clientY };
+    }
+
+    (function preventFOUC() {
+        try {
+            // Check if FOUC fix already exists (may be injected inline by PHP)
+            if (document.getElementById('phpdebugbar-fouc-fix')) return;
+
+            const settings = JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}');
+            const config = window.phpdebugbar_position_config || {};
+            const mode = settings.positionMode || config.position;
+
+            if (mode === 'floating') {
+                const style = document.createElement('style');
+                style.id = 'phpdebugbar-fouc-fix';
+                style.textContent = 'div.phpdebugbar:not(.phpdebugbar-ready){opacity:0!important;transition:opacity .15s ease!important}';
+                (document.head || document.documentElement).appendChild(style);
+            }
+        } catch (e) {}
+    })();
+
+    const SNAP_ZONES = {
+        topLeft: {
+            name: 'Top Left',
+            detect: (x, y, w, h, vw, vh, dist) => x <= dist && y <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: 0, y: 0, width: vw / 2, height: vh / 2 }),
+            priority: 0
+        },
+        topRight: {
+            name: 'Top Right',
+            detect: (x, y, w, h, vw, vh, dist) => vw - (x + w) <= dist && y <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: vw / 2, y: 0, width: vw / 2, height: vh / 2 }),
+            priority: 0
+        },
+        bottomLeft: {
+            name: 'Bottom Left',
+            detect: (x, y, w, h, vw, vh, dist) => x <= dist && vh - (y + h) <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: 0, y: vh / 2, width: vw / 2, height: vh / 2 }),
+            priority: 0
+        },
+        bottomRight: {
+            name: 'Bottom Right',
+            detect: (x, y, w, h, vw, vh, dist) => vw - (x + w) <= dist && vh - (y + h) <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: vw / 2, y: vh / 2, width: vw / 2, height: vh / 2 }),
+            priority: 0
+        },
+        bottom: {
+            name: 'Bottom',
+            detect: (x, y, w, h, vw, vh, dist) => vh - (y + h) <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: 0, y: vh - h, width: vw, height: h }),
+            priority: 1
+        },
+        top: {
+            name: 'Top',
+            detect: (x, y, w, h, vw, vh, dist) => y <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: 0, y: 0, width: vw, height: h }),
+            priority: 1
+        },
+        left: {
+            name: 'Left Half',
+            detect: (x, y, w, h, vw, vh, dist) => x <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: 0, y: 0, width: vw / 2, height: vh }),
+            priority: 2
+        },
+        right: {
+            name: 'Right Half',
+            detect: (x, y, w, h, vw, vh, dist) => vw - (x + w) <= dist,
+            getPosition: (w, h, vw, vh) => ({ x: vw / 2, y: 0, width: vw / 2, height: vh }),
+            priority: 2
+        }
+    };
+
+    const SORTED_ZONE_ENTRIES = Object.entries(SNAP_ZONES)
+        .sort((a, b) => a[1].priority - b[1].priority);
+
+    class SnapPreview {
+        constructor() {
+            this.element = null;
+            this.currentZone = null;
+        }
+
+        create() {
+            if (this.element) return;
+            this.element = document.createElement('div');
+            this.element.className = 'phpdebugbar-snap-preview';
+            document.body.appendChild(this.element);
+        }
+
+        show(position, zoneName) {
+            this.create();
+            this.element.style.cssText = `
+                left: ${position.x}px;
+                top: ${position.y}px;
+                width: ${position.width}px;
+                height: ${position.height}px;
+            `;
+            this.element.classList.add('phpdebugbar-snap-preview-active');
+            this.currentZone = zoneName;
+        }
+
+        hide() {
+            if (this.element) {
+                this.element.classList.remove('phpdebugbar-snap-preview-active');
+            }
+            this.currentZone = null;
+        }
+
+        destroy() {
+            if (this.element && this.element.parentNode) {
+                this.element.parentNode.removeChild(this.element);
+                this.element = null;
+            }
+        }
+    }
+
+    class DraggableDebugbar {
+        constructor(debugbar, options = {}) {
+            this.debugbar = debugbar;
+            this.options = Object.assign({
+                initial_x: null,
+                initial_y: null,
+                remember_position: true,
+                storage_key: STORAGE_KEY,
+                enableSnapping: true,
+                snapDistance: 60,
+                snapAnimationDuration: 200
+            }, options);
+
+            this.isDragging = false;
+            this.startX = 0;
+            this.startY = 0;
+            this.currentX = 0;
+            this.currentY = 0;
+            this.currentSnapZone = null;
+            this.isSnapped = false;
+            this.rafId = null;
+            this.pendingX = 0;
+            this.pendingY = 0;
+            this.cachedWidth = 0;
+            this.cachedHeight = 0;
+            this.cachedViewportWidth = 0;
+            this.cachedViewportHeight = 0;
+            this.lastSnapCheckX = 0;
+            this.lastSnapCheckY = 0;
+
+            this.snapPreview = new SnapPreview();
+            this.boundStartDrag = this.startDrag.bind(this);
+            this.boundDrag = this.drag.bind(this);
+            this.boundEndDrag = this.endDrag.bind(this);
+            this.boundResize = this.throttle(this.handleResize.bind(this), 100);
+
+            this.init();
+        }
+
+        throttle(func, limit) {
+            let inThrottle;
+            return (...args) => {
+                if (!inThrottle) {
+                    func.apply(this, args);
+                    inThrottle = true;
+                    setTimeout(() => inThrottle = false, limit);
+                }
+            };
+        }
+
+        init() {
+            this.dragHandle = this.debugbar.querySelector('.phpdebugbar-header');
+            if (!this.dragHandle) {
+                this.reveal();
+                return;
+            }
+
+            this.debugbar.classList.add('phpdebugbar-floating');
+            this.dragHandle.classList.add('phpdebugbar-drag-handle');
+            this.dragHandle.addEventListener('mousedown', this.boundStartDrag);
+            this.dragHandle.addEventListener('touchstart', this.boundStartDrag, { passive: false });
+            window.addEventListener('resize', this.boundResize, { passive: true });
+
+            this.loadPosition();
+            this.reveal();
+        }
+
+        reveal() {
+            this.debugbar.classList.add('phpdebugbar-ready');
+            const foucStyle = document.getElementById('phpdebugbar-fouc-fix');
+            if (foucStyle) foucStyle.remove();
+        }
+
+        detectSnapZoneCached(x, y) {
+            if (!this.options.enableSnapping) return null;
+
+            const w = this.cachedWidth;
+            const h = this.cachedHeight;
+            const vw = this.cachedViewportWidth;
+            const vh = this.cachedViewportHeight;
+            const dist = this.options.snapDistance;
+
+            for (const [key, zone] of SORTED_ZONE_ENTRIES) {
+                if (zone.detect(x, y, w, h, vw, vh, dist)) {
+                    return key;
+                }
+            }
+            return null;
+        }
+
+        startDrag(e) {
+            const target = e.target;
+            if (target.closest('.phpdebugbar-tab') ||
+                target.closest('.phpdebugbar-close-btn') ||
+                target.closest('.phpdebugbar-minimize-btn') ||
+                target.closest('.phpdebugbar-restore-btn') ||
+                target.closest('.phpdebugbar-open-btn') ||
+                target.closest('.phpdebugbar-tab-settings') ||
+                target.closest('.phpdebugbar-tab-history') ||
+                target.closest('a') ||
+                target.closest('button') ||
+                target.closest('select') ||
+                target.closest('input')) {
+                return;
+            }
+
+            e.preventDefault();
+            this.isDragging = true;
+            this.debugbar.classList.add('phpdebugbar-dragging');
+
+            if (this.isSnapped) {
+                this.unsnap();
+            }
+
+            const rect = this.debugbar.getBoundingClientRect();
+            this.cachedWidth = rect.width;
+            this.cachedHeight = rect.height;
+            this.cachedViewportWidth = window.innerWidth;
+            this.cachedViewportHeight = window.innerHeight;
+
+            const coords = getEventCoordinates(e);
+            this.startX = coords.x - rect.left;
+            this.startY = coords.y - rect.top;
+            this.currentX = rect.left;
+            this.currentY = rect.top;
+            this.lastSnapCheckX = rect.left;
+            this.lastSnapCheckY = rect.top;
+
+            this.debugbar.style.left = '0';
+            this.debugbar.style.top = '0';
+            this.debugbar.style.transform = `translate3d(${this.currentX}px, ${this.currentY}px, 0)`;
+
+            document.addEventListener('mousemove', this.boundDrag);
+            document.addEventListener('mouseup', this.boundEndDrag);
+            document.addEventListener('touchmove', this.boundDrag, { passive: false });
+            document.addEventListener('touchend', this.boundEndDrag);
+            document.addEventListener('touchcancel', this.boundEndDrag);
+        }
+
+        drag(e) {
+            if (!this.isDragging) return;
+            e.preventDefault();
+
+            const coords = getEventCoordinates(e);
+            let newX = coords.x - this.startX;
+            let newY = coords.y - this.startY;
+
+            const minVisible = 50;
+            const maxX = this.cachedViewportWidth - minVisible;
+            const minX = minVisible - this.cachedWidth;
+            newX = Math.max(minX, Math.min(newX, maxX));
+
+            const maxY = this.cachedViewportHeight - minVisible;
+            newY = Math.max(0, Math.min(newY, maxY));
+
+            this.pendingX = newX;
+            this.pendingY = newY;
+
+            if (!this.rafId) {
+                this.rafId = requestAnimationFrame(() => {
+                    this.rafId = null;
+                    this.applyPositionDuringDrag(this.pendingX, this.pendingY);
+
+                    const dx = Math.abs(this.pendingX - this.lastSnapCheckX);
+                    const dy = Math.abs(this.pendingY - this.lastSnapCheckY);
+                    if (dx > SNAP_CHECK_THRESHOLD || dy > SNAP_CHECK_THRESHOLD) {
+                        this.updateSnapPreview(this.pendingX, this.pendingY);
+                        this.lastSnapCheckX = this.pendingX;
+                        this.lastSnapCheckY = this.pendingY;
+                    }
+                });
+            }
+        }
+
+        applyPositionDuringDrag(x, y) {
+            this.debugbar.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+            this.currentX = x;
+            this.currentY = y;
+        }
+
+        updateSnapPreview(x, y) {
+            const snapZone = this.detectSnapZoneCached(x, y);
+
+            if (snapZone) {
+                const zone = SNAP_ZONES[snapZone];
+                const snapPos = zone.getPosition(
+                    this.cachedWidth,
+                    this.cachedHeight,
+                    this.cachedViewportWidth,
+                    this.cachedViewportHeight
+                );
+                this.snapPreview.show(snapPos, snapZone);
+                this.currentSnapZone = snapZone;
+            } else {
+                this.snapPreview.hide();
+                this.currentSnapZone = null;
+            }
+        }
+
+        endDrag() {
+            if (!this.isDragging) return;
+
+            if (this.rafId) {
+                cancelAnimationFrame(this.rafId);
+                this.rafId = null;
+            }
+
+            this.isDragging = false;
+            this.debugbar.classList.remove('phpdebugbar-dragging');
+
+            document.removeEventListener('mousemove', this.boundDrag);
+            document.removeEventListener('mouseup', this.boundEndDrag);
+            document.removeEventListener('touchmove', this.boundDrag);
+            document.removeEventListener('touchend', this.boundEndDrag);
+            document.removeEventListener('touchcancel', this.boundEndDrag);
+
+            this.snapPreview.hide();
+            this.debugbar.style.transform = '';
+            this.applyPosition(this.currentX, this.currentY);
+
+            if (this.currentSnapZone && this.options.enableSnapping) {
+                this.snapTo(this.currentSnapZone);
+            } else if (this.options.remember_position) {
+                this.savePosition();
+            }
+
+            this.currentSnapZone = null;
+        }
+
+        snapTo(zoneName) {
+            const zone = SNAP_ZONES[zoneName];
+            if (!zone) return;
+
+            const rect = this.debugbar.getBoundingClientRect();
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+            const targetPos = zone.getPosition(rect.width, rect.height, vw, vh);
+
+            this.debugbar.classList.add('phpdebugbar-snapping');
+
+            if (zoneName === 'bottom' || zoneName === 'top') {
+                this.debugbar.style.width = '100%';
+                this.debugbar.style.maxWidth = '100vw';
+                this.debugbar.style.borderRadius = '0';
+            }
+
+            this.debugbar.style.transition = `left ${this.options.snapAnimationDuration}ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                                              top ${this.options.snapAnimationDuration}ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                                              width ${this.options.snapAnimationDuration}ms cubic-bezier(0.25, 0.46, 0.45, 0.94)`;
+
+            this.applyPosition(targetPos.x, targetPos.y);
+
+            let cleaned = false;
+            const cleanup = () => {
+                if (cleaned) return;
+                cleaned = true;
+                this.debugbar.style.transition = '';
+                this.debugbar.classList.remove('phpdebugbar-snapping');
+                this.isSnapped = true;
+                this.currentSnapZone = zoneName;
+                this.debugbar.removeEventListener('transitionend', onTransitionEnd);
+
+                if (this.options.remember_position) {
+                    this.savePosition();
+                }
+            };
+
+            const onTransitionEnd = (e) => {
+                if (e.target === this.debugbar && e.propertyName === 'left') {
+                    cleanup();
+                }
+            };
+
+            this.debugbar.addEventListener('transitionend', onTransitionEnd);
+            setTimeout(cleanup, this.options.snapAnimationDuration + 50);
+        }
+
+        unsnap() {
+            if (!this.isSnapped) return;
+            this.debugbar.style.width = '';
+            this.debugbar.style.maxWidth = '';
+            this.debugbar.style.borderRadius = '';
+            this.isSnapped = false;
+            this.currentSnapZone = null;
+        }
+
+        getConstrainedPosition(x, y) {
+            const rect = this.debugbar.getBoundingClientRect();
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+            const minVisible = 50;
+
+            return {
+                x: Math.max(minVisible - rect.width, Math.min(x, vw - minVisible)),
+                y: Math.max(0, Math.min(y, vh - minVisible))
+            };
+        }
+
+        handleResize() {
+            if (!this.debugbar.classList.contains('phpdebugbar-floating')) return;
+
+            if (this.isSnapped && this.currentSnapZone) {
+                const zone = SNAP_ZONES[this.currentSnapZone];
+                if (zone) {
+                    const rect = this.debugbar.getBoundingClientRect();
+                    const targetPos = zone.getPosition(rect.width, rect.height, window.innerWidth, window.innerHeight);
+                    this.applyPosition(targetPos.x, targetPos.y);
+                }
+            } else {
+                const rect = this.debugbar.getBoundingClientRect();
+                const constrained = this.getConstrainedPosition(rect.left, rect.top);
+                if (rect.left !== constrained.x || rect.top !== constrained.y) {
+                    this.applyPosition(constrained.x, constrained.y);
+                    if (this.options.remember_position) {
+                        this.savePosition();
+                    }
+                }
+            }
+        }
+
+        applyPosition(x, y) {
+            this.debugbar.style.left = x + 'px';
+            this.debugbar.style.top = y + 'px';
+            this.debugbar.style.right = 'auto';
+            this.debugbar.style.bottom = 'auto';
+            this.currentX = x;
+            this.currentY = y;
+        }
+
+        savePosition() {
+            try {
+                localStorage.setItem(this.options.storage_key, JSON.stringify({
+                    x: this.currentX,
+                    y: this.currentY,
+                    snapped: this.isSnapped,
+                    snapZone: this.currentSnapZone,
+                    timestamp: Date.now()
+                }));
+            } catch (e) {}
+        }
+
+        loadPosition() {
+            let loaded = false;
+
+            if (this.options.remember_position) {
+                try {
+                    const saved = localStorage.getItem(this.options.storage_key);
+                    if (saved) {
+                        const position = JSON.parse(saved);
+                        if (position.snapped && position.snapZone && SNAP_ZONES[position.snapZone]) {
+                            this.snapTo(position.snapZone);
+                            loaded = true;
+                        } else if (position.x !== undefined && position.y !== undefined) {
+                            const constrained = this.getConstrainedPosition(position.x, position.y);
+                            this.applyPosition(constrained.x, constrained.y);
+                            loaded = true;
+                        }
+                    }
+                } catch (e) {}
+            }
+
+            if (!loaded) {
+                this.setInitialPosition();
+            }
+        }
+
+        setInitialPosition() {
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+            const rect = this.debugbar.getBoundingClientRect();
+
+            let x = this.options.initial_x;
+            let y = this.options.initial_y;
+
+            if (x === null || x === undefined) {
+                x = vw - rect.width - 10;
+            }
+            if (y === null || y === undefined) {
+                y = vh - rect.height - 10;
+            }
+
+            const constrained = this.getConstrainedPosition(x, y);
+            this.applyPosition(constrained.x, constrained.y);
+        }
+
+        resetPosition() {
+            try {
+                localStorage.removeItem(this.options.storage_key);
+            } catch (e) {}
+            this.unsnap();
+            this.setInitialPosition();
+        }
+
+        destroy() {
+            this.snapPreview.destroy();
+            window.removeEventListener('resize', this.boundResize);
+            if (this.dragHandle) {
+                this.dragHandle.removeEventListener('mousedown', this.boundStartDrag);
+                this.dragHandle.removeEventListener('touchstart', this.boundStartDrag);
+            }
+            if (this.rafId) {
+                cancelAnimationFrame(this.rafId);
+            }
+        }
+    }
+
+    let cachedSettings = null;
+
+    function getSettings() {
+        if (!cachedSettings) {
+            try {
+                cachedSettings = JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}');
+            } catch (e) {
+                cachedSettings = {};
+            }
+        }
+        return cachedSettings;
+    }
+
+    function updateSettings(key, value) {
+        const settings = getSettings();
+        settings[key] = value;
+        cachedSettings = settings;
+        try {
+            localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+        } catch (e) {}
+    }
+
+    function initDraggableDebugbar(retries = 0) {
+        const config = window.phpdebugbar_position_config || {};
+
+        if (config.position !== 'floating') {
+            return;
+        }
+
+        const debugbar = document.querySelector('div.phpdebugbar');
+        if (!debugbar) {
+            if (retries < 50) {
+                setTimeout(() => initDraggableDebugbar(retries + 1), 100);
+            }
+            return;
+        }
+
+        if (debugbar.classList.contains('phpdebugbar-floating')) {
+            return;
+        }
+
+        window.phpdebugbar_draggable = new DraggableDebugbar(debugbar, config.floating || {});
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => initDraggableDebugbar());
+    } else {
+        setTimeout(() => initDraggableDebugbar(), 0);
+    }
+
+    window.DraggableDebugbar = DraggableDebugbar;
+
+    function hookSettingsWidget(retries = 0) {
+        if (typeof window.phpdebugbar === 'undefined' || !window.phpdebugbar.settings) {
+            if (retries < 100) {
+                setTimeout(() => hookSettingsWidget(retries + 1), 50);
+            }
+            return;
+        }
+
+        if (typeof PhpDebugBar === 'undefined' || !PhpDebugBar.$) {
+            if (retries < 100) {
+                setTimeout(() => hookSettingsWidget(retries + 1), 50);
+            }
+            return;
+        }
+
+        const $ = PhpDebugBar.$;
+        const settingsWidget = window.phpdebugbar.settings.get('widget');
+
+        if (!settingsWidget) {
+            if (retries < 100) {
+                setTimeout(() => hookSettingsWidget(retries + 1), 50);
+            }
+            return;
+        }
+
+        if (settingsWidget._positionModeHooked) {
+            return;
+        }
+        settingsWidget._positionModeHooked = true;
+
+        const originalRender = settingsWidget.render;
+
+        settingsWidget.render = function() {
+            originalRender.call(this);
+            addPositionModeToSettings.call(this, $);
+        };
+
+        if (settingsWidget.$el && settingsWidget.$el.length > 0) {
+            const $existingForm = settingsWidget.$el;
+            if ($existingForm.find('.phpdebugbar-form-row').length > 0 &&
+                $existingForm.find('[data-position-mode-field]').length === 0) {
+                addPositionModeToSettings.call(settingsWidget, $);
+            }
+        }
+
+        const debugbarEl = document.querySelector('div.phpdebugbar');
+        if (debugbarEl) {
+            let observationCount = 0;
+            const observer = new MutationObserver((_, obs) => {
+                observationCount++;
+                if (observationCount > MUTATION_OBSERVER_MAX_COUNT) {
+                    obs.disconnect();
+                    return;
+                }
+                const $form = $('form.phpdebugbar-settings');
+                if ($form.length > 0 &&
+                    $form.find('.phpdebugbar-form-row').length > 0 &&
+                    $form.find('[data-position-mode-field]').length === 0) {
+                    addPositionModeToSettings.call(settingsWidget, $);
+                    obs.disconnect();
+                }
+            });
+            observer.observe(debugbarEl, { childList: true, subtree: true });
+        }
+    }
+
+    function addPositionModeToSettings($) {
+        if (!this.$el || !this.$el.length) {
+            return;
+        }
+
+        if (this.$el.find('[data-position-mode-field]').length > 0) {
+            return;
+        }
+
+        const settings = getSettings();
+        const configPosition = (window.phpdebugbar_position_config || {}).position || 'bottom';
+        const currentMode = settings.positionMode || configPosition;
+
+        const $row = $('<div />').addClass('phpdebugbar-form-row').attr('data-position-mode-field', 'true');
+        const $label = $('<div />').addClass('phpdebugbar-form-label').text('Position Mode');
+        const $input = $('<div />').addClass('phpdebugbar-form-input');
+
+        const $select = $('<select />')
+            .append($('<option value="bottom">Bottom (Fixed)</option>'))
+            .append($('<option value="floating">Floating (Draggable)</option>'))
+            .val(currentMode)
+            .on('change', function() {
+                const newMode = $(this).val();
+                storePositionMode(newMode);
+                applyPositionMode(newMode);
+            });
+
+        $input.append($select);
+        $row.append($label).append($input);
+
+        const $resetRow = this.$el.find('.phpdebugbar-form-row').filter(function() {
+            return $(this).find('button').length > 0;
+        }).first();
+
+        if ($resetRow.length > 0) {
+            $row.insertBefore($resetRow);
+        } else {
+            this.$el.append($row);
+        }
+    }
+
+    function storePositionMode(mode) {
+        updateSettings('positionMode', mode);
+        const debugbarEl = document.querySelector('div.phpdebugbar');
+        if (debugbarEl) {
+            debugbarEl.setAttribute('data-positionMode', mode);
+        }
+    }
+
+    function applyPositionMode(mode) {
+        const debugbarEl = document.querySelector('div.phpdebugbar');
+        if (!debugbarEl) return;
+
+        const wasFloating = debugbarEl.classList.contains('phpdebugbar-floating');
+
+        debugbarEl.classList.remove('phpdebugbar-floating', 'phpdebugbar-ready',
+            'phpdebugbar-snapped-bottom', 'phpdebugbar-snapped-top',
+            'phpdebugbar-snapped-left', 'phpdebugbar-snapped-right',
+            'phpdebugbar-snapped-top-left', 'phpdebugbar-snapped-top-right',
+            'phpdebugbar-snapped-bottom-left', 'phpdebugbar-snapped-bottom-right');
+
+        debugbarEl.style.cssText = '';
+
+        if (window.phpdebugbar_draggable) {
+            window.phpdebugbar_draggable.destroy();
+            window.phpdebugbar_draggable = null;
+        }
+
+        if (wasFloating && mode !== 'floating') {
+            try {
+                localStorage.removeItem(STORAGE_KEY);
+            } catch (e) {}
+        }
+
+        if (mode === 'floating') {
+            const floatingOptions = (window.phpdebugbar_position_config || {}).floating || {};
+            window.phpdebugbar_draggable = new DraggableDebugbar(debugbarEl, floatingOptions);
+        }
+
+        debugbarEl.setAttribute('data-positionMode', mode);
+    }
+
+    function applySavedPositionModeOnLoad(retries = 0) {
+        const settings = getSettings();
+        const configPosition = (window.phpdebugbar_position_config || {}).position || 'bottom';
+        const mode = settings.positionMode || configPosition;
+
+        const debugbarEl = document.querySelector('div.phpdebugbar');
+        if (!debugbarEl) {
+            if (retries < 50) {
+                setTimeout(() => applySavedPositionModeOnLoad(retries + 1), 100);
+            }
+            return;
+        }
+
+        debugbarEl.setAttribute('data-positionMode', mode);
+
+        if (mode === 'floating' && !debugbarEl.classList.contains('phpdebugbar-floating')) {
+            window.phpdebugbar_position_config = window.phpdebugbar_position_config || {};
+            window.phpdebugbar_position_config.position = 'floating';
+            const floatingOptions = (window.phpdebugbar_position_config || {}).floating || {};
+            window.phpdebugbar_draggable = new DraggableDebugbar(debugbarEl, floatingOptions);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            applySavedPositionModeOnLoad();
+            hookSettingsWidget();
+        });
+    } else {
+        applySavedPositionModeOnLoad();
+        hookSettingsWidget();
+    }
+})();

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -763,3 +763,212 @@ div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-
 div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-params {
     cursor: default;
 }
+
+/* ============================================
+   Floating/Draggable Position Styles (GPU-Optimized)
+   ============================================ */
+
+/**
+ * Floating state - GPU-accelerated for smooth 60fps dragging
+ */
+div.phpdebugbar.phpdebugbar-floating {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: auto;
+    width: auto;
+    max-width: calc(100vw - 20px);
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--debugbar-border);
+    border-top: 3px solid var(--debugbar-red-vivid);
+    /* GPU layer promotion for smooth transforms */
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+    /* Contain layout to prevent affecting other elements */
+    contain: layout style;
+}
+
+/* Box shadow on pseudo-element for cheaper animation (opacity only) */
+div.phpdebugbar.phpdebugbar-floating::before,
+div.phpdebugbar.phpdebugbar-floating::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    z-index: -1;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+div.phpdebugbar.phpdebugbar-floating::before {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    opacity: 1;
+}
+
+div.phpdebugbar.phpdebugbar-floating::after {
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    opacity: 0;
+}
+
+/* Dark mode shadows */
+div.phpdebugbar.phpdebugbar-floating[data-theme='dark']::before {
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+
+div.phpdebugbar.phpdebugbar-floating[data-theme='dark']::after {
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+/**
+ * Drag handle styling
+ */
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-drag-handle {
+    cursor: grab;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging .phpdebugbar-drag-handle {
+    cursor: grabbing;
+}
+
+/**
+ * CRITICAL: Disable ALL transitions during drag for maximum performance
+ * Uses transform: translate3d() for GPU-accelerated movement
+ */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging {
+    will-change: transform;
+    opacity: 0.92;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging,
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging *,
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging::before,
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging::after {
+    transition: none !important;
+}
+
+/* Swap shadow opacity during drag (cheap - opacity only) */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging::before {
+    opacity: 0;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-dragging::after {
+    opacity: 1;
+}
+
+/**
+ * Interactive elements - simplified selector with :is()
+ */
+div.phpdebugbar.phpdebugbar-floating :is(
+    .phpdebugbar-tab,
+    .phpdebugbar-close-btn,
+    .phpdebugbar-minimize-btn,
+    .phpdebugbar-restore-btn,
+    .phpdebugbar-open-btn,
+    a, button, select, input
+) {
+    cursor: pointer;
+}
+
+/**
+ * Minimized state
+ */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-minimized {
+    width: auto;
+    min-width: 200px;
+}
+
+div.phpdebugbar.phpdebugbar-floating div.phpdebugbar-resize-handle {
+    display: block !important;
+}
+
+/* Remove will-change when not dragging (free GPU memory) */
+div.phpdebugbar.phpdebugbar-floating:not(.phpdebugbar-dragging):not(.phpdebugbar-snapping) {
+    will-change: auto;
+}
+
+/* ============================================
+   Snap Preview Zone Styles (GPU-Optimized)
+   ============================================ */
+
+.phpdebugbar-snap-preview {
+    position: fixed;
+    pointer-events: none;
+    z-index: 2147483645;
+    background: rgba(59, 130, 246, 0.08);
+    border: 2px dashed rgba(59, 130, 246, 0.4);
+    border-radius: 6px;
+    opacity: 0;
+    /* GPU acceleration - opacity only transition */
+    transform: translate3d(0, 0, 0);
+    will-change: opacity;
+    backface-visibility: hidden;
+    transition: opacity 0.1s ease-out;
+}
+
+.phpdebugbar-snap-preview.phpdebugbar-snap-preview-active {
+    opacity: 1;
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    .phpdebugbar-snap-preview {
+        background: rgba(96, 165, 250, 0.1);
+        border-color: rgba(96, 165, 250, 0.5);
+    }
+}
+
+div.phpdebugbar[data-theme='dark'] ~ .phpdebugbar-snap-preview,
+.phpdebugbar-snap-preview[data-theme='dark'] {
+    background: rgba(96, 165, 250, 0.1);
+    border-color: rgba(96, 165, 250, 0.5);
+}
+
+/**
+ * Snapping animation - only enabled when not dragging
+ */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapping:not(.phpdebugbar-dragging) {
+    transition: left 0.2s cubic-bezier(0.2, 0, 0, 1),
+                top 0.2s cubic-bezier(0.2, 0, 0, 1),
+                width 0.2s cubic-bezier(0.2, 0, 0, 1);
+}
+
+/**
+ * Snapped state styles
+ */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom,
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top {
+    border-radius: 0;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-left {
+    border-radius: 0 4px 4px 0;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-right {
+    border-radius: 4px 0 0 4px;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top-left {
+    border-radius: 0 0 4px 0;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top-right {
+    border-radius: 0 0 0 4px;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom-left {
+    border-radius: 0 4px 0 0;
+}
+
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom-right {
+    border-radius: 4px 0 0 0;
+}
+
+div.phpdebugbar[data-positionMode="bottom"] {
+    top: auto;
+    bottom: 0;
+}

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -874,15 +874,85 @@ div.phpdebugbar.phpdebugbar-floating :is(
 }
 
 /**
- * Minimized state
+ * Closed state (clicking Laravel logo icon) - collapse to just the restore button
+ * Override inline dimension styles from snapping/resizing
  */
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-minimized {
-    width: auto;
-    min-width: 200px;
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-closed {
+    width: auto !important;
+    height: auto !important;
+    max-width: none !important;
+    border-radius: 4px !important;
+    border-top: 1px solid var(--debugbar-border) !important;
 }
+
+/* Show the external restore button when closed (override JS inline display:none) */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-closed > a.phpdebugbar-restore-btn {
+    display: block !important;
+}
+
+/**
+ * Minimized state (clicking down arrow) - keep header visible but hide body
+ * Preserves snap width (100%) when snapped to top/bottom
+ */
 
 div.phpdebugbar.phpdebugbar-floating div.phpdebugbar-resize-handle {
     display: block !important;
+}
+
+/**
+ * Resize handles for floating mode (edges and corners)
+ */
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-edge {
+    position: absolute;
+    z-index: 10;
+}
+
+/* Hide resize handles when snapped */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom .phpdebugbar-resize-edge,
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top .phpdebugbar-resize-edge {
+    display: none;
+}
+
+/* Edge handles */
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-n {
+    top: -4px; left: 8px; right: 8px; height: 8px;
+    cursor: ns-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-s {
+    bottom: -4px; left: 8px; right: 8px; height: 8px;
+    cursor: ns-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-e {
+    right: -4px; top: 8px; bottom: 8px; width: 8px;
+    cursor: ew-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-w {
+    left: -4px; top: 8px; bottom: 8px; width: 8px;
+    cursor: ew-resize;
+}
+
+/* Corner handles */
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-ne {
+    top: -4px; right: -4px; width: 12px; height: 12px;
+    cursor: nesw-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-nw {
+    top: -4px; left: -4px; width: 12px; height: 12px;
+    cursor: nwse-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-se {
+    bottom: -4px; right: -4px; width: 12px; height: 12px;
+    cursor: nwse-resize;
+}
+div.phpdebugbar.phpdebugbar-floating .phpdebugbar-resize-sw {
+    bottom: -4px; left: -4px; width: 12px; height: 12px;
+    cursor: nesw-resize;
+}
+
+/* Resizing state */
+div.phpdebugbar.phpdebugbar-floating.phpdebugbar-resizing {
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 /* Remove will-change when not dragging (free GPU memory) */
@@ -937,38 +1007,20 @@ div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapping:not(.phpdebugbar-dragg
 }
 
 /**
- * Snapped state styles
+ * Snapped state styles (bottom and top only)
  */
 div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom,
 div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top {
     border-radius: 0;
 }
 
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-left {
-    border-radius: 0 4px 4px 0;
-}
-
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-right {
-    border-radius: 4px 0 0 4px;
-}
-
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top-left {
-    border-radius: 0 0 4px 0;
-}
-
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-top-right {
-    border-radius: 0 0 0 4px;
-}
-
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom-left {
-    border-radius: 0 4px 0 0;
-}
-
-div.phpdebugbar.phpdebugbar-floating.phpdebugbar-snapped-bottom-right {
-    border-radius: 4px 0 0 0;
-}
 
 div.phpdebugbar[data-positionMode="bottom"] {
     top: auto;
     bottom: 0;
+}
+
+div.phpdebugbar[data-positionMode="top"] {
+    top: 0;
+    bottom: auto;
 }

--- a/tests/FloatingDebugbarBrowserTest.php
+++ b/tests/FloatingDebugbarBrowserTest.php
@@ -1,0 +1,437 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests;
+
+use Illuminate\Routing\Router;
+use Laravel\Dusk\Browser;
+
+class FloatingDebugbarBrowserTest extends BrowserTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['env'] = 'local';
+        $app['config']->set('debugbar.position', 'floating');
+        $app['config']->set('debugbar.floating', [
+            'initial_x' => null,
+            'initial_y' => null,
+            'remember_position' => true,
+        ]);
+
+        /** @var Router $router */
+        $router = $app['router'];
+        $this->addFloatingTestRoutes($router);
+
+        \Orchestra\Testbench\Dusk\Options::withoutUI();
+    }
+
+    protected function addFloatingTestRoutes(Router $router)
+    {
+        $router->get('floating/test', function () {
+            return '<html><head></head><body><h1>Floating Test Page</h1><div id="content">Test content for floating debugbar</div></body></html>';
+        });
+    }
+
+    public function testFloatingModeInitializesCorrectly()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar')
+                ->assertPresent('.phpdebugbar.phpdebugbar-floating')
+                ->assertPresent('.phpdebugbar.phpdebugbar-ready');
+        });
+    }
+
+    public function testDebugbarHasDragHandle()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->assertPresent('.phpdebugbar-header.phpdebugbar-drag-handle');
+        });
+    }
+
+    public function testDebugbarIsDraggable()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            $initialLeft = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            // Step 1: Start drag
+            $browser->script("
+                var header = document.querySelector('.phpdebugbar-header');
+                var rect = header.getBoundingClientRect();
+                window._testDragStartX = rect.left + 50;
+                window._testDragStartY = rect.top + 10;
+
+                var mousedown = new MouseEvent('mousedown', {
+                    bubbles: true, cancelable: true,
+                    clientX: window._testDragStartX, clientY: window._testDragStartY
+                });
+                header.dispatchEvent(mousedown);
+            ");
+
+            $browser->pause(50);
+
+            // Step 2: Move
+            $browser->script("
+                var mousemove = new MouseEvent('mousemove', {
+                    bubbles: true, cancelable: true,
+                    clientX: window._testDragStartX + 100, clientY: window._testDragStartY
+                });
+                document.dispatchEvent(mousemove);
+            ");
+
+            $browser->pause(50);
+
+            // Step 3: End drag
+            $browser->script("
+                var mouseup = new MouseEvent('mouseup', { bubbles: true, cancelable: true });
+                document.dispatchEvent(mouseup);
+            ");
+
+            $browser->pause(100);
+
+            $newLeft = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            $this->assertNotEquals($initialLeft, $newLeft, 'Debugbar should have moved');
+        });
+    }
+
+    public function testClickOnTabsDoesNotInitiateDrag()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            $initialLeft = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            // Use JavaScript click - floating mode positioning makes native clicks unreliable
+            $browser->script("document.querySelector('.phpdebugbar-tab[data-collector=\"messages\"]').click()");
+            $browser->pause(100);
+
+            $afterLeft = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            $this->assertEquals($initialLeft, $afterLeft, 'Position should not change when clicking tabs');
+        });
+    }
+
+    public function testPositionIsSavedToLocalStorage()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            // Simulate drag via JavaScript (necessary for drag operations)
+            $browser->script("
+                var header = document.querySelector('.phpdebugbar-header');
+                var rect = header.getBoundingClientRect();
+
+                var mousedown = new MouseEvent('mousedown', {
+                    bubbles: true, cancelable: true,
+                    clientX: rect.left + 50, clientY: rect.top + 10
+                });
+                header.dispatchEvent(mousedown);
+
+                var mousemove = new MouseEvent('mousemove', {
+                    bubbles: true, cancelable: true,
+                    clientX: rect.left - 100, clientY: rect.top - 50
+                });
+                document.dispatchEvent(mousemove);
+
+                var mouseup = new MouseEvent('mouseup', { bubbles: true, cancelable: true });
+                document.dispatchEvent(mouseup);
+            ");
+
+            $browser->pause(300);
+
+            $saved = $browser->script(
+                'return localStorage.getItem("phpdebugbar_floating_position")'
+            )[0];
+
+            $this->assertNotNull($saved, 'Position should be saved to localStorage');
+
+            $position = json_decode($saved, true);
+            $this->assertArrayHasKey('x', $position);
+            $this->assertArrayHasKey('y', $position);
+        });
+    }
+
+    public function testPositionIsRestoredOnPageLoad()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->script('localStorage.setItem("phpdebugbar_floating_position", JSON.stringify({x: 100, y: 80, snapped: false, snapZone: null, timestamp: Date.now()}))');
+
+            $browser->refresh()
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(300);
+
+            $left = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            $this->assertEqualsWithDelta(100, $left, 20, 'Position should be restored from localStorage');
+        });
+    }
+
+    public function testSnapPreviewAppearsNearEdge()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            // Simulate drag near edge (JavaScript required for drag simulation)
+            $browser->script("
+                var header = document.querySelector('.phpdebugbar-header');
+                var rect = header.getBoundingClientRect();
+
+                var mousedown = new MouseEvent('mousedown', {
+                    bubbles: true, cancelable: true,
+                    clientX: rect.left + 50, clientY: rect.top + 10
+                });
+                header.dispatchEvent(mousedown);
+
+                var mousemove = new MouseEvent('mousemove', {
+                    bubbles: true, cancelable: true,
+                    clientX: 30, clientY: rect.top
+                });
+                document.dispatchEvent(mousemove);
+            ");
+
+            $browser->pause(150);
+
+            $previewExists = $browser->script(
+                'return document.querySelector(".phpdebugbar-snap-preview.phpdebugbar-snap-preview-active") !== null'
+            )[0];
+
+            $browser->script("
+                var mouseup = new MouseEvent('mouseup', { bubbles: true, cancelable: true });
+                document.dispatchEvent(mouseup);
+            ");
+
+            $this->assertTrue($previewExists, 'Snap preview should appear when near edge');
+        });
+    }
+
+    public function testSnapToBottomZoneViaScript()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            $browser->script("
+                if (window.phpdebugbar_draggable) {
+                    window.phpdebugbar_draggable.snapTo('bottom');
+                }
+            ");
+
+            $browser->pause(400);
+
+            $width = $browser->script(
+                'return document.querySelector(".phpdebugbar").style.width'
+            )[0];
+
+            $this->assertEquals('100%', $width, 'Debugbar should snap to full width at bottom');
+        });
+    }
+
+    public function testPositionModeSettingAppears()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(300)
+                ->click('.phpdebugbar-tab-settings')
+                ->pause(800);
+
+            $hasPositionMode = $browser->script(
+                'return document.querySelector("[data-position-mode-field]") !== null'
+            )[0];
+
+            $this->assertTrue($hasPositionMode, 'Position Mode field should appear in settings');
+        });
+    }
+
+    public function testSwitchFromFloatingToBottomMode()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(300)
+                ->click('.phpdebugbar-tab-settings')
+                ->pause(800);
+
+            // Select dropdown value via JavaScript (necessary for custom dropdowns)
+            $browser->script("
+                var select = document.querySelector('[data-position-mode-field] select');
+                if (select) {
+                    select.value = 'bottom';
+                    select.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            ");
+
+            $browser->pause(400);
+
+            $isFloating = $browser->script(
+                'return document.querySelector(".phpdebugbar").classList.contains("phpdebugbar-floating")'
+            )[0];
+
+            $this->assertFalse($isFloating, 'Debugbar should not have floating class after switching to bottom');
+        });
+    }
+
+    public function testDragBoundsAreRespected()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            // Simulate extreme drag via JavaScript
+            $browser->script("
+                var header = document.querySelector('.phpdebugbar-header');
+                var rect = header.getBoundingClientRect();
+
+                var mousedown = new MouseEvent('mousedown', {
+                    bubbles: true, cancelable: true,
+                    clientX: rect.left + 50, clientY: rect.top + 10
+                });
+                header.dispatchEvent(mousedown);
+
+                var mousemove = new MouseEvent('mousemove', {
+                    bubbles: true, cancelable: true,
+                    clientX: -2000, clientY: rect.top
+                });
+                document.dispatchEvent(mousemove);
+
+                var mouseup = new MouseEvent('mouseup', { bubbles: true, cancelable: true });
+                document.dispatchEvent(mouseup);
+            ");
+
+            $browser->pause(100);
+
+            $left = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().left'
+            )[0];
+
+            $width = $browser->script(
+                'return document.querySelector(".phpdebugbar").getBoundingClientRect().width'
+            )[0];
+
+            $this->assertGreaterThan(-$width + 50, $left, 'Debugbar should stay at least 50px visible');
+        });
+    }
+
+    public function testFOUCPreventionStyleIsRemovedAfterReady()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-ready')
+                ->pause(100);
+
+            $foucStyleExists = $browser->script(
+                'return document.getElementById("phpdebugbar-fouc-fix") !== null'
+            )[0];
+
+            $this->assertFalse($foucStyleExists, 'FOUC prevention style should be removed after initialization');
+        });
+    }
+
+    public function testDebugbarHasReadyClassAfterInit()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->assertPresent('.phpdebugbar.phpdebugbar-ready');
+        });
+    }
+
+    public function testSnappedStateIsPersisted()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->script('localStorage.setItem("phpdebugbar_floating_position", JSON.stringify({x: 0, y: 0, snapped: true, snapZone: "bottom", timestamp: Date.now()}))');
+
+            $browser->refresh()
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(400);
+
+            $width = $browser->script(
+                'return document.querySelector(".phpdebugbar").style.width'
+            )[0];
+
+            $this->assertEquals('100%', $width, 'Snapped state should be restored');
+        });
+    }
+
+    public function testMinimizeMaximizeWorksInFloatingMode()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar.phpdebugbar-floating')
+                ->pause(200);
+
+            // Use JavaScript click - floating mode positioning makes native clicks unreliable
+            $browser->script("document.querySelector('.phpdebugbar-minimize-btn').click()");
+            $browser->pause(300);
+
+            $isMinimized = $browser->script(
+                'return document.querySelector(".phpdebugbar").classList.contains("phpdebugbar-minimized")'
+            )[0];
+
+            $this->assertTrue($isMinimized, 'Debugbar should be minimized');
+
+            $browser->script("document.querySelector('.phpdebugbar-maximize-btn').click()");
+            $browser->pause(300);
+
+            $isMinimizedAfter = $browser->script(
+                'return document.querySelector(".phpdebugbar").classList.contains("phpdebugbar-minimized")'
+            )[0];
+
+            $this->assertFalse($isMinimizedAfter, 'Debugbar should not be minimized after restore');
+        });
+    }
+
+    public function testPositionConfigIsInjectedAsInlineScript()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('floating/test')
+                ->waitFor('.phpdebugbar');
+
+            $config = $browser->script(
+                'return window.phpdebugbar_position_config'
+            )[0];
+
+            $this->assertNotNull($config, 'Position config should be available on window');
+            $this->assertEquals('floating', $config['position']);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->script('localStorage.clear()');
+        });
+
+        parent::tearDown();
+    }
+}

--- a/tests/FloatingPositionTest.php
+++ b/tests/FloatingPositionTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Barryvdh\Debugbar\Tests;
+
+use Barryvdh\Debugbar\LaravelDebugbar;
+use Illuminate\Support\Str;
+
+class FloatingPositionTest extends TestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Force the Debugbar to Enable on test/cli applications
+        $app->resolving(LaravelDebugbar::class, function ($debugbar) {
+            $refObject = new \ReflectionObject($debugbar);
+            $refProperty = $refObject->getProperty('enabled');
+            $refProperty->setValue($debugbar, true);
+        });
+    }
+
+    public function testDefaultPositionIsBottom()
+    {
+        $this->app['config']->set('debugbar.position', 'bottom');
+
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $debugbar->boot();
+
+        $renderer = $debugbar->getJavascriptRenderer();
+        $positionConfig = $renderer->getPositionConfig();
+
+        $this->assertEquals('bottom', $positionConfig['position']);
+    }
+
+    public function testFloatingPositionIsConfigurable()
+    {
+        $this->app['config']->set('debugbar.position', 'floating');
+        $this->app['config']->set('debugbar.floating', [
+            'initial_x' => 100,
+            'initial_y' => 200,
+            'remember_position' => true,
+        ]);
+
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $debugbar->boot();
+
+        $renderer = $debugbar->getJavascriptRenderer();
+        $positionConfig = $renderer->getPositionConfig();
+
+        $this->assertEquals('floating', $positionConfig['position']);
+        $this->assertEquals(100, $positionConfig['floating']['initial_x']);
+        $this->assertEquals(200, $positionConfig['floating']['initial_y']);
+        $this->assertTrue($positionConfig['floating']['remember_position']);
+    }
+
+    public function testFloatingOptionsHaveDefaults()
+    {
+        $this->app['config']->set('debugbar.position', 'floating');
+        $this->app['config']->set('debugbar.floating', []);
+
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $debugbar->boot();
+
+        $renderer = $debugbar->getJavascriptRenderer();
+        $positionConfig = $renderer->getPositionConfig();
+
+        $this->assertEquals('floating', $positionConfig['position']);
+        $this->assertNull($positionConfig['floating']['initial_x']);
+        $this->assertNull($positionConfig['floating']['initial_y']);
+        $this->assertTrue($positionConfig['floating']['remember_position']);
+    }
+
+    public function testPositionConfigIsInjectedAsInlineJs()
+    {
+        $this->app['config']->set('debugbar.position', 'floating');
+        $this->app['config']->set('debugbar.floating', [
+            'remember_position' => true,
+        ]);
+
+        $crawler = $this->call('GET', 'web/html');
+
+        // Check that the position config is injected in the response
+        $content = $crawler->content();
+        $this->assertTrue(Str::contains($content, 'window.phpdebugbar_position_config'));
+        $this->assertTrue(Str::contains($content, '"position":"floating"'));
+    }
+
+    public function testSetPositionOptionsMethod()
+    {
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $renderer = $debugbar->getJavascriptRenderer();
+
+        // Test the setPositionOptions method directly
+        $renderer->setPositionOptions('floating', [
+            'initial_x' => 50,
+            'initial_y' => 75,
+            'remember_position' => false,
+        ]);
+
+        $positionConfig = $renderer->getPositionConfig();
+
+        $this->assertEquals('floating', $positionConfig['position']);
+        $this->assertEquals(50, $positionConfig['floating']['initial_x']);
+        $this->assertEquals(75, $positionConfig['floating']['initial_y']);
+        $this->assertFalse($positionConfig['floating']['remember_position']);
+    }
+
+    public function testRememberPositionCanBeDisabled()
+    {
+        $this->app['config']->set('debugbar.position', 'floating');
+        $this->app['config']->set('debugbar.floating', [
+            'remember_position' => false,
+        ]);
+
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $debugbar->boot();
+
+        $renderer = $debugbar->getJavascriptRenderer();
+        $positionConfig = $renderer->getPositionConfig();
+
+        $this->assertFalse($positionConfig['floating']['remember_position']);
+    }
+
+    public function testDraggableJsFileIsRegistered()
+    {
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+        $renderer = $debugbar->getJavascriptRenderer();
+
+        // Get JS assets through reflection
+        $refObject = new \ReflectionObject($renderer);
+        $refProperty = $refObject->getProperty('jsFiles');
+        $jsFiles = $refProperty->getValue($renderer);
+
+        $this->assertArrayHasKey('laravel-draggable', $jsFiles);
+        $this->assertTrue(Str::endsWith($jsFiles['laravel-draggable'], 'draggable.js'));
+    }
+
+    public function testDraggableJsFileExists()
+    {
+        $expectedPath = __DIR__ . '/../src/Resources/draggable.js';
+        $this->assertFileExists($expectedPath);
+    }
+
+    public function testFloatingCssStylesExist()
+    {
+        $cssPath = __DIR__ . '/../src/Resources/laravel-debugbar.css';
+        $cssContent = file_get_contents($cssPath);
+
+        // Check for floating-related CSS classes
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-floating'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-dragging'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-drag-handle'));
+    }
+
+    public function testSnapPreviewCssStylesExist()
+    {
+        $cssPath = __DIR__ . '/../src/Resources/laravel-debugbar.css';
+        $cssContent = file_get_contents($cssPath);
+
+        // Check for snap preview CSS classes
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-snap-preview'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-snap-preview-active'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-snapping'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-snapped-bottom'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-snapped-top'));
+    }
+
+    public function testPositionModeCssStylesExist()
+    {
+        $cssPath = __DIR__ . '/../src/Resources/laravel-debugbar.css';
+        $cssContent = file_get_contents($cssPath);
+
+        $this->assertTrue(Str::contains($cssContent, 'data-positionMode="bottom"'));
+    }
+
+    public function testDraggableJsHasPositionModeFeatures()
+    {
+        $jsPath = __DIR__ . '/../src/Resources/draggable.js';
+        $jsContent = file_get_contents($jsPath);
+
+        // Check that the position mode settings hook code exists
+        $this->assertTrue(Str::contains($jsContent, 'hookSettingsWidget'));
+        $this->assertTrue(Str::contains($jsContent, 'addPositionModeToSettings'));
+        $this->assertTrue(Str::contains($jsContent, 'storePositionMode'));
+        $this->assertTrue(Str::contains($jsContent, 'applyPositionMode'));
+        $this->assertTrue(Str::contains($jsContent, 'Position Mode'));
+    }
+
+    public function testConfigFileHasPositionOption()
+    {
+        $configPath = __DIR__ . '/../config/debugbar.php';
+        $configContent = file_get_contents($configPath);
+
+        $this->assertTrue(Str::contains($configContent, "'position'"));
+        $this->assertTrue(Str::contains($configContent, "'floating'"));
+        $this->assertTrue(Str::contains($configContent, "'initial_x'"));
+        $this->assertTrue(Str::contains($configContent, "'initial_y'"));
+        $this->assertTrue(Str::contains($configContent, "'remember_position'"));
+    }
+
+    public function testNoConfigInjectedForBottomPosition()
+    {
+        // When position is 'bottom' (default), config should still be injected
+        // but the floating class should not be added
+        $this->app['config']->set('debugbar.position', 'bottom');
+
+        $crawler = $this->call('GET', 'web/html');
+
+        $content = $crawler->content();
+        // Config should still be present
+        $this->assertTrue(Str::contains($content, 'window.phpdebugbar_position_config'));
+        // But should indicate 'bottom' position
+        $this->assertTrue(Str::contains($content, '"position":"bottom"'));
+    }
+}

--- a/tests/FloatingPositionTest.php
+++ b/tests/FloatingPositionTest.php
@@ -219,4 +219,15 @@ class FloatingPositionTest extends TestCase
         // But should indicate 'bottom' position
         $this->assertTrue(Str::contains($content, '"position":"bottom"'));
     }
+
+    public function testFloatingClosedStateCssStylesExist()
+    {
+        $cssPath = __DIR__ . '/../src/Resources/laravel-debugbar.css';
+        $cssContent = file_get_contents($cssPath);
+
+        // Check for floating closed state CSS rules
+        // These ensure the closed floating debugbar shows only a small icon
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-floating.phpdebugbar-closed'));
+        $this->assertTrue(Str::contains($cssContent, '.phpdebugbar-floating.phpdebugbar-closed > a.phpdebugbar-restore-btn'));
+    }
 }


### PR DESCRIPTION
## Add Floating/Draggable Position Mode

### Summary

This PR introduces a new `floating` position mode that allows users to drag the debugbar anywhere on the screen, providing a more flexible debugging experience especially when working with full-height layouts or when the bottom-fixed debugbar obscures important UI elements.

### Motivation

The current debugbar is fixed to the bottom of the viewport, which can be problematic when:
- Debugging layouts with important content at the bottom of the screen
- Working with full-height applications where the debugbar covers content
- Preferring to keep the debugbar in a corner while developing
- Using smaller screens where the fixed bar takes up valuable space

### Features

| Feature | Description |
|---------|-------------|
| **Drag & Drop** | Drag the debugbar anywhere on screen via the header |
| **Snap Zones** | Snap to edges and corners with visual preview (8 zones) |
| **Position Memory** | Position persists in localStorage across page loads |
| **Touch Support** | Full support for touch devices |
| **Settings Toggle** | Switch between modes via Settings panel dropdown |
| **FOUC Prevention** | Smooth initialization without flash of unstyled content |
| **Viewport Bounds** | Debugbar stays within visible viewport |
| **Minimize/Maximize** | Fully compatible with existing minimize functionality |

### Configuration

```php
// config/debugbar.php

'position' => 'floating', // 'bottom' (default) or 'floating'

'floating' => [
    'initial_x' => null,         // Initial X position (null = bottom-right)
    'initial_y' => null,         // Initial Y position (null = bottom-right)
    'remember_position' => true, // Persist position in localStorage
],
```

### Snap Zones

When dragging near screen edges, users see a preview of where the debugbar will snap:

| Zone | Behavior |
|------|----------|
| **Bottom** | Full-width, fixed to bottom (like default mode) |
| **Top** | Full-width, fixed to top |
| **Left/Right** | Half-width, full-height sidebar |
| **Corners** | Quarter-screen in each corner |

### Technical Implementation

- **New file**: `src/Resources/draggable.js` (766 lines) - Standalone draggable functionality
- **CSS additions**: Floating mode styles, snap preview, transitions
- **PHP integration**: Position config injection, JS asset registration
- **Performance**: Throttled snap detection, RAF-based updates, optimized event handling

### Screenshots

<!-- Add screenshots/GIF demonstrating: -->
<!-- 1. Dragging the debugbar -->
<!-- 2. Snap preview appearing near edges -->
<!-- 3. Settings panel with Position Mode dropdown -->
<!-- 4. Snapped states (bottom, corner, sidebar) -->

### Testing

- **Unit tests**: `FloatingPositionTest.php` (14 tests)
  - Configuration options
  - Default values
  - Position config injection
  - CSS/JS file registration

- **Browser tests**: `FloatingDebugbarBrowserTest.php` (16 tests)
  - Floating mode initialization
  - Drag functionality
  - Position persistence
  - Snap zones and preview
  - Settings panel integration
  - FOUC prevention
  - Minimize/maximize compatibility

```bash
# Run tests
./vendor/bin/phpunit tests/FloatingPositionTest.php tests/FloatingDebugbarBrowserTest.php
```

### Breaking Changes

**None.** Default behavior remains unchanged (`'position' => 'bottom'`).

### Checklist

- [x] Code follows existing project conventions
- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Documentation updated in README
- [x] No console.log/debug statements in production code
- [x] Works with existing minimize/maximize functionality
- [x] Touch device support included
- [x] FOUC prevention implemented
- [x] Position respects viewport bounds

<img width="1473" height="1014" alt="Screenshot 2025-12-26 at 5 08 43 PM" src="https://github.com/user-attachments/assets/bf720eb6-d1cc-4b7d-b60a-e4548c05af8f" />

<img width="734" height="526" alt="Screenshot 2025-12-26 at 5 08 54 PM" src="https://github.com/user-attachments/assets/4949d6a2-c1be-47ec-9ecb-7a3696097ecc" />

<img width="737" height="533" alt="Screenshot 2025-12-26 at 5 09 10 PM" src="https://github.com/user-attachments/assets/8635cd54-6691-4354-bedb-c4949e52d078" />

<img width="736" height="515" alt="Screenshot 2025-12-26 at 5 09 29 PM" src="https://github.com/user-attachments/assets/e37b26a5-cf9c-4e52-8475-e60d40e082e1" />



