### PR TITLE
Fix null handling quoting in emulateQuote[QueryCollector]

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -189,7 +189,7 @@ class QueryCollector extends PDOCollector
         $search = ["\\",  "\x00", "\n",  "\r",  "'",  '"', "\x1a"];
         $replace = ["\\\\","\\0","\\n", "\\r", "\'", '\"', "\\Z"];
 
-        return "'" . str_replace($search, $replace, (string) $value) . "'";
+        return "'" . str_replace($search, $replace, $value) . "'";
     }
 
     /**
@@ -606,7 +606,7 @@ class QueryCollector extends PDOCollector
                         : "/:{$key}(?=(?:[^'\\\']*'[^'\\\']*')*[^'\\\']*$)/";
 
                     // Mimic bindValue and only quote non-integer and non-float data types
-                    if (!is_int($binding) && !is_float($binding)) {
+                    if (!is_int($binding) && !is_float($binding) && !is_null($binding)) {
                         if ($pdo) {
                             try {
                                 $binding = $pdo->quote((string) $binding);
@@ -618,7 +618,7 @@ class QueryCollector extends PDOCollector
                         }
                     }
 
-                    $sql = preg_replace($regex, addcslashes($binding, '$'), $sql, 1);
+                    $sql = preg_replace($regex, addcslashes($binding ?? 'NULL', '$'), $sql, 1);
                 }
             }
         }


### PR DESCRIPTION
The cast is not needed anymore after arg data type
https://github.com/barryvdh/laravel-debugbar/blob/97a58b3138c6784c3b8fa01d89daf3301732cd93/src/DataCollector/QueryCollector.php#L221
Also it give me
`QueryCollector::emulateQuote(): Argument #1 ($value) must be of type string, null given, called in /var/www/vendor/barryvdh/laravel-debugbar/src/DataCollector/QueryCollector.php on line 617`
https://github.com/barryvdh/laravel-debugbar/blob/97a58b3138c6784c3b8fa01d89daf3301732cd93/src/DataCollector/QueryCollector.php#L664-L666

Review on #1828