### PR TITLE
ui: add index to executed queries list

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -485,7 +485,7 @@ class QueryCollector extends PDOCollector
         $queries = $this->queries;
 
         $statements = [];
-        foreach ($queries as $query) {
+        foreach ($queries as $index => $query) {
             $source = reset($query['source']);
             $normalizedPath = is_object($source) ? $this->normalizeFilePath($source->file ?: '') : '';
             if ($query['type'] != 'transaction' && Str::startsWith($normalizedPath, $this->excludePaths)) {
@@ -506,6 +506,7 @@ class QueryCollector extends PDOCollector
             };
 
             $statements[] = [
+                'index' => $index,
                 'sql' => $this->getSqlQueryToDisplay($query),
                 'type' => $query['type'],
                 'params' => [],

--- a/src/Resources/laravel-debugbar.css
+++ b/src/Resources/laravel-debugbar.css
@@ -418,6 +418,17 @@ ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widget
     max-width: 100%;
 }
 
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-index {
+    margin-right: 10px;
+    display: inline-block;
+    border-right-width: 1px;
+    border-right-style: solid;
+    border-right-color: rgba(127,127,127,0.4);
+    color: gray;
+    min-width: 40px;
+    text-align: center;
+}
+
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-copy-clipboard,
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-duration,
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item .phpdebugbar-widgets-stmt-id,

--- a/src/Resources/queries/widget.js
+++ b/src/Resources/queries/widget.js
@@ -234,6 +234,9 @@
                 if (statement.slow) {
                     $li.addClass(csscls('sql-slow'));
                 }
+
+                $li.prepend($('<span />').addClass(csscls('index')).text(statement.index));
+
                 const $code = $('<code />').html(PhpDebugBar.Widgets.highlight(statement.sql, 'sql')).addClass(csscls('sql')),
                     duplicated = this.duplicateQueries.has(statement);
                 $li.attr('data-connection', statement.connection)


### PR DESCRIPTION
Add index column to query list for better readability

When many queries are executed, it’s difficult to reference
a specific query. This change adds a sequential index to each
query row to improve clarity and debugging experience.