### PR TITLE
Bring back logs collector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -49,6 +49,7 @@ return [
         'mail'            => env('DEBUGBAR_COLLECTORS_MAIL', true),             // Catch mail messages
         'laravel'         => env('DEBUGBAR_COLLECTORS_LARAVEL', true),          // Laravel version and environment
         'events'          => env('DEBUGBAR_COLLECTORS_EVENTS', false),          // All events fired
+        'logs'            => env('DEBUGBAR_COLLECTORS_LOGS', false),            // Add the latest log messages
         'config'          => env('DEBUGBAR_COLLECTORS_CONFIG', false),          // Display config settings
         'cache'           => env('DEBUGBAR_COLLECTORS_CACHE', true),            // Display cache events
         'models'          => env('DEBUGBAR_COLLECTORS_MODELS', true),           // Display models
@@ -132,6 +133,9 @@ return [
         'events' => [
             'data' => env('DEBUGBAR_OPTIONS_EVENTS_DATA', false), // Collect events data, listeners
             'excluded' => [], // Example: ['eloquent.*', 'composing', Illuminate\Cache\Events\CacheHit::class]
+        ],
+        'logs' => [
+            'file' => env('DEBUGBAR_OPTIONS_LOGS_FILE'),
         ],
         'cache' => [
             'values' => env('DEBUGBAR_OPTIONS_CACHE_VALUES', true), // Collect cache values

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -20,6 +20,7 @@ use Barryvdh\Debugbar\CollectorProviders\JobsCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\LaravelCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\LivewireCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\LogCollectorProvider;
+use Barryvdh\Debugbar\CollectorProviders\LogsCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\MailCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\MemoryCollectorProvider;
 use Barryvdh\Debugbar\CollectorProviders\MessagesCollectorProvider;
@@ -203,6 +204,7 @@ class LaravelDebugbar extends DebugBar
             'views' => ViewsCollectorProvider::class,
             'route' => RouteCollectorProvider::class,
             'log' => LogCollectorProvider::class,
+            'logs' => LogsCollectorProvider::class,
             'db' => DatabaseCollectorProvider::class,
             'models' => ModelsCollectorProvider::class,
             'livewire' => LivewireCollectorProvider::class,


### PR DESCRIPTION
This collector was removed in #1846, 
But the provider was created; I'm assuming it was removed by mistake, since the entire collector is still there.

https://github.com/barryvdh/laravel-debugbar/blob/0b6127228d80fc90e44f1dc90bfdc00d162e09e4/readme.md?plain=1#L29