### PR TITLE
Update message handling in GateCollector

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -25,6 +25,7 @@ class GateCollector extends MessagesCollector
     public function __construct(Gate $gate, Router $router)
     {
         parent::__construct('gate');
+        $this->compactDumps = true;
         $this->router = $router;
         $this->setDataFormatter(new SimpleFormatter());
         $gate->after(function ($user, $ability, $result, $arguments = []) {
@@ -35,17 +36,16 @@ class GateCollector extends MessagesCollector
     /**
      * {@inheritDoc}
      */
-    protected function customizeMessageHtml(?string $messageHtml, mixed $message): ?string
+    protected function compactMessageDump(?string $messageHtml): ?string
     {
         $pos = strpos((string) $messageHtml, 'array:5');
-        if ($pos !== false) {
+        preg_match('/.*>\s*ability\s*<.*<span class=sf-dump-str\b[^>]*>([^<]+)<\/span>/i', (string) $messageHtml, $match);
 
-            $name = $message['ability'] . ' ' . ($message['target'] ?? '');
-
-            $messageHtml = substr_replace($messageHtml, $name, $pos, 7);
+        if ($pos !== false && isset($match[1])) {
+            $messageHtml = substr_replace($messageHtml, $match[1], $pos, 7);
         }
 
-        return parent::customizeMessageHtml($messageHtml, $message);
+        return parent::compactMessageDump($messageHtml);
     }
 
     public function addCheck(mixed $user, string $ability, mixed $result, array $arguments = []): void


### PR DESCRIPTION
- https://github.com/php-debugbar/php-debugbar/pull/903#issuecomment-3719185545

`customizeMessageHtml` was apparently used to assign the ability as the main message instead of `array:5`. Changing the method name loses this functionality, and it also doesn't execute without `compactDumps`. Any other solutions?