### PR TITLE
Fix explain option access in DatabaseCollectorProvider

### DIFF
--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -49,7 +49,7 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
             $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
         }
 
-        if ($options['explain.enabled'] ?? false) {
+        if ($options['explain']['enabled'] ?? false) {
             $queryCollector->setExplainSource(true);
         }
 


### PR DESCRIPTION
Maybe just `'explain' => true/false` on config