### PR TITLE
Make 'explain' option default

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -97,9 +97,6 @@ return [
             'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
             'timeline'          => env('DEBUGBAR_OPTIONS_DB_TIMELINE', false),  // Add the queries to the timeline
             'duration_background'  => env('DEBUGBAR_OPTIONS_DB_DURATION_BACKGROUND', true),   // Show shaded background on each query relative to how long it took to execute.
-            'explain' => [                 // Show EXPLAIN output on queries
-                'enabled' => env('DEBUGBAR_OPTIONS_DB_EXPLAIN_ENABLED', false),
-            ],
             'hints'             => env('DEBUGBAR_OPTIONS_DB_HINTS', false),          // Show hints for common mistakes
             'only_slow_queries' => env('DEBUGBAR_OPTIONS_DB_ONLY_SLOW_QUERIES', true), // Only track queries that last longer than `slow_threshold`
             'slow_threshold'    => env('DEBUGBAR_OPTIONS_DB_SLOW_THRESHOLD', false), // Max query execution time (ms). Exceeding queries will be highlighted

--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -49,10 +49,6 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
             $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
         }
 
-        if ($options['explain.enabled'] ?? false) {
-            $queryCollector->setExplainSource(true);
-        }
-
         $this->addCollector($queryCollector);
 
         try {

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -29,7 +29,6 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider
     protected ?int $lastMemoryUsage = null;
     protected bool|int $findSource = false;
     protected array $middleware = [];
-    protected bool $explainQuery = false;
     protected array $explainTypes = ['SELECT']; // ['SELECT', 'INSERT', 'UPDATE', 'DELETE']; for MySQL 5.6.3+
     protected array $reflection = [];
     protected array $excludePaths = [];
@@ -117,14 +116,6 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider
     public function isSqlRenderedWithParams(): bool
     {
         return $this->renderSqlWithParams;
-    }
-
-    /**
-     * Enable/disable the EXPLAIN queries
-     */
-    public function setExplainSource(bool $enabled): void
-    {
-        $this->explainQuery = $enabled;
     }
 
     public function startMemoryUsage(): void
@@ -414,7 +405,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider
                 'source' => $source,
                 'xdebug_link' => is_object($source) ? $this->getXdebugLink($source->file ?: '', $source->line) : null,
                 'connection' => $connectionName,
-                'explain' => $this->explainQuery && $canExplainQuery ? [
+                'explain' => $canExplainQuery ? [
                     'url' => route('debugbar.queries.explain'),
                     'driver' => $query['driver'],
                     'connection' => $query['connection']->getName(),


### PR DESCRIPTION
- Alternative to #1879

https://github.com/fruitcake/laravel-debugbar/pull/1879#issuecomment-3740573610
>Furthermore, after the last optimization, the explain function no longer runs automatically; now a button is used. In my opinion, it should always be active.