### PR TITLE
Fix checkVersion accessibility

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -783,7 +783,7 @@ class LaravelDebugbar extends DebugBar
     /**
      * Check the version of Laravel
      */
-    protected function checkVersion(string $version, string $operator = ">="): bool
+    public function checkVersion(string $version, string $operator = ">="): bool
     {
         return version_compare($this->version, $version, $operator);
     }


### PR DESCRIPTION
`checkVersion` was used to maintain compatibility between different versions of Laravel. Now that each collector has its own provider, it should be public so it can be used if needed.