### PR TITLE
Separate the debugbar from the application load(TimeCollector)

### DIFF
--- a/src/CollectorProviders/TimeCollectorProvider.php
+++ b/src/CollectorProviders/TimeCollectorProvider.php
@@ -39,8 +39,6 @@ class TimeCollectorProvider extends AbstractCollectorProvider
             );
         }
 
-        $timeCollector->startMeasure('application', 'Application', 'time');
-
         $events->listen(Routing::class, fn() => $timeCollector->startMeasure('Routing'));
         $events->listen(RouteMatched::class, fn() => $timeCollector->stopMeasure('Routing'));
 

--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -150,6 +150,8 @@ class LaravelDebugbar extends DebugBar
 
         /** @var Repository $config */
         $config = $this->app->get(Repository::class);
+        $timeStart = microtime(true);
+        $memoryStart = memory_get_usage(false);
 
         $this->editorTemplate = $config->get('debugbar.editor') ?: $config->get('app.editor');
         $this->remotePathReplacements = $this->getRemoteServerReplacements();
@@ -188,6 +190,13 @@ class LaravelDebugbar extends DebugBar
         $this->registerCollectors();
 
         $this->booted = true;
+        
+        if ($this->hasCollector('time')) {
+            /** @var \DebugBar\DataCollector\TimeDataCollector $timeCollector */
+            $timeCollector = $this['time'];
+            $timeCollector->addMeasure('Debugbar Load', $timeStart, microtime(true), ['memoryUsage' => memory_get_usage(false) - $memoryStart], 'time');
+            $timeCollector->startMeasure('application', 'Application', 'time');
+        }
     }
 
     protected function registerCollectors(): void


### PR DESCRIPTION
This is a proof of concept; it may need more work.

<img width="552" height="60" alt="image" src="https://github.com/user-attachments/assets/6cab9a4e-75a0-456d-bfb0-355437eb941b" />

I've noticed that the debugbar can take up to a third of the application's load time. Would it be a good idea to try to differentiate the time the debugbar takes from the application's load time?