### PR TITLE
Tweak ClearCommand for uninstall

### DIFF
--- a/src/Console/ClearCommand.php
+++ b/src/Console/ClearCommand.php
@@ -2,6 +2,7 @@
 
 namespace Barryvdh\Debugbar\Console;
 
+use Barryvdh\Debugbar\LaravelDebugbar;
 use DebugBar\DebugBar;
 use Illuminate\Console\Command;
 
@@ -9,20 +10,13 @@ class ClearCommand extends Command
 {
     protected $name = 'debugbar:clear';
     protected $description = 'Clear the Debugbar Storage';
-    protected $debugbar;
 
-    public function __construct(DebugBar $debugbar)
+
+    public function handle(LaravelDebugbar $debugbar)
     {
-        $this->debugbar = $debugbar;
+        $debugbar->boot();
 
-        parent::__construct();
-    }
-
-    public function handle()
-    {
-        $this->debugbar->boot();
-
-        if ($storage = $this->debugbar->getStorage()) {
+        if ($storage = $debugbar->getStorage()) {
             try {
                 $storage->clear();
             } catch (\InvalidArgumentException $e) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Barryvdh\Debugbar;
 
+use Barryvdh\Debugbar\Console\ClearCommand;
 use Barryvdh\Debugbar\Middleware\InjectDebugbar;
 use DebugBar\DataFormatter\DataFormatter;
 use DebugBar\DataFormatter\DataFormatterInterface;
@@ -41,13 +42,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->app->alias(LaravelDebugbar::class, 'debugbar');
 
-        $this->app->singleton(
-            'command.debugbar.clear',
-            function ($app) {
-                return new Console\ClearCommand($app['debugbar']);
-            }
-        );
-
         Collection::macro('debug', function () {
             debug($this);
             return $this;
@@ -68,7 +62,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         $this->registerMiddleware(InjectDebugbar::class);
 
-        $this->commands(['command.debugbar.clear']);
+        $this->commands([ClearCommand::class]);
     }
 
     /**


### PR DESCRIPTION
Fixes uninstall error.

> > Illuminate\Foundation\ComposerScripts::prePackageUninstall
> Script Illuminate\Foundation\ComposerScripts::prePackageUninstall handling the pre-package-uninstall event terminated with an exception
> 
> In ProcessDriver.php line 46:
>                                                           
>   Concurrent process failed with exit code [1]. Message:  
                                                          
Work-around: add `--no-scripts` to your uninstall.
