### PR TITLE
Fix explain table css on queries widget

### DIFF
--- a/resources/laravel-debugbar.css
+++ b/resources/laravel-debugbar.css
@@ -300,6 +300,10 @@ div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain th {
     padding: 0 5px
 }
 
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain td {
+    color: var(--debugbar-text-muted);
+}
+
 ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:nth-child(even) table.phpdebugbar-widgets-explain th {
     background-color: var(--debugbar-background);
 }

--- a/resources/laravel-debugbar.css
+++ b/resources/laravel-debugbar.css
@@ -291,8 +291,21 @@ div.phpdebugbar-widgets-sqlqueries button.phpdebugbar-widgets-explain-btn {
     color: #fff;
 }
 
+div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain {
+    width: 100%;
+}
+
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain th {
-    border: 1px solid var(--debugbar-border);
+    border-botton: 1px solid var(--debugbar-border);
+    padding: 0 5px
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:nth-child(even) table.phpdebugbar-widgets-explain th {
+    background-color: var(--debugbar-background);
+}
+
+ul.phpdebugbar-widgets-list li.phpdebugbar-widgets-list-item:nth-child(odd) table.phpdebugbar-widgets-explain th {
+    background-color: var(--debugbar-background-alt);
 }
 
 div.phpdebugbar-widgets-sqlqueries a.phpdebugbar-widgets-visual-explain:after {


### PR DESCRIPTION
Fix headers padding
Fix even/odd headers color(before it was like that)

<img width="202" height="85" alt="image" src="https://github.com/user-attachments/assets/a9e775b9-bd28-43dc-998b-908cb7d5f008" />

.


<img width="153" height="70" alt="image" src="https://github.com/user-attachments/assets/ed9ea03c-c6b4-4ff6-a45e-f4ec778a8028" />
