### PR TITLE
Update onCacheEvent to accept multiple event types

### DIFF
--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -54,7 +54,7 @@ class CacheCollector extends TimeDataCollector implements AssetProvider, Resetta
         return $this->classMap;
     }
 
-    public function onCacheEvent(CacheEvent $event): void
+    public function onCacheEvent(CacheEvent|CacheFailedOver|CacheFlushed|CacheFlushFailed|CacheFlushing $event): void
     {
         $class = get_class($event);
         $params = get_object_vars($event);


### PR DESCRIPTION
This fixes https://github.com/fruitcake/laravel-debugbar/issues/1942

The reason these classes (specifically the flush-related ones) do not extend CacheEvent is that CacheEvent requires a $key property in its constructor, whereas flush operations typically affect the entire store or tags rather than a specific key. CacheFailedOver also has a different structure, focusing on the store name and the exception encountered.