### PR TITLE
Change bindings return value on limited

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -159,7 +159,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
         }
 
         $bindings = match (true) {
-            $limited && filled($query->bindings) => [],
+            $limited && filled($query->bindings) => null,
             default => $query->connection->prepareBindings($query->bindings),
         };
 


### PR DESCRIPTION
https://github.com/fruitcake/laravel-debugbar/blob/6e919fe5c94016d06b2e450475823bc334088e09/src/DataCollector/QueryCollector.php#L401-L402

Null is needed for avoid explain error `$query['bindings'] !== null`

<img width="413" height="26" alt="image" src="https://github.com/user-attachments/assets/d321786c-722d-4c8d-99ee-4bb661257a42" />

This problem occurs when `soft_limit` is set; the bindings are no longer collected, so `explain` fails.