### PR TITLE
Handle missing bindings in SQL formatting

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -543,7 +543,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
                 // ignore error for non-pdo laravel drivers
             }
 
-            $sql = $this->getQueryFormatter()->formatSqlWithBindings($sql, $query['bindings'], $pdo);
+            $sql = $this->getQueryFormatter()->formatSqlWithBindings($sql, $query['bindings'] ?? [], $pdo);
         }
 
         return $this->getQueryFormatter()->formatSql($sql);


### PR DESCRIPTION
it could be null, must be an array
[php-debugbar/src/DataFormatter/QueryFormatter.php#L80](https://github.com/php-debugbar/php-debugbar/blob/f52f0f148a6cc32b4a16c00ce74f369b81bea378/src/DataFormatter/QueryFormatter.php#L80)

```
DebugBar\DataFormatter\QueryFormatter::formatSqlWithBindings():
    Argument #2 ($bindings) must be of type array, null given,
called in:
     /var/www/vendor/fruitcake/laravel-debugbar/src/DataCollector/QueryCollector.php on line 546
```