### PR TITLE
chore: replace deprecated Request::get() with Request::input()

### DIFF
--- a/src/Controllers/AssetController.php
+++ b/src/Controllers/AssetController.php
@@ -16,7 +16,7 @@ class AssetController extends BaseController
     {
         $assetHandler = new AssetHandler($this->debugbar);
 
-        $type = (string) $request->get('type');
+        $type = (string) $request->input('type');
 
         $response = new Response();
         $driver = $this->debugbar->getHttpDriver();

--- a/src/Controllers/CacheController.php
+++ b/src/Controllers/CacheController.php
@@ -20,7 +20,7 @@ class CacheController extends BaseController
         }
 
         if ($request->has('tags')) {
-            $cache = $cache->tags($request->get('tags'));
+            $cache = $cache->tags($request->input('tags'));
         }
 
         $success = $cache->forget($key);


### PR DESCRIPTION
Hello!

The `Request::get()` method has been deprecated and is generating the following logs: `Since symfony/http-foundation 7.4: Request::get() is deprecated, use properties ->attributes, query or request directly instead. in /var/www/eaglesys/releases/255/vendor/symfony/deprecation-contracts/function.php on line 25
`

Thanks!