### PR TITLE
Cast LARAVEL_START const to float

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -215,7 +215,7 @@ class LaravelDebugbar extends DebugBar
 
     public function booted(): void
     {
-        $startTime = defined('LARAVEL_START') ? LARAVEL_START : null;
+        $startTime = defined('LARAVEL_START') ? (float) LARAVEL_START : null;
         if ($startTime) {
             $this->addMeasure('Booting', $startTime, microtime(true));
         }


### PR DESCRIPTION
LARAVEL_START constant may be a string, for example when configured by PHPUnit configuration file:
```xml
<env name="DEBUGBAR_ENABLED" value="false"/>
<const name="LARAVEL_START" value="0"/>
```
This leads to following error:
<img width="1280" height="308" alt="image" src="https://github.com/user-attachments/assets/c4c8ba35-7a95-40cb-987b-08f7521c1949" />

Note that disabling Debugbar doesn't help because exception is thrown in `LaravelDebugbar` class constructor.

This PR enforces casting LARAVEL_START constant to a float.