### PR TITLE
GateCollector backtrace need more steps

### DIFF
--- a/src/DataCollector/GateCollector.php
+++ b/src/DataCollector/GateCollector.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Str;
 class GateCollector extends MessagesCollector implements Resettable
 {
     protected array $reflection = [];
+    protected int $backtraceLimit = 20;
 
     public function addCheck(mixed $user, string|int $ability, mixed $result, array $arguments = []): void
     {


### PR DESCRIPTION

I've noticed that almost all my calls require a limit of 18; I've rounded it up to 20 because it seems sufficient. 
Limit 15 doesn't work since `src/CollectorProviders/GateCollectorProvider.php` was added.