### PR TITLE
Add masked keys to ConfigCollector

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -144,6 +144,9 @@ return [
         'logs' => [
             'file' => env('DEBUGBAR_OPTIONS_LOGS_FILE'),
         ],
+        'config' => [
+            'masked' => [],
+        ],
         'cache' => [
             'values' => env('DEBUGBAR_OPTIONS_CACHE_VALUES', true), // Collect cache values
             'timeline' => env('DEBUGBAR_OPTIONS_CACHE_TIMELINE', false),  // Add mails to the timeline

--- a/src/CollectorProviders/ConfigCollectorProvider.php
+++ b/src/CollectorProviders/ConfigCollectorProvider.php
@@ -11,7 +11,7 @@ class ConfigCollectorProvider extends AbstractCollectorProvider
     public function __invoke(array $options): void
     {
         $configCollector = new ConfigCollector();
-        $masked = ['key', 'previous_keys'];
+        $masked = ['app.key', 'app.previous_keys', '*.*_key', '*.*apikey'];
         $configCollector->addMaskedKeys(array_merge($masked, $options['masked'] ?? []));
         $this->addCollector($configCollector);
     }

--- a/src/CollectorProviders/ConfigCollectorProvider.php
+++ b/src/CollectorProviders/ConfigCollectorProvider.php
@@ -11,6 +11,8 @@ class ConfigCollectorProvider extends AbstractCollectorProvider
     public function __invoke(array $options): void
     {
         $configCollector = new ConfigCollector();
+        $masked = ['key', 'previous_keys'];
+        $configCollector->addMaskedKeys(array_merge($masked, $options['masked'] ?? []));
         $this->addCollector($configCollector);
     }
 }


### PR DESCRIPTION
I believe they should be hidden as sensitive data

[laravel/laravel/config/app.php#L100-L106](https://github.com/laravel/laravel/blob/41e7b8f00c1a5c7801a47fb42b51c30c27344e0e/config/app.php#L100-L106)
```php
'key' => env('APP_KEY'),
'previous_keys' => [
    ///
```
**UPDATE:**
After https://github.com/php-debugbar/php-debugbar/pull/1006, a wider mask range was added

[laravel/passport/config/passport.php#L31-L33](https://github.com/laravel/passport/blob/c40cefb47900199340ff101f4555ee20716349bd/config/passport.php#L31-L33)
```php
'private_key' => env('PASSPORT_PRIVATE_KEY'),
'public_key' => env('PASSPORT_PUBLIC_KEY'),
```
  
