### PR TITLE
Catch serialization errors when populating cache stats

### DIFF
--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -23,6 +23,7 @@ use Illuminate\Cache\Events\{CacheEvent,
     RetrievingKey,
     WritingKey};
 use Illuminate\Support\Facades\Route;
+use Throwable;
 
 class CacheCollector extends TimeDataCollector implements AssetProvider, Resettable
 {
@@ -63,7 +64,10 @@ class CacheCollector extends TimeDataCollector implements AssetProvider, Resetta
         $label = $this->classMap[$class][0];
 
         if (isset($params['value'])) {
-            $params['memoryUsage'] = strlen(serialize($params['value'])) * 8;
+            try {
+                $params['memoryUsage'] = strlen(serialize($params['value'])) * 8;
+            } catch (Throwable) {
+            }
 
             if (!$this->collectValues) {
                 unset($params['value']);


### PR DESCRIPTION
Serialization added in 5930bca should have been checking for errors (e.g. with `Closure`s.) This fixes that oversight.