### PR TITLE
Simplify explain option on config

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -103,9 +103,7 @@ return [
             'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
             'timeline'          => env('DEBUGBAR_OPTIONS_DB_TIMELINE', false),  // Add the queries to the timeline
             'duration_background'  => env('DEBUGBAR_OPTIONS_DB_DURATION_BACKGROUND', true),   // Show shaded background on each query relative to how long it took to execute.
-            'explain' => [                 // Show EXPLAIN output on queries
-                'enabled' => env('DEBUGBAR_OPTIONS_DB_EXPLAIN_ENABLED', true),
-            ],
+            'explain'           => env('DEBUGBAR_OPTIONS_DB_EXPLAIN_ENABLED', true), // Show EXPLAIN output on queries
             'show_query_result' => env('DEBUGBAR_OPTIONS_DB_SHOW_QUERY_RESULT', false), // Show option to re-run SELECT queries and show the result
             'only_slow_queries' => env('DEBUGBAR_OPTIONS_DB_ONLY_SLOW_QUERIES', true), // Only track queries that last longer than `slow_threshold`
             'slow_threshold'    => env('DEBUGBAR_OPTIONS_DB_SLOW_THRESHOLD', false), // Max query execution time (ms). Exceeding queries will be highlighted

--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -48,7 +48,7 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
             $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
         }
 
-        if (($options['explain']['enabled'] ?? false) && $this->debugbar->isStorageOpen($request)) {
+        if (($options['explain']['enabled'] ?? ($options['explain'] ?? false)) === true && $this->debugbar->isStorageOpen($request)) {
             $queryCollector->setExplainQuery(true);
         }
 

--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -48,7 +48,7 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
             $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
         }
 
-        if (($options['explain']['enabled'] ?? ($options['explain'] ?? false)) === true && $this->debugbar->isStorageOpen($request)) {
+        if (($options['explain'] ?? false) === true && $this->debugbar->isStorageOpen($request)) {
             $queryCollector->setExplainQuery(true);
         }
 

--- a/src/Controllers/QueriesController.php
+++ b/src/Controllers/QueriesController.php
@@ -33,7 +33,7 @@ class QueriesController
             ]);
         }
 
-        if (!config('debugbar.options.db.explain.enabled', false) || !$debugbar->isStorageOpen($request)) {
+        if ((!config('debugbar.options.db.explain.enabled', false) && config('debugbar.options.db.explain', false) !== true) || !$debugbar->isStorageOpen($request)) {
             return response()->json([
                 'success' => false,
                 'message' => 'EXPLAIN is currently disabled in the Debugbar.',

--- a/src/Controllers/QueriesController.php
+++ b/src/Controllers/QueriesController.php
@@ -33,7 +33,7 @@ class QueriesController
             ]);
         }
 
-        if ((!config('debugbar.options.db.explain.enabled', false) && config('debugbar.options.db.explain', false) !== true) || !$debugbar->isStorageOpen($request)) {
+        if (config('debugbar.options.db.explain') !== true || !$debugbar->isStorageOpen($request)) {
             return response()->json([
                 'success' => false,
                 'message' => 'EXPLAIN is currently disabled in the Debugbar.',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -62,6 +62,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return;
         }
 
+        if (config('debugbar.options.db.explain.enabled', false)) { // fallback for old config
+            config(['debugbar.options.db.explain' => true]);
+        }
+
         $this->loadRoutesFrom(__DIR__ . '/debugbar-routes.php');
         // Resolve the LaravelDebugbar instance during boot to force it to be loaded in the Octane sandbox
         try {

--- a/tests/Controllers/QueriesControllerTest.php
+++ b/tests/Controllers/QueriesControllerTest.php
@@ -11,7 +11,7 @@ class QueriesControllerTest extends DebugbarTest
     public function testExplainReturnsErrorWhenStorageIsNotOpen(): void
     {
         $this->app['config']->set('debugbar.storage.open', false);
-        $this->app['config']->set('debugbar.options.db.explain.enabled', true);
+        $this->app['config']->set('debugbar.options.db.explain', true);
         $this->resetStorageOpen();
 
         $response = $this->postJson('/_debugbar/queries/explain', [
@@ -28,7 +28,7 @@ class QueriesControllerTest extends DebugbarTest
     public function testExplainReturnsErrorWhenExplainIsDisabled(): void
     {
         $this->app['config']->set('debugbar.storage.open', true);
-        $this->app['config']->set('debugbar.options.db.explain.enabled', false);
+        $this->app['config']->set('debugbar.options.db.explain', false);
 
         $response = $this->postJson('/_debugbar/queries/explain', [
             'connection' => 'sqlite',
@@ -47,7 +47,7 @@ class QueriesControllerTest extends DebugbarTest
     public function testExplainValidatesRequiredFields(): void
     {
         $this->app['config']->set('debugbar.storage.open', true);
-        $this->app['config']->set('debugbar.options.db.explain.enabled', true);
+        $this->app['config']->set('debugbar.options.db.explain', true);
 
         $response = $this->postJson('/_debugbar/queries/explain', []);
 
@@ -58,7 +58,7 @@ class QueriesControllerTest extends DebugbarTest
     public function testExplainValidatesModeValues(): void
     {
         $this->app['config']->set('debugbar.storage.open', true);
-        $this->app['config']->set('debugbar.options.db.explain.enabled', true);
+        $this->app['config']->set('debugbar.options.db.explain', true);
 
         $response = $this->postJson('/_debugbar/queries/explain', [
             'connection' => 'sqlite',
@@ -75,7 +75,7 @@ class QueriesControllerTest extends DebugbarTest
     public function testExplainAcceptsValidModeValues(): void
     {
         $this->app['config']->set('debugbar.storage.open', true);
-        $this->app['config']->set('debugbar.options.db.explain.enabled', true);
+        $this->app['config']->set('debugbar.options.db.explain', true);
 
         foreach (['visual', 'result'] as $mode) {
             $response = $this->postJson('/_debugbar/queries/explain', [

--- a/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
+++ b/tests/DataCollector/QueryCollectorRuntimeDatabaseTest.php
@@ -13,7 +13,7 @@ class QueryCollectorRuntimeDatabaseTest extends TestCase
     {
         $app['config']->set('database.default', null);
         $app['config']->set('database.connections', []);
-        $app['config']->set('debugbar.options.db.explain.enabled', false);
+        $app['config']->set('debugbar.options.db.explain', false);
     }
 
     public function testCollectsQueriesFromRuntimeConnections()


### PR DESCRIPTION
Is there any reason why it should still be an array?