### PR TITLE
fix: InertiaCollector duplicate page on XHR.

### DIFF
--- a/src/DataCollector/InertiaCollector.php
+++ b/src/DataCollector/InertiaCollector.php
@@ -22,7 +22,7 @@ class InertiaCollector extends TemplateCollector
 
     public function addFromResponse(Response $response): void
     {
-        if (!$response->headers->has('X-Inertia') || $response->headers->get('Content-Type') !== 'application/json') {
+        if (!$response->headers->has('X-Inertia') || $response->headers->get('Content-Type') !== 'application/json' || $this->templates) {
             return;
         }
 


### PR DESCRIPTION
The Inertia tab shows 2 identical page entries on every Inertia XHR request. Full page loads correctly show 1 entry.

Laravel's Router dispatches ResponsePrepared twice per request so addFromResponse() runs both times, adding the same template twice.
                                                                                                                                                                                                
Fix: skip if $this->templates is already populated.