### PR TITLE
Add model filename to query statement output

### DIFF
--- a/src/Support/Clockwork/Converter.php
+++ b/src/Support/Clockwork/Converter.php
@@ -126,8 +126,7 @@ class Converter
                     'duration' => ($statement['duration'] ?? 0) * 1000,
                     'time' => $statement['start'] ?? null,
                     'connection' => $statement['connection'] ?? null,
-                    'model' => $statement['filename']
-                        ?? (($statement['xdebug_link'] ?? null) ? $statement['xdebug_link']['filename'] . ':' . $statement['xdebug_link']['line'] : null),
+                    'model' => $statement['filename'] ?? null,
                 ];
             }
 

--- a/src/Support/Clockwork/Converter.php
+++ b/src/Support/Clockwork/Converter.php
@@ -126,6 +126,8 @@ class Converter
                     'duration' => ($statement['duration'] ?? 0) * 1000,
                     'time' => $statement['start'] ?? null,
                     'connection' => $statement['connection'] ?? null,
+                    'model' => $statement['filename']
+                        ?? (($statement['xdebug_link'] ?? null) ? $statement['xdebug_link']['filename'] . ':' . $statement['xdebug_link']['line'] : null),
                 ];
             }
 


### PR DESCRIPTION
It's an idea; there's a column in the queries tab that's always empty.
Couldn't it be reused to show the file and line where the query was executed?

<img width="437" height="286" alt="image" src="https://github.com/user-attachments/assets/85245a64-114a-4955-a6a5-3dbfb6ae27e9" />
