### PR TITLE
Add CLI tests

### DIFF
--- a/tests/Console/ClearCommandTest.php
+++ b/tests/Console/ClearCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\Console;
+
+use DebugBar\Storage\StorageInterface;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class ClearCommandTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('debugbar.enabled', true);
+        $app['config']->set('debugbar.storage.enabled', true);
+    }
+
+    public function testClearCommandClearsStorage(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())->method('clear');
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        Artisan::call('debugbar:clear');
+        static::assertStringContainsString('Debugbar Storage cleared!', Artisan::output());
+    }
+
+    public function testClearCommandHandlesNoStorage(): void
+    {
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage(null);
+
+        Artisan::call('debugbar:clear');
+        static::assertStringContainsString('No Debugbar Storage found', Artisan::output());
+    }
+
+    public function testClearCommandSuppressesNonExistentDirectoryError(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('clear')->willThrowException(
+            new \InvalidArgumentException('The "/tmp/nonexistent" directory does not exist.')
+        );
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        Artisan::call('debugbar:clear');
+        static::assertStringContainsString('Debugbar Storage cleared!', Artisan::output());
+    }
+
+    public function testClearCommandRethrowsOtherInvalidArgumentExceptions(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('clear')->willThrowException(
+            new \InvalidArgumentException('Some other error')
+        );
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Some other error');
+
+        Artisan::call('debugbar:clear');
+    }
+}

--- a/tests/Console/FindCommandTest.php
+++ b/tests/Console/FindCommandTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\Console;
+
+use DebugBar\Storage\StorageInterface;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class FindCommandTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('debugbar.enabled', true);
+        $app['config']->set('debugbar.storage.enabled', true);
+    }
+
+    private function setupStorage(array $findResult, array $getResults = []): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('find')->willReturn($findResult);
+        $storage->method('get')->willReturnCallback(fn(string $id) => $getResults[$id] ?? []);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+    }
+
+    private function makeRequestRow(string $id, string $uri = '/test', string $method = 'GET'): array
+    {
+        return ['id' => $id, 'uri' => $uri, 'method' => $method, 'ip' => '127.0.0.1', 'utime' => 1234567890];
+    }
+
+    private function makeRequestData(array $overrides = []): array
+    {
+        return array_merge([
+            'exceptions' => ['count' => 0],
+            'queries' => [
+                'nb_statements' => 1,
+                'accumulated_duration_str' => '5ms',
+                'statements' => [],
+                'nb_failed_statements' => 0,
+            ],
+            'time' => ['duration' => 0.05, 'duration_str' => '50ms'],
+            'memory' => ['peak_usage_str' => '2MB'],
+            '__meta' => ['status' => '200'],
+            'request' => ['tooltip' => ['status' => '200']],
+        ], $overrides);
+    }
+
+    public function testFindCommandHandlesNoStorage(): void
+    {
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage(null);
+
+        Artisan::call('debugbar:find');
+        static::assertStringContainsString('No Debugbar Storage found', Artisan::output());
+    }
+
+    public function testFindCommandShowsNoResultsMessage(): void
+    {
+        $this->setupStorage([]);
+
+        Artisan::call('debugbar:find');
+        static::assertStringContainsString('No results found', Artisan::output());
+    }
+
+    public function testFindCommandListsRequests(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('abc123', '/test')],
+            ['abc123' => $this->makeRequestData([
+                'time' => ['duration_str' => '120ms'],
+                'memory' => ['peak_usage_str' => '4MB'],
+                'queries' => ['nb_statements' => 5, 'accumulated_duration_str' => '10ms'],
+            ])],
+        );
+
+        Artisan::call('debugbar:find');
+        $output = Artisan::output();
+
+        static::assertStringContainsString('abc123', $output);
+        static::assertStringContainsString('/test', $output);
+        static::assertStringContainsString('120ms/4MB request', $output);
+        static::assertStringContainsString('5 queries in 10ms', $output);
+    }
+
+    public function testFindCommandPassesFilters(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())
+            ->method('find')
+            ->with(
+                static::callback(fn(array $filters) => $filters['method'] === 'POST' && $filters['uri'] === '/api/*'),
+                static::equalTo(20),
+                static::equalTo(0),
+            )
+            ->willReturn([]);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        Artisan::call('debugbar:find', ['--method' => 'POST', '--uri' => '/api/*']);
+    }
+
+    public function testFindCommandMaxAndOffsetOptions(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())
+            ->method('find')
+            ->with([], 50, 10)
+            ->willReturn([]);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        Artisan::call('debugbar:find', ['--max' => 50, '--offset' => 10]);
+    }
+
+    public function testFindCommandIssuesFilterShowsExceptions(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req1', '/err')],
+            ['req1' => $this->makeRequestData(['exceptions' => ['count' => 2]])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('2 exception(s)', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsHttpErrors(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req2', '/fail')],
+            ['req2' => $this->makeRequestData(['__meta' => ['status' => '500']])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('HTTP 500', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsHighQueryCount(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req3', '/heavy')],
+            ['req3' => $this->makeRequestData([
+                'queries' => ['nb_statements' => 60, 'accumulated_duration_str' => '500ms', 'statements' => [], 'nb_failed_statements' => 0],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('60 queries', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsSlowDuration(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req4', '/slow')],
+            ['req4' => $this->makeRequestData([
+                'time' => ['duration' => 2.5, 'duration_str' => '2.5s'],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('slow', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsDuplicateQueries(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req5', '/dup')],
+            ['req5' => $this->makeRequestData([
+                'queries' => [
+                    'nb_statements' => 3,
+                    'accumulated_duration_str' => '15ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select * from users', 'type' => 'query', 'connection' => 'mysql'],
+                        ['sql' => 'select * from users', 'type' => 'query', 'connection' => 'mysql'],
+                        ['sql' => 'select * from users', 'type' => 'query', 'connection' => 'mysql'],
+                    ],
+                ],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true, '--min-duplicates' => 1]);
+        static::assertStringContainsString('duplicate group(s)', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsSlowQueries(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req6', '/sq')],
+            ['req6' => $this->makeRequestData([
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select * from big_table', 'type' => 'query', 'slow' => true],
+                    ],
+                ],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('1 slow query', Artisan::output());
+    }
+
+    public function testFindCommandIssuesFilterShowsFailedQueries(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req7', '/fq')],
+            ['req7' => $this->makeRequestData([
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 1,
+                    'statements' => [],
+                ],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('1 failed query', Artisan::output());
+    }
+
+    public function testFindCommandNoIssuesFoundMessage(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req8', '/ok')],
+            ['req8' => $this->makeRequestData()],
+        );
+
+        Artisan::call('debugbar:find', ['--issues' => true]);
+        static::assertStringContainsString('No issues found', Artisan::output());
+    }
+
+    public function testFindCommandCustomThresholds(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req9', '/ct')],
+            ['req9' => $this->makeRequestData([
+                'queries' => ['nb_statements' => 15, 'accumulated_duration_str' => '50ms', 'statements' => [], 'nb_failed_statements' => 0],
+            ])],
+        );
+
+        Artisan::call('debugbar:find', ['--min-queries' => 10]);
+        static::assertStringContainsString('15 queries', Artisan::output());
+    }
+
+    public function testFindCommandShowsExceptionCountInSummary(): void
+    {
+        $this->setupStorage(
+            [$this->makeRequestRow('req10', '/ex')],
+            ['req10' => $this->makeRequestData(['exceptions' => ['count' => 1]])],
+        );
+
+        Artisan::call('debugbar:find');
+        static::assertStringContainsString('1 exception(s)', Artisan::output());
+    }
+}

--- a/tests/Console/GetCommandTest.php
+++ b/tests/Console/GetCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\Console;
+
+use DebugBar\Storage\StorageInterface;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class GetCommandTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('debugbar.enabled', true);
+        $app['config']->set('debugbar.storage.enabled', true);
+    }
+
+    private function setupStorage(array $findResult = [], array $getData = []): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('find')->willReturn($findResult);
+        $storage->method('get')->willReturnCallback(fn(string $id) => $getData[$id] ?? []);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+    }
+
+    public function testGetCommandShowsSummary(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                '__meta' => ['id' => 'abc123', 'uri' => '/test', 'method' => 'GET', 'status' => '200'],
+                'time' => ['duration_str' => '120ms'],
+                'memory' => ['peak_usage_str' => '4MB'],
+                'queries' => [
+                    'nb_statements' => 5,
+                    'accumulated_duration_str' => '10ms',
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:get', ['id' => 'abc123']);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('abc123', $output);
+        static::assertStringContainsString('120ms', $output);
+        static::assertStringContainsString('5 queries in 10ms', $output);
+    }
+
+    public function testGetCommandResolvesLatest(): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())
+            ->method('find')
+            ->with([], 1)
+            ->willReturn([['id' => 'latest-id']]);
+        $storage->method('get')->willReturn([
+            '__meta' => ['id' => 'latest-id', 'uri' => '/latest', 'method' => 'GET', 'status' => '200'],
+            'time' => ['duration_str' => '50ms'],
+        ]);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+
+        Artisan::call('debugbar:get', ['id' => 'latest']);
+        static::assertStringContainsString('latest-id', Artisan::output());
+    }
+
+    public function testGetCommandShowsSpecificCollector(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                '__meta' => ['id' => 'abc123'],
+                'exceptions' => [
+                    'count' => 1,
+                    'exceptions' => [
+                        ['message' => 'Test exception', 'type' => 'RuntimeException'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:get', ['id' => 'abc123', '--collector' => 'exceptions', '--raw' => true]);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('Test exception', $output);
+        static::assertStringContainsString('RuntimeException', $output);
+    }
+
+    public function testGetCommandCollectorNotFound(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                '__meta' => ['id' => 'abc123'],
+            ],
+        ]);
+
+        Artisan::call('debugbar:get', ['id' => 'abc123', '--collector' => 'nonexistent']);
+        static::assertStringContainsString('No data found for collector nonexistent', Artisan::output());
+    }
+
+    public function testGetCommandRawOutput(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                '__meta' => ['id' => 'abc123', 'uri' => '/test', 'method' => 'GET'],
+                'time' => ['duration_str' => '50ms'],
+            ],
+        ]);
+
+        Artisan::call('debugbar:get', ['id' => 'abc123', '--raw' => true]);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('"__meta"', $output);
+        static::assertStringContainsString('"duration_str"', $output);
+        static::assertStringContainsString('50ms', $output);
+    }
+
+    public function testGetCommandRawOutputWithCollector(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                '__meta' => ['id' => 'abc123'],
+                'queries' => [
+                    'nb_statements' => 3,
+                    'accumulated_duration_str' => '15ms',
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:get', ['id' => 'abc123', '--collector' => 'queries', '--raw' => true]);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('"nb_statements"', $output);
+        static::assertStringContainsString('3', $output);
+    }
+}

--- a/tests/Console/QueriesCommandTest.php
+++ b/tests/Console/QueriesCommandTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\Console;
+
+use DebugBar\Storage\StorageInterface;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+
+class QueriesCommandTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('debugbar.enabled', true);
+        $app['config']->set('debugbar.storage.enabled', true);
+    }
+
+    private function setupStorage(array $findResult = [], array $getData = []): void
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('find')->willReturn($findResult);
+        $storage->method('get')->willReturnCallback(fn(string $id) => $getData[$id] ?? []);
+
+        $debugbar = app(LaravelDebugbar::class);
+        $debugbar->boot();
+        $debugbar->setStorage($storage);
+    }
+
+    public function testQueriesCommandShowsNoQueriesMessage(): void
+    {
+        $this->setupStorage([], ['abc123' => ['queries' => []]]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123']);
+        static::assertStringContainsString('No queries found', Artisan::output());
+    }
+
+    public function testQueriesCommandShowsSummaryTable(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 3,
+                    'accumulated_duration_str' => '15ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select * from users', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'UserController.php'],
+                        ['sql' => 'select * from posts', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '3ms', 'slow' => false, 'filename' => 'PostController.php'],
+                        ['sql' => 'select count(*) from users', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '7ms', 'slow' => false, 'filename' => 'UserController.php'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123']);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('3 statements', $output);
+        static::assertStringContainsString('15ms total', $output);
+        static::assertStringContainsString('select * from users', $output);
+        static::assertStringContainsString('select * from posts', $output);
+    }
+
+    public function testQueriesCommandResolvesLatest(): void
+    {
+        $this->setupStorage(
+            [['id' => 'latest-id']],
+            ['latest-id' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select 1', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'test.php'],
+                    ],
+                ],
+            ]],
+        );
+
+        Artisan::call('debugbar:queries', ['id' => 'latest']);
+        static::assertStringContainsString('latest-id', Artisan::output());
+    }
+
+    public function testQueriesCommandDetectsDuplicates(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 3,
+                    'accumulated_duration_str' => '15ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select * from users where id = ?', 'params' => [1], 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'a.php'],
+                        ['sql' => 'select * from users where id = ?', 'params' => [1], 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'b.php'],
+                        ['sql' => 'select * from users where id = ?', 'params' => [1], 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'c.php'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123']);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('3 duplicate queries in 1 group(s)', $output);
+        static::assertStringContainsString('3x', $output);
+    }
+
+    public function testQueriesCommandShowsSlowQueryFlag(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '2s',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select * from big_table', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '2s', 'slow' => true, 'filename' => 'test.php'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123']);
+        static::assertStringContainsString('SLOW', Artisan::output());
+    }
+
+    public function testQueriesCommandShowsStatementDetail(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        [
+                            'sql' => 'select * from users where id = ?',
+                            'params' => [42],
+                            'type' => 'query',
+                            'connection' => 'mysql',
+                            'duration_str' => '5ms',
+                            'slow' => false,
+                            'filename' => 'UserController.php',
+                            'backtrace' => [
+                                ['index' => 0, 'name' => 'app/Http/Controllers/UserController.php', 'line' => 25],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123', '--statement' => 0]);
+        $output = Artisan::output();
+
+        static::assertStringContainsString('Statement #0', $output);
+        static::assertStringContainsString('select * from users where id = ?', $output);
+        static::assertStringContainsString('42', $output);
+        static::assertStringContainsString('mysql', $output);
+        static::assertStringContainsString('5ms', $output);
+        static::assertStringContainsString('Backtrace', $output);
+        static::assertStringContainsString('UserController.php', $output);
+    }
+
+    public function testQueriesCommandInvalidStatementIndex(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => 'select 1', 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'test.php'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123', '--statement' => 99]);
+        static::assertStringContainsString('Statement #99 not found', Artisan::output());
+    }
+
+    public function testQueriesCommandExplainRejectsNonSelect(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        [
+                            'sql' => 'delete from users where id = 1',
+                            'type' => 'query',
+                            'connection' => 'mysql',
+                            'duration_str' => '5ms',
+                            'slow' => false,
+                            'filename' => 'test.php',
+                            'explain' => ['connection' => 'mysql', 'query' => 'delete from users where id = 1'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123', '--statement' => 0, '--explain' => true]);
+        static::assertStringContainsString('Only SELECT queries can be explained', Artisan::output());
+    }
+
+    public function testQueriesCommandResultRejectsNonSelect(): void
+    {
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        [
+                            'sql' => 'update users set name = "test"',
+                            'type' => 'query',
+                            'connection' => 'mysql',
+                            'duration_str' => '5ms',
+                            'slow' => false,
+                            'filename' => 'test.php',
+                            'explain' => ['connection' => 'mysql', 'query' => 'update users set name = "test"'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123', '--statement' => 0, '--result' => true]);
+        static::assertStringContainsString('Only SELECT queries can be executed', Artisan::output());
+    }
+
+    public function testQueriesCommandTruncatesLongSql(): void
+    {
+        $longSql = 'select ' . str_repeat('a', 200) . ' from users';
+
+        $this->setupStorage([], [
+            'abc123' => [
+                'queries' => [
+                    'nb_statements' => 1,
+                    'accumulated_duration_str' => '5ms',
+                    'nb_failed_statements' => 0,
+                    'statements' => [
+                        ['sql' => $longSql, 'type' => 'query', 'connection' => 'mysql', 'duration_str' => '5ms', 'slow' => false, 'filename' => 'test.php'],
+                    ],
+                ],
+            ],
+        ]);
+
+        Artisan::call('debugbar:queries', ['id' => 'abc123']);
+        static::assertStringContainsString('...', Artisan::output());
+    }
+}


### PR DESCRIPTION
  4 test files covering all CLI commands documented in core.blade.php:                                                                                                                                                                                                                                             
   
  - tests/Console/ClearCommandTest.php (4 tests) — debugbar:clear                                                                                                                                                                                                                                                  
    - Clears storage successfully                                                                                                                                                                                                                                                                                
    - Handles missing storage                                                                                                                                                                                                                                                                                      
    - Suppresses "does not exist" directory errors                                                                                                                                                                                                                                                               
    - Rethrows other InvalidArgumentExceptions                                                                                                                                                                                                                                                                     
  - tests/Console/FindCommandTest.php (14 tests) — debugbar:find                                                                                                                                                                                                                                                   
    - No storage, no results, listing requests with summary                                                                                                                                                                                                                                                        
    - Filter passthrough (--uri, --method)                                                                                                                                                                                                                                                                         
    - --max and --offset options                                                                                                                                                                                                                                                                                   
    - --issues flag detecting: exceptions, HTTP errors, high query count, slow duration, duplicate queries, slow queries, failed queries                                                                                                                                                                           
    - No issues found message                                                                                                                                                                                                                                                                                      
    - Custom thresholds (--min-queries)                                                                                                                                                                                                                                                                          
    - Exception count in summary (without --issues)                                                                                                                                                                                                                                                                
  - tests/Console/GetCommandTest.php (6 tests) — debugbar:get                                                                                                                                                                                                                                                      
    - Summary display, latest resolution                                                                                                                                                                                                                                                                           
    - --collector for specific collector data                                                                                                                                                                                                                                                                      
    - Collector not found error                                                                                                                                                                                                                                                                                  
    - --raw JSON output                                                                                                                                                                                                                                                                                            
  - tests/Console/QueriesCommandTest.php (11 tests) — debugbar:queries                                                                                                                                                                                                                                           
    - No queries message, summary table, latest resolution                                                                                                                                                                                                                                                         
    - Duplicate detection with count                                                                                                                                                                                                                                                                               
    - Slow query flag                                                                                                                                                                                                                                                                                              
    - --statement=N detail view with backtrace                                                                                                                                                                                                                                                                     
    - Invalid statement index error                                                                                                                                                                                                                                                                              
    - --explain and --result reject non-SELECT queries                                                                                                                                                                                                                                                             
    - Long SQL truncation 