### PR TITLE
feat: add editor links to SQL query backtrace entries

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -101,6 +101,7 @@ return [
             ],
             'backtrace'         => env('DEBUGBAR_OPTIONS_DB_BACKTRACE', true),   // Use a backtrace to find the origin of the query in your files.
             'backtrace_exclude_paths' => [],   // Paths to exclude from backtrace. (in addition to defaults)
+            'backtrace_editor_links' => env('DEBUGBAR_OPTIONS_DB_BACKTRACE_EDITOR_LINKS', false), // Add editor links to backtrace entries (non-vendor files only)
             'timeline'          => env('DEBUGBAR_OPTIONS_DB_TIMELINE', false),  // Add the queries to the timeline
             'duration_background'  => env('DEBUGBAR_OPTIONS_DB_DURATION_BACKGROUND', true),   // Show shaded background on each query relative to how long it took to execute.
             'explain' => [                 // Show EXPLAIN output on queries

--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -51,6 +51,10 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
             $queryCollector->mergeBacktraceExcludePaths($excludeBacktracePaths);
         }
 
+        if ($options['backtrace_editor_links'] ?? false) {
+            $queryCollector->setBacktraceEditorLinks(true);
+        }
+
         if (($options['explain']['enabled'] ?? false) && $this->debugbar->isStorageOpen($request)) {
             $queryCollector->setExplainQuery(true);
         }

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -51,6 +51,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
     protected bool $renderSqlWithParams = false;
     protected bool $durationBackground = false;
     protected ?float $slowThreshold = null;
+    protected bool $backtraceEditorLinks = false;
 
     public function getQueryFormatter(): QueryFormatter
     {
@@ -147,6 +148,14 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
     public function setShowQueryResult(bool $enabled): void
     {
         $this->showQueryResult = $enabled;
+    }
+
+    /**
+     * Enable/disable editor links on backtrace entries
+     */
+    public function setBacktraceEditorLinks(bool $enabled): void
+    {
+        $this->backtraceEditorLinks = $enabled;
     }
 
     public function startMemoryUsage(): void
@@ -504,7 +513,14 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
                 'sql' => $this->getSqlQueryToDisplay($query),
                 'type' => $query['type'],
                 'params' => $query['bindings'] ?? [],
-                'backtrace' => array_values($query['source']),
+                'backtrace' => array_map(function ($trace): mixed {
+                    if ($this->backtraceEditorLinks && is_object($trace) && $trace->file !== null && $trace->file !== ''
+                        && !str_starts_with($this->normalizeFilePath($trace->file), 'vendor/')
+                    ) {
+                        $trace->xdebug_link = $this->getXdebugLink($trace->file, $trace->line);
+                    }
+                    return $trace;
+                }, array_values($query['source'])),
                 'start' => $query['start'] ?? null,
                 'duration' => $query['time'],
                 'duration_str' => $query['time'] ? $this->getDataFormatter()->formatDuration($query['time']) : null,


### PR DESCRIPTION
Each backtrace frame in the queries panel now generates an `xdebug_link`, allowing clickable links to open files directly in the configured editor (phpstorm, vscode, etc.), just like the main query filename already does.

## Changes

- **QueryCollector.php**: Generate an `xdebug_link` for each backtrace entry via `getXdebugLink()`
- **resources/queries/widget.js**: Override backtrace rendering in `itemRenderer` to append an editor link icon next to each trace frame

## Implementation note

The JS override works by finding the Backtrace `<thead>` rendered by the parent `SQLQueriesWidget` and replacing the `<tbody>` content with editor-linked entries. This is a bit fragile (depends on the `Backtrace` label text), but I couldn't find a cleaner approach since the base widget doesn't expose any hook to customize the backtrace rendering. Open to suggestions if there's a better way.
