### PR TITLE
fix: editor links not visible in Request tab kvlist

### DIFF
--- a/resources/laravel-debugbar.css
+++ b/resources/laravel-debugbar.css
@@ -134,6 +134,10 @@ table.phpdebugbar-widgets-tablevar td {
     border-top: 0px;
 }
 
+dl.phpdebugbar-widgets-kvlist {
+    grid-template-columns: minmax(160px, 15%) minmax(0, 1fr);
+}
+
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter,
 div.phpdebugbar-widgets-messages div.phpdebugbar-widgets-toolbar a.phpdebugbar-widgets-filter.phpdebugbar-widgets-excluded {
     background-color: #6d6d6d;


### PR DESCRIPTION
## Problem

The editor links (for `controller` and `file` rows) in the Request tab are rendered in the DOM but pushed off-screen to the right, making them invisible.

### Root cause

The upstream `widgets.css` in php-debugbar defines the kvlist grid as:

```css
grid-template-columns: minmax(160px, 15%) 1fr;
```

`1fr` does not constrain the column's max width — when a value is very wide (e.g. `request_server` with 50+ entries), the second column overflows the container. The `float: right` filename span (containing the editor link) ends up at 2200px +, far off-screen.

### Fix

Override the grid definition in `laravel-debugbar.css` with `minmax(0, 1fr)` which caps the second column to the available space:

```css
dl.phpdebugbar-widgets-kvlist {
    grid-template-columns: minmax(160px, 15%) minmax(0, 1fr);
}
```

This keeps the existing `float: right` behavior working correctly and the editor links stay visible on the right side of the panel.

### Before

<img width="1019" height="433" alt="image" src="https://github.com/user-attachments/assets/f6e61d84-f4f6-4e71-a25a-fd736d38651e" />

### After

<img width="1019" height="432" alt="image" src="https://github.com/user-attachments/assets/4b0c9ab6-1e1d-4f22-9623-8871c64b988a" />