### PR TITLE
Avoid hash mismatch by stringify bindings

### DIFF
--- a/resources/queries/widget.js
+++ b/resources/queries/widget.js
@@ -96,7 +96,7 @@
             const body = {
                 connection: statement.explain.connection,
                 query: statement.explain.query,
-                bindings: statement.params,
+                bindings: JSON.stringify(statement.params),
                 hash: statement.explain.hash,
                 mode: mode,
             };

--- a/src/Controllers/QueriesController.php
+++ b/src/Controllers/QueriesController.php
@@ -17,6 +17,7 @@ class QueriesController
     public function explain(QueriesExplainRequest $request, LaravelDebugbar $debugbar, Explain $explain): \Illuminate\Http\JsonResponse
     {
         $validated = $request->validated();
+        $validated['bindings'] = json_decode($validated['bindings'] ?? '[]', true) ?: [];
 
         if (($validated['mode'] ?? null) === 'result') {
 
@@ -29,7 +30,7 @@ class QueriesController
 
             return response()->json([
                 'success' => true,
-                'data' => $explain->generateSelectResult($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash'], $validated['format'] ?? null),
+                'data' => $explain->generateSelectResult($validated['connection'], $validated['query'], $validated['bindings'], $validated['hash'], $validated['format'] ?? null),
             ]);
         }
 
@@ -44,13 +45,13 @@ class QueriesController
             if (($validated['mode'] ?? null) === 'visual') {
                 return response()->json([
                     'success' => true,
-                    'data' => $explain->generateVisualExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash']),
+                    'data' => $explain->generateVisualExplain($validated['connection'], $validated['query'], $validated['bindings'], $validated['hash']),
                 ]);
             }
 
             return response()->json([
                 'success' => true,
-                'data' => $explain->generateRawExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash']),
+                'data' => $explain->generateRawExplain($validated['connection'], $validated['query'], $validated['bindings'], $validated['hash']),
                 'visual' => $explain->isVisualExplainSupported($validated['connection']) ? [
                     'confirm' => $explain->confirmVisualExplain($validated['connection']),
                 ] : null,

--- a/src/Requests/QueriesExplainRequest.php
+++ b/src/Requests/QueriesExplainRequest.php
@@ -13,7 +13,7 @@ class QueriesExplainRequest extends FormRequest
         return [
             'connection' => ['required', 'string'],
             'query' => ['required', 'string'],
-            'bindings' => ['nullable', 'array'],
+            'bindings' => ['nullable', 'json'],
             'hash' => ['required', 'string'],
             'mode' => ['nullable', 'string', 'in:explain,visual,result'],
             'format' => ['nullable', 'string'],

--- a/tests/Controllers/QueriesControllerTest.php
+++ b/tests/Controllers/QueriesControllerTest.php
@@ -17,7 +17,7 @@ class QueriesControllerTest extends DebugbarTest
         $response = $this->postJson('/_debugbar/queries/explain', [
             'connection' => 'sqlite',
             'query' => 'SELECT 1',
-            'bindings' => [],
+            'bindings' => '[]',
             'hash' => 'abc123',
         ]);
 
@@ -33,7 +33,7 @@ class QueriesControllerTest extends DebugbarTest
         $response = $this->postJson('/_debugbar/queries/explain', [
             'connection' => 'sqlite',
             'query' => 'SELECT 1',
-            'bindings' => [],
+            'bindings' => '[]',
             'hash' => 'abc123',
         ]);
 
@@ -63,7 +63,7 @@ class QueriesControllerTest extends DebugbarTest
         $response = $this->postJson('/_debugbar/queries/explain', [
             'connection' => 'sqlite',
             'query' => 'SELECT 1',
-            'bindings' => [],
+            'bindings' => '[]',
             'hash' => 'abc123',
             'mode' => 'invalid',
         ]);
@@ -81,7 +81,7 @@ class QueriesControllerTest extends DebugbarTest
             $response = $this->postJson('/_debugbar/queries/explain', [
                 'connection' => 'sqlite',
                 'query' => 'SELECT 1',
-                'bindings' => [],
+                'bindings' => '[]',
                 'hash' => 'abc123',
                 'mode' => $mode,
             ]);


### PR DESCRIPTION
When using `\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull`
Bindings like 
```
array:3 [
 0 => ""
 1 => ""
 2 => "" 
]
```
transform into
```
array:3 [
 0 => null
 1 => null
 2 => null 
]
```
Therefore, the hashes do not match, and you cannot use explain or run the query.
