### PR TITLE
Avoid hash mismatch on query explain/result

### DIFF
--- a/resources/queries/widget.js
+++ b/resources/queries/widget.js
@@ -94,9 +94,7 @@
 
         fetchQuery(statement, mode, format) {
             const body = {
-                connection: statement.explain.connection,
-                query: statement.explain.query,
-                bindings: statement.params,
+                id: PhpDebugBar.instance.activeDatasetId,
                 hash: statement.explain.hash,
                 mode: mode,
             };

--- a/src/Controllers/QueriesController.php
+++ b/src/Controllers/QueriesController.php
@@ -16,27 +16,54 @@ class QueriesController
      */
     public function explain(QueriesExplainRequest $request, LaravelDebugbar $debugbar, Explain $explain): \Illuminate\Http\JsonResponse
     {
+        if (!$debugbar->isStorageOpen($request)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'To enable public access to previous requests, set debugbar.storage.open to true in your config, or enable DEBUGBAR_OPEN_STORAGE if you did not publish the config.',
+            ], 400);
+        }
+
         $validated = $request->validated();
+        foreach ($debugbar->getStorage()->get($validated['id'])['queries']['statements'] ?? [] as $query) {
+            if (($query['explain']['hash'] ?? null) === $validated['hash']) {
+                $validated += ['connection' => $query['explain']['connection'], 'query' => $query['explain']['query'], 'bindings' => $query['params']];
+                break;
+            }
+        }
 
         if (($validated['mode'] ?? null) === 'result') {
 
-            if (!config('debugbar.options.db.show_query_result', false) || !$debugbar->isStorageOpen($request)) {
+            if (!config('debugbar.options.db.show_query_result', false)) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Query result is currently disabled in the Debugbar.',
                 ], 400);
             }
 
+            if (!($validated['query'] ?? null)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Statement #{$validated['hash']} not found.",
+                ], 400);
+            }
+
             return response()->json([
                 'success' => true,
-                'data' => $explain->generateSelectResult($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash'], $validated['format'] ?? null),
+                'data' => $explain->generateSelectResult($validated['connection'], $validated['query'], $validated['bindings'] ?? [], $validated['hash'], $validated['format'] ?? null),
             ]);
         }
 
-        if (!config('debugbar.options.db.explain.enabled', false) || !$debugbar->isStorageOpen($request)) {
+        if (!config('debugbar.options.db.explain.enabled', false)) {
             return response()->json([
                 'success' => false,
                 'message' => 'EXPLAIN is currently disabled in the Debugbar.',
+            ], 400);
+        }
+
+        if (!($validated['query'] ?? null)) {
+            return response()->json([
+                'success' => false,
+                'message' => "Statement #{$validated['hash']} not found.",
             ], 400);
         }
 
@@ -44,13 +71,13 @@ class QueriesController
             if (($validated['mode'] ?? null) === 'visual') {
                 return response()->json([
                     'success' => true,
-                    'data' => $explain->generateVisualExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash']),
+                    'data' => $explain->generateVisualExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? [], $validated['hash']),
                 ]);
             }
 
             return response()->json([
                 'success' => true,
-                'data' => $explain->generateRawExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? null, $validated['hash']),
+                'data' => $explain->generateRawExplain($validated['connection'], $validated['query'], $validated['bindings'] ?? [], $validated['hash']),
                 'visual' => $explain->isVisualExplainSupported($validated['connection']) ? [
                     'confirm' => $explain->confirmVisualExplain($validated['connection']),
                 ] : null,

--- a/src/Requests/QueriesExplainRequest.php
+++ b/src/Requests/QueriesExplainRequest.php
@@ -11,9 +11,7 @@ class QueriesExplainRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'connection' => ['required', 'string'],
-            'query' => ['required', 'string'],
-            'bindings' => ['nullable', 'array'],
+            'id' => ['required', 'string'],
             'hash' => ['required', 'string'],
             'mode' => ['nullable', 'string', 'in:explain,visual,result'],
             'format' => ['nullable', 'string'],

--- a/tests/Controllers/QueriesControllerTest.php
+++ b/tests/Controllers/QueriesControllerTest.php
@@ -15,9 +15,7 @@ class QueriesControllerTest extends DebugbarTest
         $this->resetStorageOpen();
 
         $response = $this->postJson('/_debugbar/queries/explain', [
-            'connection' => 'sqlite',
-            'query' => 'SELECT 1',
-            'bindings' => [],
+            'id' => 'uuid123',
             'hash' => 'abc123',
         ]);
 
@@ -31,9 +29,7 @@ class QueriesControllerTest extends DebugbarTest
         $this->app['config']->set('debugbar.options.db.explain.enabled', false);
 
         $response = $this->postJson('/_debugbar/queries/explain', [
-            'connection' => 'sqlite',
-            'query' => 'SELECT 1',
-            'bindings' => [],
+            'id' => 'uuid123',
             'hash' => 'abc123',
         ]);
 
@@ -52,7 +48,7 @@ class QueriesControllerTest extends DebugbarTest
         $response = $this->postJson('/_debugbar/queries/explain', []);
 
         $response->assertUnprocessable();
-        $response->assertJsonValidationErrors(['connection', 'query', 'hash']);
+        $response->assertJsonValidationErrors(['id', 'hash']);
     }
 
     public function testExplainValidatesModeValues(): void
@@ -61,9 +57,7 @@ class QueriesControllerTest extends DebugbarTest
         $this->app['config']->set('debugbar.options.db.explain.enabled', true);
 
         $response = $this->postJson('/_debugbar/queries/explain', [
-            'connection' => 'sqlite',
-            'query' => 'SELECT 1',
-            'bindings' => [],
+            'id' => 'uuid123',
             'hash' => 'abc123',
             'mode' => 'invalid',
         ]);
@@ -79,9 +73,7 @@ class QueriesControllerTest extends DebugbarTest
 
         foreach (['visual', 'result'] as $mode) {
             $response = $this->postJson('/_debugbar/queries/explain', [
-                'connection' => 'sqlite',
-                'query' => 'SELECT 1',
-                'bindings' => [],
+                'id' => 'uuid123',
                 'hash' => 'abc123',
                 'mode' => $mode,
             ]);

--- a/tests/DataCollector/RouteCollectorTest.php
+++ b/tests/DataCollector/RouteCollectorTest.php
@@ -101,7 +101,7 @@ class RouteCollectorTest extends TestCase
 
     public static function controllerData()
     {
-        $filePath = urlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockController.php')));
+        $filePath = rawurlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockController.php')));
         return [['MockController@show',
             'MockController.php',
             sprintf('phpstorm://open?file=%s', $filePath),
@@ -110,7 +110,7 @@ class RouteCollectorTest extends TestCase
 
     public static function viewComponentData()
     {
-        $filePath = urlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockViewComponent.php')));
+        $filePath = rawurlencode(str_replace('\\', '/', realpath(__DIR__ . '/../Mocks/MockViewComponent.php')));
         return [['MockViewComponent@render',
             'MockViewComponent.php',
             sprintf('phpstorm://open?file=%s', $filePath),

--- a/tests/DataCollector/ViewCollectorTest.php
+++ b/tests/DataCollector/ViewCollectorTest.php
@@ -25,7 +25,7 @@ class ViewCollectorTest extends TestCase
 
         tap(Arr::first($collector->collect()['templates']), function (array $template) {
             $this->assertEquals(
-                'phpstorm://open?file=' . urlencode(str_replace('\\', '/', realpath(__DIR__ . '/../resources/views/dashboard.blade.php'))) . '&line=1',
+                'phpstorm://open?file=' . rawurlencode(str_replace('\\', '/', realpath(__DIR__ . '/../resources/views/dashboard.blade.php'))) . '&line=1',
                 $template['xdebug_link']['url'],
             );
         });


### PR DESCRIPTION
- Alternative to https://github.com/fruitcake/laravel-debugbar/pull/2028#issuecomment-4273063343

If it's the same hash sent by the client and found on the server side, in my opinion, recalculating the hash is unnecessary.