### PR TITLE
fix: allow Debugbar to load with strict form request validation enabled

### DIFF
--- a/src/Requests/AssetRequest.php
+++ b/src/Requests/AssetRequest.php
@@ -12,6 +12,8 @@ class AssetRequest extends FormRequest
     {
         return [
             'type' => ['required', 'string', 'in:js,css'],
+            'mtime' => ['nullable'],
+            'hash' => ['nullable'],
         ];
     }
 }


### PR DESCRIPTION
Laravel **[v13.4.0](https://github.com/laravel/framework/releases/tag/v13.4.0)** introduced a new feature: **[strict mode for form request validation](https://github.com/laravel/framework/pull/59430)**.

When enabled globally, this causes Debugbar assets to not load because the `hash` and `mtime` parameters are missing from the form request validation.

As a result, these requests will return a 302 status response:

- http://laravel.test/_debugbar/assets?type=css&mtime=1776531680
- http://laravel.test/_debugbar/assets?type=js&hash=1776531680

You can verify this by adding the following to `app/Providers/AppServiceProvider.php`:

```php
use Illuminate\Foundation\Http\FormRequest;

public function boot(): void
{
    FormRequest::failOnUnknownFields();
}
```

This PR fixes the issue by adding `hash` and `mtime` as optional parameters to the `AssetRequest` validation rules.