### PR TITLE
Fix description for `debugbar:get` command

### DIFF
--- a/src/Console/GetCommand.php
+++ b/src/Console/GetCommand.php
@@ -19,7 +19,7 @@ class GetCommand extends Command
     {--collector= : Show a specific collector}
     {--raw : Show raw JSON data}
     ';
-    protected $description = 'List the Debugbar Storage';
+    protected $description = 'Shows a Debugbar request from the Storage';
 
     public function handle(LaravelDebugbar $debugbar): void
     {

--- a/src/Console/GetCommand.php
+++ b/src/Console/GetCommand.php
@@ -19,7 +19,7 @@ class GetCommand extends Command
     {--collector= : Show a specific collector}
     {--raw : Show raw JSON data}
     ';
-    protected $description = 'Shows a Debugbar request from the Storage';
+    protected $description = 'Get a Debugbar request from the Storage';
 
     public function handle(LaravelDebugbar $debugbar): void
     {


### PR DESCRIPTION
Hey 👋🏽

While upgrading from v3 to v4 and trying out the new CLI, I noticed that the `debugbar:get` command has a slightly misleading description. It doesn't list requests, it actually inspects a single one. Seems to be a duplicate of `debugbar:find`.

I updated the description and tried to match the `debugbar:queries` command's tone, but feel free to tweak it.

Thanks for the new CLI tool, it's super helpful.