### PR TITLE
Get event hash before changing the array to get the start time

### DIFF
--- a/src/DataCollector/CacheCollector.php
+++ b/src/DataCollector/CacheCollector.php
@@ -62,6 +62,7 @@ class CacheCollector extends TimeDataCollector implements AssetProvider, Resetta
         $class = get_class($event);
         $params = get_object_vars($event);
         $label = $this->classMap[$class][0];
+        $startHashKey = $this->getEventHash($this->classMap[$class][1] ?? '', $params);
 
         if (isset($params['value'])) {
             if (!($params['value'] instanceof \Closure || is_resource($params['value']))) {
@@ -77,7 +78,6 @@ class CacheCollector extends TimeDataCollector implements AssetProvider, Resetta
         }
 
         $time = microtime(true);
-        $startHashKey = $this->getEventHash($this->classMap[$class][1] ?? '', $params);
         $startTime = $this->eventStarts[$startHashKey] ?? $time;
 
         $this->addMeasure($label . "\t" . ($params['key'] ?? ''), $startTime, $time, $params);


### PR DESCRIPTION
This bug was added when merging an old PR where this wasn't originally planned.

<img width="172" height="63" alt="image" src="https://github.com/user-attachments/assets/1baed3af-afd5-440c-80bc-c10fb0bf2f21" />
