### PR TITLE
Make the visible backtrace length configurable

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -384,4 +384,13 @@ return [
      | If you need larger stacktraces, you can increase this number. Setting it to 0 will result in no limit.
      */
     'debug_backtrace_limit' => (int) env('DEBUGBAR_DEBUG_BACKTRACE_LIMIT', 50),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Default visible backtrace length
+     |--------------------------------------------------------------------------
+     |
+     | By default, the Debugbar limits the number of printed backtrace lines.
+     */
+    'debug_visible_backtrace_length_limit' => (int) env('DEBUGBAR_DEBUG_VISIBLE_BACKTRACE_LENGTH_LIMIT', 5),
 ];

--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -260,7 +260,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
             $sources[] = $this->parseTrace($index, $trace);
         }
 
-        return array_slice(array_filter($sources), 0, is_int($this->findSource) ? $this->findSource : 5);
+        return array_slice(array_filter($sources), 0, is_int($this->findSource) ? $this->findSource : app('config')->get('debugbar.debug_visible_backtrace_length_limit', 5));
     }
 
     /**


### PR DESCRIPTION
Can we make this configurable? Now I have to modify the `array_slice` on each composer update when I want to see more backtrace lines.