### PR TITLE
Bring back view measuring

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -118,6 +118,7 @@ return [
         ],
         'views' => [
             'timeline' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE', true),                  // Add the views to the timeline
+            'timeline_duration' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE_DURATION', true),// Add the views duration on timeline (Experimental)
             'data' => env('DEBUGBAR_OPTIONS_VIEWS_DATA', false),                         // True for all data, 'keys' for only names, false for no parameters.
             'group' => (int) env('DEBUGBAR_OPTIONS_VIEWS_GROUP', 50),                    // Group duplicate views. Pass value to auto-group, or true/false to force
             'exclude_paths' => [    // Add the paths which you don't want to appear in the views

--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -118,7 +118,7 @@ return [
         ],
         'views' => [
             'timeline' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE', true),                  // Add the views to the timeline
-            'timeline_duration' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE_DURATION', true),// Add the views duration on timeline (Experimental)
+            'timeline_duration' => env('DEBUGBAR_OPTIONS_VIEWS_TIMELINE_DURATION', false),// Add the views duration on timeline (Experimental)
             'data' => env('DEBUGBAR_OPTIONS_VIEWS_DATA', false),                         // True for all data, 'keys' for only names, false for no parameters.
             'group' => (int) env('DEBUGBAR_OPTIONS_VIEWS_GROUP', 50),                    // Group duplicate views. Pass value to auto-group, or true/false to force
             'exclude_paths' => [    // Add the paths which you don't want to appear in the views

--- a/src/CollectorProviders/ViewsCollectorProvider.php
+++ b/src/CollectorProviders/ViewsCollectorProvider.php
@@ -17,7 +17,7 @@ class ViewsCollectorProvider extends AbstractCollectorProvider
 
         $viewCollector = new ViewCollector($collectData, $excludePaths, $group);
 
-        if ($options['timeline'] ?? true) {
+        if (($options['timeline'] ?? true) && !($options['timeline_duration'] ?? false)) {
             $timeCollector = $this->debugbar->getTimeCollector();
             $viewCollector->setTimeDataCollector($timeCollector);
         }

--- a/src/DebugbarViewEngine.php
+++ b/src/DebugbarViewEngine.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar;
+
+use Illuminate\Contracts\View\Engine;
+
+class DebugbarViewEngine implements Engine
+{
+    /**
+     * @var Engine
+     */
+    protected $engine;
+
+    /**
+     * @var LaravelDebugbar
+     */
+    protected $laravelDebugbar;
+
+    /**
+     * @var array
+     */
+    protected $exclude_paths;
+
+    public function __construct(Engine $engine, LaravelDebugbar $laravelDebugbar)
+    {
+        $this->engine = $engine;
+        $this->laravelDebugbar = $laravelDebugbar;
+        $this->exclude_paths = app('config')->get('debugbar.options.views.exclude_paths', []);
+    }
+
+    /**
+     * @param string|null $path
+     */
+    public function get($path, array $data = []): string
+    {
+        $basePath = base_path();
+        $shortPath = @file_exists((string) $path) ? realpath($path) : $path;
+
+        if (str_starts_with($shortPath, $basePath)) {
+            $shortPath = ltrim(
+                str_replace('\\', '/', substr($shortPath, strlen($basePath))),
+                '/',
+            );
+        }
+
+        foreach ($this->exclude_paths as $excludePath) {
+            if (str_starts_with($shortPath, $excludePath)) {
+                return $this->engine->get($path, $data);
+            }
+        }
+
+        return $this->laravelDebugbar->measure($shortPath, function () use ($path, $data): string {
+            return $this->engine->get($path, $data);
+        }, 'views', 'Views Rendering');
+    }
+
+    /**
+     * NOTE: This is done to support other Engine swap (example: Livewire).
+     */
+    public function __call($name, $arguments): mixed
+    {
+        return $this->engine->$name(...$arguments);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -16,7 +16,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Engine;
-use Illuminate\Contracts\View\Factory
+use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Queue\Events\JobProcessed;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -45,6 +45,46 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             debug($this);
             return $this;
         });
+
+        if (
+            !$this->app['config']->get('debugbar.collectors.time', false)
+            || !$this->app['config']->get('debugbar.collectors.views', false)
+            || !$this->app['config']->get('debugbar.options.views.timeline', false)
+            || !$this->app['config']->get('debugbar.options.views.timeline_duration', false)
+        ) {
+            return;
+        }
+
+        $this->app->extend(
+            'view',
+            function (Factory $factory, Container $application): Factory {
+                assert($factory instanceof ViewFactory);
+                $laravelDebugbar = $application->make(LaravelDebugbar::class);
+
+                if (! $laravelDebugbar->isEnabled()) {
+                    return $factory; // Do not swap the engine to save performance
+                }
+
+                $extensions = array_reverse($factory->getExtensions());
+                $engines = array_flip($extensions);
+                $enginesResolver = $application->make('view.engine.resolver');
+
+                foreach ($engines as $engine => $extension) {
+                    $resolved = $enginesResolver->resolve($engine);
+
+                    $factory->addExtension($extension, $engine, function () use ($resolved, $laravelDebugbar): Engine {
+                        return new DebugbarViewEngine($resolved, $laravelDebugbar);
+                    });
+                }
+
+                // returns original order of extensions
+                foreach ($extensions as $extension => $engine) {
+                    $factory->addExtension($extension, $engine);
+                }
+
+                return $factory;
+            }
+        );
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,12 +13,16 @@ use Fruitcake\LaravelDebugbar\Console\GetCommand;
 use Fruitcake\LaravelDebugbar\Console\QueriesCommand;
 use Fruitcake\LaravelDebugbar\Support\Octane\ResetDebugbar;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\View\Engine;
+use Illuminate\Contracts\View\Factory
 use Illuminate\Foundation\Events\Terminating;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Support\Collection;
+use Illuminate\View\Factory as ViewFactory;
 use Laravel\Octane\Events\RequestReceived;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider


### PR DESCRIPTION
OPT-IN on  `debugbar.options.views.timeline_duration = true`

Replaces [vdauchy/laravel-debugbar-view-meter](https://github.com/vdauchy/laravel-debugbar-view-meter)

<img width="1132" height="290" alt="image" src="https://github.com/user-attachments/assets/d54f94ff-3d16-451c-98f3-afc3f0c66ab7" />

Currently it only shows the time of the view, but not the duration; is it possible to have it again, at least as an OPT-IN?


