### PR TITLE
Allow non-string messages in QueryCollector::addMessage

### DIFF
--- a/src/DataCollector/QueryCollector.php
+++ b/src/DataCollector/QueryCollector.php
@@ -403,7 +403,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
     /**
      * Adds a custom message to statements.
      */
-    public function addMessage(string $message, string $type = 'message'): void
+    public function addMessage(mixed $message, string $type = 'message'): void
     {
         $this->infoStatements++;
         $source = [];
@@ -416,7 +416,7 @@ class QueryCollector extends DataCollector implements Renderable, AssetProvider,
         }
 
         $this->queries[] = [
-            'sql' => $message,
+            'sql' => (string) $message,
             'type' => $type,
             'start' => microtime(true),
             ...(count($source) ? ['xdebug_link' => $source[0]] : []),

--- a/tests/DataCollector/QueryCollectorTest.php
+++ b/tests/DataCollector/QueryCollectorTest.php
@@ -61,6 +61,19 @@ class QueryCollectorTest extends TestCase
         });
     }
 
+    public function testItAcceptsNonStringMessages(): void
+    {
+        debugbar()->boot();
+
+        /** @var \Fruitcake\LaravelDebugbar\DataCollector\QueryCollector $collector */
+        $collector = debugbar()->getCollector('queries');
+        $collector->addMessage(42);
+
+        tap(Arr::first($collector->collect()['statements']), function (array $statement) {
+            $this->assertSame('42', $statement['sql']);
+        });
+    }
+
     public function testResultModeForSelectQuery(): void
     {
         debugbar()->boot();


### PR DESCRIPTION
`QueryCollector::addMessage()` typed `$message` as `string`, so passing something like `$collection->count()` throws a `TypeError`. Widen it to `mixed` and cast to string, matching `LaravelDebugbar::addMessage()`.

Fixes https://github.com/fruitcake/laravel-debugbar/issues/2008
