### PR TITLE
Fix font size on query explain/rerun select

### DIFF
--- a/resources/laravel-debugbar.css
+++ b/resources/laravel-debugbar.css
@@ -299,6 +299,7 @@ div.phpdebugbar-widgets-explain-scroll {
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain {
     width: 100%;
     border-collapse: collapse;
+    font-size: 12px;
 }
 
 div.phpdebugbar-widgets-sqlqueries table.phpdebugbar-widgets-explain th {


### PR DESCRIPTION
In certain apps, the size grows too much; it's better for it to be fixed.

<img width="1338" height="330" alt="image" src="https://github.com/user-attachments/assets/02e7937c-71f8-4aff-aca4-b4a3e8a60b9e" />
