### PR TITLE
Fix font size on query explain/rerun popup table

### DIFF
--- a/resources/laravel-debugbar.css
+++ b/resources/laravel-debugbar.css
@@ -431,6 +431,7 @@ table.phpdebugbar-widgets-explain.phpdebugbar-widgets-explain-full td {
 
 div.phpdebugbar-widgets-explain-popup-body table.phpdebugbar-widgets-explain {
     width: 100%;
+    font-size: 12px;
 }
 
 div.phpdebugbar-widgets-explain-popup-body table.phpdebugbar-widgets-explain th {


### PR DESCRIPTION
In certain apps, the size grows too much; it's better for it to be fixed.
<img width="705" height="202" alt="image" src="https://github.com/user-attachments/assets/257a8ae2-e952-476d-b25a-a5538aec7d1c" />


