### PR TITLE
Fix truncated nested Inertia props

### DIFF
--- a/src/DataCollector/InertiaCollector.php
+++ b/src/DataCollector/InertiaCollector.php
@@ -44,7 +44,10 @@ class InertiaCollector extends TemplateCollector
 
         $type = '';
         $component = $page['component'];
-        $props = $page['props'] ?? [];
+        $props = array_map(
+            fn(mixed $value): mixed => $this->getDataFormatter()->formatVar($value),
+            $page['props'] ?? [],
+        );
 
         $pagePath = config('debugbar.options.inertia.pages', 'js/Pages');
         if ($files = glob(resource_path($pagePath . '/' . $name . '.*'))) {

--- a/tests/DataCollector/InertiaCollectorTest.php
+++ b/tests/DataCollector/InertiaCollectorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\DataCollector;
+
+use Fruitcake\LaravelDebugbar\DataCollector\InertiaCollector;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Illuminate\View\View;
+use Mockery;
+
+class InertiaCollectorTest extends TestCase
+{
+    public function testNestedInertiaPropsAreNotTruncated(): void
+    {
+        $collector = new InertiaCollector();
+
+        $view = Mockery::mock(View::class);
+
+        $view->shouldReceive('getData')->once()->andReturn([
+            'page' => [
+                'component' => 'Users/Index',
+                'props' => [
+                    'users' => [
+                        [
+                            'profile' => [
+                                'name' => 'John Doe',
+                            ],
+                        ],
+                    ],
+                    'string' => 'value',
+                    'integer' => 42,
+                    'null' => null,
+                    'boolean' => true,
+                    'object' => (object) [
+                        'name' => 'Jane Doe',
+                    ],
+                ],
+            ],
+        ]);
+
+        $view->shouldReceive('getName')->once()->andReturn('app');
+        $view->shouldReceive('getPath')->once()->andReturn(null);
+
+        $collector->addFromView($view);
+
+        $params = $collector->collect()['templates'][0]['params'];
+
+        $this->assertStringContainsString('John Doe', $params['users']);
+        $this->assertSame('value', $params['string']);
+        $this->assertSame('42', $params['integer']);
+        $this->assertSame('NULL', $params['null']);
+        $this->assertSame('true', $params['boolean']);
+        $this->assertStringContainsString('Jane Doe', $params['object']);
+    }
+}


### PR DESCRIPTION
Fixes #2055.

Nested Inertia props were formatted with shallow depth by the parent template collector, causing deeply nested values to be truncated.

This change formats Inertia props using the default deep formatter before passing them to the template collector.

### Testing

- Added regression coverage for nested arrays
- Added coverage for string, integer, null, boolean, and object props
- PHPUnit passed
- PHPStan passed
- Pint passed