### PR TITLE
Return false when the client IP check fails in isStorageOpen

### DIFF
--- a/src/LaravelDebugbar.php
+++ b/src/LaravelDebugbar.php
@@ -617,6 +617,7 @@ class LaravelDebugbar extends DebugBar
                 // Allow localhost request when not explicitly allowed/disallowed
                 $this->storageOpen = IpUtils::isPrivateIp($request->getClientIp());
             } catch (\ValueError $e) {
+                $this->storageOpen = false;
             }
         }
 

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -140,6 +140,20 @@ class DebugbarTest extends TestCase
         static::assertArrayNotHasKey('rid', $meta);
     }
 
+    public function testIsStorageOpenReturnsFalseForEmptyClientIp()
+    {
+        $this->app['config']->set('debugbar.storage.open', null);
+        $this->resetStorageOpen();
+
+        $request = Request::create('web/html', 'GET', server: ['REMOTE_ADDR' => '']);
+
+        /** @var LaravelDebugbar $debugbar */
+        $debugbar = $this->app->make(LaravelDebugbar::class);
+
+        static::assertSame('', $request->getClientIp());
+        static::assertFalse($debugbar->isStorageOpen($request));
+    }
+
     private function collectMetaDataForRequest(Request $request): array
     {
         /** @var LaravelDebugbar $debugbar */


### PR DESCRIPTION
On Octane/FrankenPHP workers the bootstrap request has an empty client IP, so `IpUtils::isPrivateIp()` throws a `ValueError`. The catch added in #2071 handles the throw but leaves `storageOpen` unset, so `isStorageOpen()` returns null and its `: bool` return type crashes the worker. Setting it to false keeps storage closed for an empty or invalid IP.

Fixes #2073
