### PR TITLE
Allow explain queries with comments at the beginning

### DIFF
--- a/src/Support/Explain.php
+++ b/src/Support/Explain.php
@@ -15,7 +15,11 @@ class Explain
 {
     public function isReadOnlyQuery(string $query): bool
     {
-        return (bool) preg_match('/^(SELECT|WITH)\b/i', ltrim($query));
+        return (bool) preg_match('/^(SELECT|WITH)\b/i', ltrim(preg_replace(
+            '/\A(?:\s+|\/\*.*?\*\/|--[^\r\n]*(?:\R|$)|#[^\r\n]*(?:\R|$))+/s',
+            '',
+            $query
+        )));
     }
 
     public function isRawExplainSupported(string $driver, ?array $bindings): bool


### PR DESCRIPTION
If a comment is added at the beginning of a query, `EXPLAIN` can no longer be used because the query does not start with `SELECT` or `WITH`; this fix removes first-line comments.

**Examples:** https://onlinephp.io/c/6c215
```php
function isReadOnlyQuery(string $query): bool
{
    return (bool) preg_match('/^(SELECT|WITH)\b/i', ltrim(preg_replace(
        '/\A(?:\s+|\/\*.*?\*\/|--[^\r\n]*(?:\R|$)|#[^\r\n]*(?:\R|$))+/s',
        '',
        $query
    )));
}
$array=[
'SELECT ...',
'/* comentario */
SELECT ...',
'/* comentario */ SELECT ...',
'/* comentario */SELECT ...',
'-- comentario
SELECT ...',
'# comentario
SELECT ...',
'/* uno */
/* dos */
SELECT ...',
'
/* dos */
SELECT ...',
' UPDATE ...',
'/* comentario */
UPDATE ...',
'# comentario
UPDATE ...',
'/* comentario */
UPDATE table SET field="*/"',
];

foreach($array as $k=>$value){
    echo ($k+1).' '.(isReadOnlyQuery($value)?'YES':'NO').PHP_EOL;
}
```