### PR TITLE
Link Livewire single- and multi-file components to their source

### DIFF
--- a/src/DataCollector/LivewireCollector.php
+++ b/src/DataCollector/LivewireCollector.php
@@ -34,9 +34,50 @@ class LivewireCollector extends TemplateCollector
         $data['#component'] = get_class($component);
         $data['#id'] = $id;
 
-        $path = (new \ReflectionClass($component))->getFileName();
+        $this->addTemplate($key, $data, 'livewire', $this->resolveSourcePath($component));
+    }
 
-        $this->addTemplate($key, $data, 'livewire', $path);
+    /**
+     * Resolve the file the component was written in.
+     *
+     * Livewire 4 compiles single- and multi-file components into the cache
+     * directory, so reflection reports the compiled class rather than the
+     * source the user can edit.
+     */
+    protected function resolveSourcePath(Component $component): ?string
+    {
+        $path = (new \ReflectionClass($component))->getFileName() ?: null;
+
+        if (!app()->bound('livewire.finder')) {
+            return $path;
+        }
+
+        try {
+            $finder = app('livewire.finder');
+            $name = $component->getName();
+
+            // A multi-file component resolves to its directory, so point at the
+            // class file inside it rather than the directory itself.
+            if ($directory = $finder->resolveMultiFileComponentPath($name)) {
+                $basename = basename($directory);
+
+                foreach ([$basename . '.php', $basename . '.blade.php'] as $candidate) {
+                    if (is_file($file = $directory . DIRECTORY_SEPARATOR . $candidate)) {
+                        return $file;
+                    }
+                }
+
+                return $directory;
+            }
+
+            if ($singleFile = $finder->resolveSingleFileComponentPath($name)) {
+                return $singleFile;
+            }
+        } catch (\Throwable $e) {
+            //
+        }
+
+        return $path;
     }
 
     /**

--- a/tests/DataCollector/Livewire/mfc/counter/counter.blade.php
+++ b/tests/DataCollector/Livewire/mfc/counter/counter.blade.php
@@ -1,0 +1,1 @@
+<div>{{ $count }}</div>

--- a/tests/DataCollector/Livewire/mfc/counter/counter.php
+++ b/tests/DataCollector/Livewire/mfc/counter/counter.php
@@ -1,0 +1,13 @@
+<?php
+
+use Livewire\Component;
+
+new class extends Component
+{
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+};

--- a/tests/DataCollector/LivewireMfcCollectorTest.php
+++ b/tests/DataCollector/LivewireMfcCollectorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fruitcake\LaravelDebugbar\Tests\DataCollector;
+
+use Composer\InstalledVersions;
+use Fruitcake\LaravelDebugbar\DataCollector\LivewireCollector;
+use Fruitcake\LaravelDebugbar\ServiceProvider;
+use Fruitcake\LaravelDebugbar\Tests\TestCase;
+use Livewire\LivewireServiceProvider;
+
+class LivewireMfcCollectorTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [ServiceProvider::class, LivewireServiceProvider::class];
+    }
+
+    public function testItLinksToTheSourceOfAMultiFileComponent()
+    {
+        if (version_compare(InstalledVersions::getVersion('livewire/livewire'), '4.0', '<')) {
+            static::markTestSkipped('Multi-file components require Livewire 4.');
+        }
+
+        app('livewire.finder')->addLocation(viewPath: __DIR__ . '/Livewire/mfc');
+
+        debugbar()->boot();
+
+        /** @var LivewireCollector $collector */
+        $collector = debugbar()->getCollector('livewire');
+
+        $component = app('livewire.factory')->create('counter', '123');
+
+        $collector->addLivewireComponent($component, request());
+
+        $data = $collector->collect();
+        $link = $data['templates'][0]['xdebug_link'] ?? null;
+
+        static::assertNotNull($link, 'No source link was collected for the component.');
+
+        $url = urldecode($link['url']);
+
+        static::assertStringContainsString('mfc/counter/counter.php', $url);
+        static::assertStringNotContainsString('/livewire/classes/', $url);
+    }
+}


### PR DESCRIPTION
Fixes #2043.

Livewire 4 compiles single- and multi-file components into the view cache, so `ReflectionClass::getFileName()` returns `storage/framework/views/livewire/classes/<hash>.php` and "Go to source" opens the compiled file. The collector now asks `livewire.finder` for the component path, falling back to reflection when it is unavailable (Livewire 3).

For a multi-file component the finder returns the directory, so the class file inside it is preferred. Test skips below Livewire 4.

Note: `RouteCollector` has the same problem for Livewire requests, but it also takes start/end lines from the reflection, which do not map onto the source — left out of this PR.