### PR TITLE
Update backtrace handling in DatabaseCollectorProvider

### DIFF
--- a/src/CollectorProviders/DatabaseCollectorProvider.php
+++ b/src/CollectorProviders/DatabaseCollectorProvider.php
@@ -40,7 +40,7 @@ class DatabaseCollectorProvider extends AbstractCollectorProvider
         }
 
         if ($backtrace = ($options['backtrace'] ?? true)) {
-            $queryCollector->setFindSource($backtrace, $router->getMiddleware());
+            $queryCollector->setFindSource(is_bool($backtrace) ? $backtrace : (int) $backtrace, $router->getMiddleware());
         }
 
         if ($excludePaths = ($options['exclude_paths'] ?? [])) {


### PR DESCRIPTION
```
Fruitcake\LaravelDebugbar\DataCollector\QueryCollector::setFindSource():
Argument #1 ($value) must be of type int|bool, string given,
called in /vendor/fruitcake/laravel-debugbar/src/CollectorProviders/DatabaseCollectorProvider.php on line 43
```
Closes https://github.com/fruitcake/laravel-debugbar/pull/2056#issuecomment-5366071074

After datatype `bool|int` on `setFindSource` this fails
https://github.com/fruitcake/laravel-debugbar/blob/a1cbd485509175453c03c82ca55ceac77c258cc0/src/DataCollector/QueryCollector.php#L85

